### PR TITLE
Updates and integrate with crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ license:
 TODO
 
 ### Curation
-#### PATCH /curations/:type/:provider/:namespace?/:name/:revision
+#### PATCH /curations/:type/:provider/:namespace/:name/:revision
 
 ##### Request Body
 ```
@@ -115,10 +115,11 @@ This location is temporary, as harvested data grows will likely need to move it 
 ```
 type
   provider
-    name
-      revision
-        toolConfiguration
-          [native output files]
+    namespace -- if none then set to '-'
+      name
+        revision
+          tool
+            toolVersion -- this is the native output file. If more than one file then they should be archived together
 ```
 
 #### Raw Notes

--- a/business/summarizer.js
+++ b/business/summarizer.js
@@ -2,45 +2,69 @@
 // SPDX-License-Identifier: MIT
 
 // Responsible for summarizing tool-specific format to a normalized summary schema:
-//   package:
-//     type: string
-//     name: string
-//     provider: string
-//     revision: string
-//   source_location:
-//     provider: string
-//     url: string
-//     revision: string
-//     path: string
-//   copyright:
-//     statements: string[]
-//     holders: string[]
-//     authors: string[]
-//   license:
-//     expression: string
+//  package:
+//    type: string
+//    provider: string
+//    namespace: string
+//    name: string
+//    revision: string
+//  described: 
+//    source_location:
+//      type: string
+//      provider: string
+//      url: string
+//      revision: string
+//      path: string
+//  licensed:  
+//    copyright:
+//      statements: string[]
+//      holders: string[]
+//      authors: string[]
+//    license:
+//      expression: string
 
 const summarizers = require('../providers/summary');
 
-class Summarizer {
+class SummaryService {
 
   constructor(options) {
     this.options = options;
   }
 
-  summarize(packageCoordinates, toolConfiguration, filter, data) {
-    const toolName = (toolConfiguration.substring(0, toolConfiguration.indexOf('--')) || toolConfiguration).toLowerCase();
-    if (!summarizers[toolName])
+  /**
+   * Summarize the data for each of the supplied data points for different versions of an
+   * identified tool. Use the given filter function to determine if a particular file
+   * mentioned in the data should play a role in summarization.
+   * 
+   * @param {} packageCoordinates the package being summarized
+   * @param {string} tool the name of the tool whose output is being summarized
+   * @param {function} filter filter function identifying analyzed files to NOT include in the summary
+   * @param {*} data the data to summarize
+   */
+  summarizeTool(packageCoordinates, tool, filter, data) {
+    if (!summarizers[tool])
       return data;
-    const summarizer = summarizers[toolName](this.options[toolName] || {});
-    return summarizer.summarize(packageCoordinates, filter, data);
+    const summarizer = summarizers[tool](this.options[tool] || {});
+    return Object.getOwnPropertyNames(data).reduce((result, version) => {
+      result[version] = summarizer.summarize(packageCoordinates, filter, data[version]);
+      return result;
+    }, {});
   }
 
+  /**
+   * Summarize all of the data for the identified package using the given filter function 
+   * to determine if a particular file mentioned in the data should play a role in summarization.
+   * 
+   * @param {} packageCoordinates the package being summarized
+   * @param {function} filter filter function identifying analyzed files to NOT include in the summary
+   * @param {*} data the data to summarize
+   */
   summarizeAll(packageCoordinates, filter, data) {
-    return Object.getOwnPropertyNames(data).reduce((result, toolConfiguration) => {
-      result[toolConfiguration] = this.summarize(packageCoordinates, toolConfiguration, filter, data[toolConfiguration]);
+    return Object.getOwnPropertyNames(data).reduce((result, tool) => {
+      result[tool] = this.summarizeTool(packageCoordinates, tool, filter, data[tool]);
       return result;
     }, {});
   }
 }
 
-module.exports = (options) => new Summarizer(options);
+module.exports = options => new SummaryService(options);

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,13 +19,13 @@ module.exports = {
   },
   harvest: {
     harvester: {
-      provider: config.get('HARVESTER_PROVIDER') || 'vstsOrt',
-      vstsOrt: {
-        authToken: config.get('HARVESTER_VSTSORT_AUTH_TOKEN'),
-        collectionUrl: config.get('HARVESTER_VSTSORT_BUILD_COLLECTION_URL') || 'https://clearlydefined.visualstudio.com',
-        projectName: config.get('HARVESTER_VSTSORT_BUILD_PROJECT_NAME') || 'ClearlyDefined',
-        buildDefinitionName: config.get('HARVESTER_VSTSORT_BUILD_NAME') || 'oss-review-toolkit',
-        buildVariableName: config.get('HARVESTER_VSTSORT_SPEC_VAR') || 'ortSpec'
+      provider: config.get('HARVESTER_PROVIDER') || 'vsts',
+      vsts: {
+        authToken: config.get('HARVESTER_VSTS_AUTH_TOKEN'),
+        collectionUrl: config.get('HARVESTER_VSTS_BUILD_COLLECTION_URL') || 'https://clearlydefined.visualstudio.com',
+        projectName: config.get('HARVESTER_VSTS_BUILD_PROJECT_NAME') || 'ClearlyDefined',
+        buildDefinitionName: config.get('HARVESTER_VSTS_BUILD_NAME') || 'clearlydefined-ort',
+        buildVariableName: config.get('HARVESTER_VSTS_SPEC_VAR') || 'ortSpec'
       }
     },
     store: {

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
+
 const GitHubApi = require('github');
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,42 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-function normalizePackageName(namespace, name) {
-  return (namespace ? `${namespace}/` : '') + name;
-}
+const semver = require('semver');
 
-function getPackageCoordinates(req) {
+function toPackageCoordinates(request) {
   return {
-    type: req.params.type,
-    provider: req.params.provider,
-    name: normalizePackageName(req.params.namespace, req.params.name),
-    revision: req.params.revision,
-    toolConfiguration: req.params.toolConfiguration,
-    file: req.params.file
+    type: request.params.type,
+    provider: request.params.provider,
+    namespace: request.params.namespace === '-' ? null : request.params.namespace,
+    name: request.params.name,
+    revision: request.params.revision,
+    tool: request.params.tool,
+    toolVersion: request.params.toolVersion
   };
 }
 
-function getPathFromCoordinates(packageCoordinates) {
+function toPathFromCoordinates(packageCoordinates) {
   const c = packageCoordinates;
-  return [c.type, c.provider, c.name, c.revision, c.toolConfiguration, c.file].filter(s => s).join('/');
-}
-
-// search the summarized data for an entry that best matches the given tool spec
-function findData(toolSpec, summarized) {
-  const ordered = Object.getOwnPropertyNames(summarized)
-    .filter(name => name.toLowerCase().startsWith(toolSpec))
-    .sort((spec1, spec2) => this.getSpecVersion(spec1) - this.getSpecVersion(spec2));
-  return ordered.length ? summarized[ordered[0]] : null;
-}
-
-function getSpecVersion(spec) {
-  const index = spec.lastIndexOf('--');
-  return index === -1 ? '0' : spec.substring(index);
+  const revisionPart = c.revision ? `revision/${c.revision}` : null;
+  const toolVersionPart = c.toolVersion ? c.toolVersion : null;
+  const toolPart = c.tool ? `tool/${c.tool}` : null;
+  return [c.type, c.provider, c.namespace || '-', c.name, revisionPart, toolPart, toolVersionPart].filter(s => s).join('/');
 }
 
 module.exports = {
-  normalizePackageName,
-  getPackageCoordinates,
-  getPathFromCoordinates,
-  findData
+  toPackageCoordinates,
+  toPathFromCoordinates
 };

--- a/providers/harvest/vsts.js
+++ b/providers/harvest/vsts.js
@@ -1,36 +1,30 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
-const config = require('../../lib/config');
+
 const vsts = require('vso-node-api');
 
-class VstsOrt {
+class Vsts {
 
   constructor(options) {
     this.options = options;
-    this.build = new Build();
-  }
-
-  harvest(spec) {
-    return this.build.queueBuild(spec);
-  }
-}
-
-class Build {
-  constructor() {
-    const token = config.harvest.harvester.vstsOrt.authToken;
+    const token = options.authToken;
     if (!token) {
       throw new Error('Auth token unspecified!');
     }
-    const collectionUrl = config.harvest.harvester.vstsOrt.collectionUrl;
+    const collectionUrl = options.collectionUrl;
     const authHandler = vsts.getPersonalAccessTokenHandler(token);
     const connection = new vsts.WebApi(collectionUrl, authHandler);
-    this.project = config.harvest.harvester.vstsOrt.projectName;
+    this.project = options.projectName;
     this.vstsBuild = connection.getBuildApi();
-    this.buildDefinitionName = config.harvest.harvester.vstsOrt.buildDefinitionName;
-    this.buildVariableName = config.harvest.harvester.vstsOrt.buildVariableName;
+    this.buildDefinitionName = options.buildDefinitionName;
+    this.buildVariableName = options.buildVariableName;
   }
 
-  queueBuild(spec) {
+  harvest(spec) {
+    return this._queueBuild(spec);
+  }
+
+  _queueBuild(spec) {
     const self = this;
     return this.vstsBuild.getDefinitions(self.project, self.buildDefinitionName).then(definitions => {
       if (!definitions[0] || !definitions[0].id) {
@@ -47,4 +41,4 @@ class Build {
   }
 }
 
-module.exports = (options) => new VstsOrt(options);
+module.exports = (options) => new Vsts(options);

--- a/providers/summary/clearlydescribed.js
+++ b/providers/summary/clearlydescribed.js
@@ -2,22 +2,19 @@
 // SPDX-License-Identifier: MIT
 
 // Responsible for summarizing tool-specific format to a normalized summary schema:
-//   package:
-//     type: string
-//     name: string
-//     provider: string
-//     revision: string
-//   source_location:
-//     provider: string
-//     url: string
-//     revision: string
-//     path: string
-//   copyright:
-//     statements: string[]
-//     holders: string[]
-//     authors: string[]
-//   license:
-//     expression: string
+//  package:
+//    type: string
+//    provider: string
+//    name: string
+//    revision: string
+//  described:
+//    source_location:
+//      type: string    
+//      provider: string
+//      url: string
+//      revision: string
+//      path: string
+const _ = require('lodash');
 
 class ClearlyDescribedSummarizer {
 
@@ -26,8 +23,36 @@ class ClearlyDescribedSummarizer {
   }
 
   summarize(packageCoordinates, filter, data) {
-    return data['output.json'];
+    const sourceLocation = data.sourceInfo
+      ? _.pick(data.sourceInfo, ['type', 'provider', 'url', 'revision', 'path'])
+      : null;
+    const result = this.getSourceLocation(data, filter);
+    switch (packageCoordinates.type) {
+      case 'npm':
+        return this.addNpmData(result, data, filter);
+      default:
+        return result;
+    }
+  }
+
+  getSourceLocation(data, filter) {
+    const sourceLocation = data.sourceInfo
+      ? _.pick(data.sourceInfo, ['type', 'provider', 'url', 'revision', 'path'])
+      : null;
+    return {
+      described: { sourceLocation }
+    };
+  }
+
+  addNpmData(result, data, filter) {
+    result.described.projectWebsite = data.manifest.homepage;
+    result.described.issueTracker = data.manifest.bugs;
+    result.licensed = {
+      license: data.manifest.license
+    }
+    return result;
   }
 }
 
-module.exports = (options) => new ClearlyDescribedSummarizer(options);
+module.exports = options => new ClearlyDescribedSummarizer(options);
+

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -5,14 +5,14 @@ const router = express.Router();
 const utils = require('../lib/utils');
 
 // Get an existing patch for a specific revision of a package
-router.get('/:type/:provider/:namespace?/:name/:revision', async (request, response, next) => {
-  const packageCoordinates = utils.getPackageCoordinates(request);
+router.get('/:type/:provider/:namespace/:name/:revision', async (request, response, next) => {
+  const packageCoordinates = utils.toPackageCoordinates(request);
   return curationService.get(packageCoordinates).then(result =>
     response.status(200).send(result));
 });
 
-router.patch('/:type/:provider/:namespace?/:name/:revision', async (request, response, next) => {
-  const packageCoordinates = utils.getPackageCoordinates(request);
+router.patch('/:type/:provider/:namespace/:name/:revision', async (request, response, next) => {
+  const packageCoordinates = utils.toPackageCoordinates(request);
   return curationService.addOrUpdate(packageCoordinates, request.body).then(result =>
     response.sendStatus(200));
 });

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -1,8 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
+
 const express = require('express');
 const router = express.Router();
 const utils = require('../lib/utils');
+
+// Get a proposed patch for a specific revision of a package
+router.get('/:type/:provider/:namespace/:name/:revision/pr/:pr', async (request, response, next) => {
+  const packageCoordinates = utils.toPackageCoordinates(request);
+  return curationService.get(packageCoordinates, request.params.pr).then(result =>
+    response.status(200).send(result));
+});
 
 // Get an existing patch for a specific revision of a package
 router.get('/:type/:provider/:namespace/:name/:revision', async (request, response, next) => {
@@ -11,6 +19,7 @@ router.get('/:type/:provider/:namespace/:name/:revision', async (request, respon
     response.status(200).send(result));
 });
 
+// Create a patch for a specific revision of a package
 router.patch('/:type/:provider/:namespace/:name/:revision', async (request, response, next) => {
   const packageCoordinates = utils.toPackageCoordinates(request);
   return curationService.addOrUpdate(packageCoordinates, request.body).then(result =>

--- a/routes/harvest.js
+++ b/routes/harvest.js
@@ -45,13 +45,6 @@ function buildFilter(dimensions) {
   return file => !list.some(filter => minimatch(file, filter));
 }
 
-// Gets a listing of harvested files in the system for a given tool configuration
-// router.get('/:type/:provider/:namespace/:name/:revision/:tool/:toolVersion?', (request, response, next) => {
-//   const packageCoordinates = utils.toPackageCoordinates(request);
-//   return harvestStore.list(packageCoordinates).then(result =>
-//     response.status(200).send(result));
-// });
-
 // Gets ALL the harvested data for a given component revision
 router.get('/:type/:provider/:namespace/:name/:revision', (request, response, next) => {
   const packageCoordinates = utils.toPackageCoordinates(request);


### PR DESCRIPTION
Some pretty sweeping changes to 

* update url structure (see readme)
* Integrate harvesting storage with the Azure blob storage configuration used in the crawler
* support getting the effective output based on a proposed PR
* enhance summarization to include NPM info found on packages
* add some handy comments here and there. 