### PR TITLE
Add initial PR builder travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+# node version specified in .nvmrc
+
+cache:
+  directories:
+    - "node_modules"


### PR DESCRIPTION
Not much to see here. Travis will execute `npm test` which currently runs `eslint` and our (non-existent) tests 😜 .

Need someone with permissions to enable travis for `clearlydefined/service`: https://travis-ci.org/profile/clearlydefined