### PR TITLE
add curation, harvest and packages search endpoints

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,9 @@ module.exports = {
         repo: config.get('CURATION_GITHUB_REPO') || 'curated-data',
         branch: config.get('CURATION_GITHUB_BRANCH') || process.env.NODE_ENV,
         token: config.get('CURATION_GITHUB_TOKEN'),
-        webhookSecret: config.get('CURATION_GITHUB_WEBHOOK_SECRET')
+        webhookSecret: config.get('CURATION_GITHUB_WEBHOOK_SECRET'),
+        tempLocation: config.get('CURATION_TEMP_LOCATION') || (process.platform === 'win32' ? 'c:/temp' : '/tmp'),
+        curationFreshness: config.get('CURATION_FRESHNESS') || 600000
       }
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
     "agent-base": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-      "integrity": "sha1-gPps3kQPTc+a8mF88kYJm12Z8Mg=",
+      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
       "requires": {
         "es6-promisify": "5.0.0"
       }
@@ -62,7 +62,7 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -318,7 +318,7 @@
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
@@ -329,7 +329,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -361,7 +361,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
@@ -387,7 +387,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -410,7 +410,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "concat-map": {
@@ -432,7 +432,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -447,7 +447,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -471,7 +471,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
       "version": "0.3.1",
@@ -549,7 +549,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -557,7 +557,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.5"
@@ -602,7 +602,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
     "dns-prefetch-control": {
@@ -613,7 +613,7 @@
     "doctrine": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha1-aPls6O/FbMQmUfH6rbTxdSc7AHU=",
+      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -753,7 +753,7 @@
     "espree": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
@@ -763,7 +763,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
       "version": "1.0.0",
@@ -844,7 +844,7 @@
         "qs": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha1-jQSVTTZN7z78VbWgeT4eLIsebkk="
+          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
         },
         "statuses": {
           "version": "1.3.1",
@@ -856,7 +856,7 @@
     "express-basic-auth": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.1.3.tgz",
-      "integrity": "sha1-GJJMAv7xjZ7+WOIoR+4x4kB0nzM=",
+      "integrity": "sha512-+tYtERHfl46Y1sPexskNcnIgYCmEnvj4Hp8/19dfByMUQAAWKEQ/Ik1taQ+Kj9LLJP1ItuXa95Ta8e8LtyltVQ==",
       "requires": {
         "basic-auth": "1.1.0"
       }
@@ -869,7 +869,7 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -1018,7 +1018,7 @@
     "github": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/github/-/github-13.0.1.tgz",
-      "integrity": "sha1-TM9KQd9mL5I2fnekdGdOq7G2x40=",
+      "integrity": "sha512-rApJzcnzy6E3WXhjGlSeRlWKnKM/yoi0fAxNjcOuq+1fjX4dMsiS/AWakrrhpMV3ZHi+mbNgNopS5d3go2AopQ==",
       "requires": {
         "debug": "3.1.0",
         "dotenv": "4.0.0",
@@ -1031,7 +1031,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -1041,7 +1041,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -1055,7 +1055,7 @@
     "globals": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
-      "integrity": "sha1-YyZERX9fDjrnEYBxg3AOvy5GM+Q=",
+      "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
       "dev": true
     },
     "globby": {
@@ -1075,13 +1075,12 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "har-schema": {
@@ -1142,7 +1141,7 @@
     "helmet": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.9.0.tgz",
-      "integrity": "sha1-eyzwFaLRCbyoPt55JEIHmcDmfe4=",
+      "integrity": "sha512-czCyS77TyanWlfVSoGlb9GBJV2Q2zJayKxU5uBw0N1TzDTs/qVNh1SL8Q688KU0i0Sb7lQ/oLtnaEqXzl2yWvA==",
       "requires": {
         "dns-prefetch-control": "0.1.0",
         "dont-sniff-mimetype": "1.0.0",
@@ -1161,7 +1160,7 @@
     "helmet-csp": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.6.0.tgz",
-      "integrity": "sha1-wfVZWvvF+D5fHmwV+ELwehD26gQ=",
+      "integrity": "sha512-n/oW9l6RtO4f9YvphsNzdvk1zITrSN7iRT8ojgrJu/N3mVdHl9zE4OjbiHWcR64JK32kbqx90/yshWGXcjUEhw==",
       "requires": {
         "camelize": "1.0.0",
         "content-security-policy-builder": "1.1.0",
@@ -1188,7 +1187,7 @@
     "hsts": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.1.0.tgz",
-      "integrity": "sha1-y9bJGKI4X+4d1WgL+ys6GUwBIcw="
+      "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
     },
     "http-errors": {
       "version": "1.6.2",
@@ -1214,7 +1213,7 @@
     "https-proxy-agent": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
-      "integrity": "sha1-p85DgqG6gmbuhIV4d4Ei1JEmD9k=",
+      "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
       "requires": {
         "agent-base": "4.1.2",
         "debug": "3.1.0"
@@ -1223,7 +1222,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -1233,7 +1232,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ienoopen": {
       "version": "1.0.0",
@@ -1243,7 +1242,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -1270,7 +1269,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
@@ -1333,7 +1332,7 @@
     "is-resolvable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
-      "integrity": "sha1-rMoc022+RLl0uSQyFVWnC6A7HPQ=",
+      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
       "dev": true
     },
     "is-typedarray": {
@@ -1366,7 +1365,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -1467,7 +1466,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -1525,7 +1524,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -1774,7 +1773,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -1851,6 +1850,17 @@
         "process-nextick-args": "1.0.7",
         "string_decoder": "0.10.31",
         "util-deprecate": "1.0.2"
+      }
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.0.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "recursive-readdir": {
@@ -1972,7 +1982,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -2005,7 +2015,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sax": {
       "version": "0.5.2",
@@ -2015,7 +2025,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "send": {
       "version": "0.15.6",
@@ -2060,6 +2070,11 @@
         "send": "0.15.6"
       }
     },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
     "setprototypeof": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
@@ -2089,7 +2104,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -2133,7 +2148,7 @@
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -2143,7 +2158,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -2197,7 +2212,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -2237,7 +2252,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -2282,7 +2297,7 @@
     "type-detect": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha1-1w5byB223io4G8rKDG4MvcdjXeI=",
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
       "dev": true
     },
     "type-is": {
@@ -2337,7 +2352,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validator": {
       "version": "3.35.0",
@@ -2384,7 +2399,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "moment": "^2.19.4",
     "morgan": "~1.9.0",
     "painless-config": "^0.1.0",
+    "readdirp": "^2.1.0",
     "recursive-readdir": "^2.2.1",
     "request-id": "^0.11.1",
     "request-promise-native": "^1.0.5",

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -206,7 +206,7 @@ class GitHubCurationService {
    * @param {string} searchPattern - a partial path that describes the sort of curation to look for. 
    * @returns {[URL]} - Array of URLs describing he available curations
    */
-  async search(searchPattern) {
+  async list(searchPattern) {
     await this.ensureCurations();
     const root = `${this.tempLocation.name}/${this.options.repo}/${this._getSearchRoot(searchPattern)}`;
     if (!fs.existsSync(root))

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -4,9 +4,15 @@
 const _ = require('underscore');
 const base64 = require('base-64');
 const extend = require('extend');
+const { exec } = require('child_process');
+const fs = require('fs');
 const moment = require('moment');
+const readdirp = require('readdirp');
 const yaml = require('js-yaml');
 const Github = require('../../lib/github');
+const utils = require('../../lib/utils');
+const tmp = require('tmp');
+tmp.setGracefulCleanup();
 
 // Responsible for managing curation patches in a store
 //
@@ -15,25 +21,35 @@ const Github = require('../../lib/github');
 class GitHubCurationService {
   constructor(options) {
     this.options = options;
+    this.curationUpdateTime = null;
+    this.tempLocation = tmp.dirSync(this.tmpOptions);
   }
 
-  addOrUpdate(packageCoordinates, patch) {
+  get tmpOptions() {
+    return {
+      unsafeCleanup: true,
+      template: `${this.options.tempLocation}/cd-XXXXXX`
+    };
+  }
+
+  addOrUpdate(coordinates, patch) {
     if (!patch.patch)
       throw new Error('Cannot add or update an empty patch. Did you forget to put it in a "patch" property?');
     const github = Github.getClient(this.options);
     const { owner, repo, branch } = this.options;
-    const path = this._getCurationPath(packageCoordinates);
-    const prBranch = this._getBranchName(packageCoordinates);
+    const path = this._getCurationPath(coordinates);
+    const prBranch = this._getBranchName(coordinates);
     let curationPathSha = null;
 
-    return this.getAll(packageCoordinates)
+    return this.getAll(coordinates)
       .then(parsedContent => {
         // make patch independent of directory structure
         parsedContent = _.assign(parsedContent, {
           package: {
-            type: packageCoordinates.type,
-            provider: packageCoordinates.provider,
-            name: packageCoordinates.name
+            type: coordinates.type,
+            provider: coordinates.provider,
+            namespace: coordinates.namespace === '-' ? null : coordinates.namespace,
+            name: coordinates.name
           }
         });
 
@@ -48,7 +64,7 @@ class GitHubCurationService {
         }
 
         // add/update the patch for this revision
-        parsedContent.revisions[packageCoordinates.revision] = _.assign(parsedContent.revisions[packageCoordinates.revision] || {}, patch.patch);
+        parsedContent.revisions[coordinates.revision] = _.assign(parsedContent.revisions[coordinates.revision] || {}, patch.patch);
 
         // return the serialized YAML
         return yaml.safeDump(parsedContent, { sortKeys: true });
@@ -62,7 +78,7 @@ class GitHubCurationService {
           .then(() => updatedPatch);
       })
       .then(updatedPatch => {
-        const message = `Update ${path} ${packageCoordinates.revision}`;
+        const message = `Update ${path} ${coordinates.revision}`;
         if (curationPathSha)
           return github.repos.updateFile({
             owner,
@@ -86,7 +102,7 @@ class GitHubCurationService {
         return github.pullRequests.create({
           owner,
           repo,
-          title: this._getPrTitle(packageCoordinates),
+          title: this._getPrTitle(coordinates),
           body: patch.description,
           head: `refs/heads/${prBranch}`,
           base: branch
@@ -123,8 +139,8 @@ class GitHubCurationService {
    * @returns {Object} The requested curations where the revisions property has a property for each
    * curated revision.
    */
-  async getAll(packageCoordinates, pr = null) {
-    const curationPath = this._getCurationPath(packageCoordinates);
+  async getAll(coordinates, pr = null) {
+    const curationPath = this._getCurationPath(coordinates);
     const { owner, repo } = this.options;
     const branch = await this.getBranch(pr);
 
@@ -185,6 +201,50 @@ class GitHubCurationService {
     }
   }
 
+  /**
+   * Given a partial spec, return the list of full spec urls for each curated version of the spec'd components 
+   * @param {string} searchPattern - a partial path that describes the sort of curation to look for. 
+   * @returns {[URL]} - Array of URLs describing he available curations
+   */
+  async search(searchPattern) {
+    await this.ensureCurations();
+    const root = `${this.tempLocation.name}/${this.options.repo}/${this._getSearchRoot(searchPattern)}`;
+    if (!fs.existsSync(root))
+      return [];
+    return new Promise((resolve, reject) => {
+      const result = [];
+      readdirp({ root, fileFilter: '*.yaml' })
+        .on('data', entry => result.push(...this.handleEntry(entry)))
+        .on('end', () => resolve(result))
+        .on('error', reject)
+    });
+  }
+
+  handleEntry(entry) {
+    const curation = yaml.safeLoad(fs.readFileSync(entry.fullPath.replace(/\\/g, '/')));
+    const { package: p, revisions } = curation;
+    const root = `${p.type}/${p.provider}/${p.namespace || '-'}/${p.name}/`;
+    return Object.getOwnPropertyNames(revisions).map(version => root + version);
+  }
+
+  async ensureCurations() {
+    if (this.curationUpdateTime && (Date.now - this.curationUpdateTime < this.options.curationFreshness))
+      return;
+    const { owner, repo } = this.options;
+    const url = `https://github.com/${owner}/${repo}.git`
+    const command = this.curationUpdateTime
+      ? `cd ${this.tempLocation.name}/${repo} && git pull`
+      : `cd ${this.tempLocation.name} && git clone ${url}`;
+    return new Promise((resolve, reject) => {
+      exec(command, (error, stdout, stderr) => {
+        if (error)
+          return reject(error);
+        this.curationUpdateTime = Date.now;
+        resolve(stdout);
+      });
+    });
+  }
+
   async getPrFiles(number) {
     const { owner, repo } = this.options;
     const github = Github.getClient(this.options);
@@ -197,18 +257,25 @@ class GitHubCurationService {
     }
   }
 
-  _getPrTitle(packageCoordinates) {
-    const c = packageCoordinates;
+  _getPrTitle(coordinates) {
+    const c = coordinates;
     // Structure the PR title to match the entity coordinates so we can hackily reverse engineer that to build a URL... :-/
     return `${c.type.toLowerCase()}/${c.provider.toLowerCase()}/${c.namespace || '-'}/${c.name}/${c.revision}`;
   }
 
-  _getBranchName(packageCoordinates) {
-    return `${packageCoordinates.type.toLowerCase()}_${packageCoordinates.name}_${packageCoordinates.revision}_${moment().format('YYMMDD_HHmmss.SSS')}`;
+  _getBranchName(coordinates) {
+    const c = coordinates;
+    return `${c.type.toLowerCase()}_${c.name}_${c.revision}_${moment().format('YYMMDD_HHmmss.SSS')}`;
   }
 
-  _getCurationPath(packageCoordinates) {
-    return `curations/${packageCoordinates.type.toLowerCase()}/${packageCoordinates.provider.toLowerCase()}/${packageCoordinates.name}.yaml`;
+  _getCurationPath(coordinates) {
+    const c = coordinates;
+    return `curations/${c.type.toLowerCase()}/${c.provider.toLowerCase()}/${c.namespace || '-'}/${c.name}.yaml`;
+  }
+
+  _getSearchRoot(path) {
+    // TODO validate the path is not bogus
+    return `curations/${path.split('/').slice(0, 4).join('/')}`;
   }
 
   // @todo improve validation via schema, etc

--- a/providers/harvest/azblob.js
+++ b/providers/harvest/azblob.js
@@ -30,18 +30,11 @@ class AzBlobHarvesterService {
     return this.blobService;
   }
 
-  list(packageCoordinates) {
-    const name = utils.toPathFromCoordinates(packageCoordinates);
+  list(pattern) {
     return new Promise((resolve, reject) => {
+      const name = pattern.startsWith('/') ? pattern.slice(1) : pattern;
       this.blobService.listBlobsSegmentedWithPrefix(this.containerName, name, null, resultOrError(resolve, reject));
-    }).then(result =>
-      result.entries.map(entry => {
-        return {
-          name: entry.name.substr(entry.name.lastIndexOf('/') + 1),
-          lastModified: moment(entry.lastModified).format(),
-          etag: entry.etag
-        };
-      }));
+    }).then(result => result.entries.map(entry => entry.name).filter(entry => !entry.startsWith('deadletter')));
   }
 
   get(packageCoordinates, stream) {

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -9,14 +9,26 @@ const utils = require('../lib/utils');
 // Get a proposed patch for a specific revision of a package
 router.get('/:type/:provider/:namespace/:name/:revision/pr/:pr', asyncMiddleware(async (request, response) => {
   const packageCoordinates = utils.toPackageCoordinates(request);
-  return curationService.get(packageCoordinates, request.params.pr).then(result =>
-    response.status(200).send(result));
+  return curationService.get(packageCoordinates, request.params.pr).then(result => {
+    if (result)
+      return response.status(200).send(result);
+    response.sendStatus(404);
+  })
 }));
 
 // Get an existing patch for a specific revision of a package
 router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async (request, response) => {
   const packageCoordinates = utils.toPackageCoordinates(request);
-  return curationService.get(packageCoordinates).then(result =>
+  return curationService.get(packageCoordinates).then(result => {
+    if (result)
+      return response.status(200).send(result);
+    response.sendStatus(404);
+  });
+}));
+
+// Search for any patches related to the given path, as much as is given
+router.get('/:type?/:provider?/:namespace?/:name?', asyncMiddleware(async (request, response) => {
+  return curationService.search(request.path).then(result =>
     response.status(200).send(result));
 }));
 

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -28,7 +28,7 @@ router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async 
 
 // Search for any patches related to the given path, as much as is given
 router.get('/:type?/:provider?/:namespace?/:name?', asyncMiddleware(async (request, response) => {
-  return curationService.search(request.path).then(result =>
+  return curationService.list(request.path).then(result =>
     response.status(200).send(result));
 }));
 

--- a/routes/harvest.js
+++ b/routes/harvest.js
@@ -8,7 +8,7 @@ const utils = require('../lib/utils');
 const bodyParser = require('body-parser');
 
 // Gets a given harvested file
-router.get('/:type/:provider/:namespace/:name/:revision/:tool/:toolVersion?', asyncMiddleware(async (request, response) => {
+router.get('/:type/:provider/:namespace/:name/:revision/:tool/:toolVersion', asyncMiddleware(async (request, response) => {
   const packageCoordinates = utils.toPackageCoordinates(request);
   switch ((request.query.form || 'summary').toLowerCase()) {
     case 'streamed':
@@ -24,14 +24,15 @@ router.get('/:type/:provider/:namespace/:name/:revision/:tool/:toolVersion?', as
       response.status(200).send(result);
       break;
     }
-    case 'list': {
-      const result = await harvestStore.list(packageCoordinates);
-      response.status(200).send(result);
-      break;
-    }
     default:
       throw new Error(`Invalid request form: ${request.query.form}`);
   }
+}));
+
+// Get a list of the harvested data that we have that matches the url as a prefix
+router.get('/:type?/:provider?/:namespace?/:name?/:revision?/:tool?', asyncMiddleware(async (request, response) => {
+  const result = await harvestStore.list(request.path);
+  response.status(200).send(result);
 }));
 
 async function getFilter(packageCoordinates) {


### PR DESCRIPTION
to make data more discoverable, we need to be able to search for curations and harvested data. This PR adds curation prefix accessing in a really simplistic way.

* The service keeps a clone (on demand) of the entire curation repo. This obviously does not scale but will do for a while. There is a configurable TTL for the clone after which a `git pull` is done before accessing.
* The file system is then used as the search space and all `.yaml` files under the given prefix are found, and their revisions teased out.

Eventually we will need something more than this. Perhaps a level based query, perhaps a real database, ... who knows. Oh, and this does not do pagination.

Having said all that, it works and we have precisely one curation in the dev repo right now :-)

For the harvest endpoint we already have `list` so just check that it is coherent with the new curation endpoint.

Then in `packages` we need to union the two results.
  