### PR TITLE
First stab at validating curation against schema

### DIFF
--- a/lib/curation.js
+++ b/lib/curation.js
@@ -1,0 +1,44 @@
+// Copyright (c) 2017, The Linux Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const yaml = require('js-yaml');
+const Ajv = require('ajv');
+const ajv = new Ajv();
+ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
+const curationSchema = require('../schemas/curation');
+
+class Curation {
+  constructor({content, data = null, path = ''}) {
+    this.errors = [];
+    this.data = data;
+    this.isValid = false;
+    this.path = path;
+
+    if (content) {
+      this.load(content);
+    }
+    if (this.data) {
+      this.validate();
+    }
+  }
+
+  load(content) {
+    try {
+      this.data = yaml.safeLoad(content);
+    } catch (error) {
+      this.errors.push({
+        message: 'Invalid yaml',
+        error
+      });
+    }
+  }
+
+  validate() {
+    this.isValid = ajv.validate(curationSchema, this.data);
+    if (!this.isValid) {
+      this.errors.push(...ajv.errors.map(error => ({message: 'Invalid curation', error})));
+    }
+  }
+}
+
+module.exports = options => new Curation(options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,18 +39,19 @@
     "agent-base": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
+      "integrity": "sha1-gPps3kQPTc+a8mF88kYJm12Z8Mg=",
       "requires": {
         "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.0.1.tgz",
+      "integrity": "sha1-KJhYCp8971+chd/q16IiPvE889o=",
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -62,7 +63,7 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
       "dev": true
     },
     "ansi-regex": {
@@ -318,7 +319,7 @@
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
@@ -329,7 +330,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -361,7 +362,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli-cursor": {
@@ -387,7 +388,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -410,7 +411,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "concat-map": {
@@ -432,7 +433,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -447,7 +448,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -471,7 +472,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
     },
     "cookie": {
       "version": "0.3.1",
@@ -549,7 +550,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -557,7 +558,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
         "type-detect": "4.0.5"
@@ -602,7 +603,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
       "dev": true
     },
     "dns-prefetch-control": {
@@ -613,7 +614,7 @@
     "doctrine": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+      "integrity": "sha1-aPls6O/FbMQmUfH6rbTxdSc7AHU=",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -753,7 +754,7 @@
     "espree": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
@@ -763,7 +764,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
     },
     "esquery": {
       "version": "1.0.0",
@@ -844,7 +845,7 @@
         "qs": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
+          "integrity": "sha1-jQSVTTZN7z78VbWgeT4eLIsebkk="
         },
         "statuses": {
           "version": "1.3.1",
@@ -856,7 +857,7 @@
     "express-basic-auth": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.1.3.tgz",
-      "integrity": "sha512-+tYtERHfl46Y1sPexskNcnIgYCmEnvj4Hp8/19dfByMUQAAWKEQ/Ik1taQ+Kj9LLJP1ItuXa95Ta8e8LtyltVQ==",
+      "integrity": "sha1-GJJMAv7xjZ7+WOIoR+4x4kB0nzM=",
       "requires": {
         "basic-auth": "1.1.0"
       }
@@ -869,7 +870,7 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -885,14 +886,12 @@
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1018,7 +1017,7 @@
     "github": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/github/-/github-13.0.1.tgz",
-      "integrity": "sha512-rApJzcnzy6E3WXhjGlSeRlWKnKM/yoi0fAxNjcOuq+1fjX4dMsiS/AWakrrhpMV3ZHi+mbNgNopS5d3go2AopQ==",
+      "integrity": "sha1-TM9KQd9mL5I2fnekdGdOq7G2x40=",
       "requires": {
         "debug": "3.1.0",
         "dotenv": "4.0.0",
@@ -1031,7 +1030,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -1041,7 +1040,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -1055,7 +1054,7 @@
     "globals": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
-      "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
+      "integrity": "sha1-YyZERX9fDjrnEYBxg3AOvy5GM+Q=",
       "dev": true
     },
     "globby": {
@@ -1080,7 +1079,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
       "dev": true
     },
     "har-schema": {
@@ -1095,6 +1094,17 @@
       "requires": {
         "ajv": "4.11.8",
         "har-schema": "1.0.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
       }
     },
     "has-ansi": {
@@ -1141,7 +1151,7 @@
     "helmet": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.9.0.tgz",
-      "integrity": "sha512-czCyS77TyanWlfVSoGlb9GBJV2Q2zJayKxU5uBw0N1TzDTs/qVNh1SL8Q688KU0i0Sb7lQ/oLtnaEqXzl2yWvA==",
+      "integrity": "sha1-eyzwFaLRCbyoPt55JEIHmcDmfe4=",
       "requires": {
         "dns-prefetch-control": "0.1.0",
         "dont-sniff-mimetype": "1.0.0",
@@ -1160,7 +1170,7 @@
     "helmet-csp": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.6.0.tgz",
-      "integrity": "sha512-n/oW9l6RtO4f9YvphsNzdvk1zITrSN7iRT8ojgrJu/N3mVdHl9zE4OjbiHWcR64JK32kbqx90/yshWGXcjUEhw==",
+      "integrity": "sha1-wfVZWvvF+D5fHmwV+ELwehD26gQ=",
       "requires": {
         "camelize": "1.0.0",
         "content-security-policy-builder": "1.1.0",
@@ -1187,7 +1197,7 @@
     "hsts": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.1.0.tgz",
-      "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
+      "integrity": "sha1-y9bJGKI4X+4d1WgL+ys6GUwBIcw="
     },
     "http-errors": {
       "version": "1.6.2",
@@ -1213,7 +1223,7 @@
     "https-proxy-agent": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
-      "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
+      "integrity": "sha1-p85DgqG6gmbuhIV4d4Ei1JEmD9k=",
       "requires": {
         "agent-base": "4.1.2",
         "debug": "3.1.0"
@@ -1222,7 +1232,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -1232,7 +1242,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
     },
     "ienoopen": {
       "version": "1.0.0",
@@ -1242,7 +1252,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
       "dev": true
     },
     "imurmurhash": {
@@ -1269,7 +1279,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
@@ -1332,7 +1342,7 @@
     "is-resolvable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
-      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "integrity": "sha1-rMoc022+RLl0uSQyFVWnC6A7HPQ=",
       "dev": true
     },
     "is-typedarray": {
@@ -1365,7 +1375,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -1393,8 +1403,7 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -1466,7 +1475,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -1524,7 +1533,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -1772,7 +1781,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
       "dev": true
     },
     "prelude-ls": {
@@ -1981,7 +1990,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -2014,7 +2023,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "sax": {
       "version": "0.5.2",
@@ -2024,7 +2033,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
     },
     "send": {
       "version": "0.15.6",
@@ -2103,7 +2112,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -2147,7 +2156,7 @@
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+      "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -2157,7 +2166,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -2211,7 +2220,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -2251,7 +2260,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -2295,7 +2304,7 @@
     "type-detect": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+      "integrity": "sha1-1w5byB223io4G8rKDG4MvcdjXeI=",
       "dev": true
     },
     "type-is": {
@@ -2350,7 +2359,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
     },
     "validator": {
       "version": "3.35.0",
@@ -2397,7 +2406,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
+    "ajv": "^6.0.1",
     "azure-storage": "^2.7.0",
     "base-64": "^0.1.0",
     "body-parser": "~1.18.2",

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -9,11 +9,7 @@ const fs = require('fs');
 const moment = require('moment');
 const readdirp = require('readdirp');
 const yaml = require('js-yaml');
-const Ajv = require('ajv');
-const ajv = new Ajv();
-ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
 const Github = require('../../lib/github');
-const curationSchema = require('../../schemas/curation');
 const tmp = require('tmp');
 tmp.setGracefulCleanup();
 
@@ -279,25 +275,6 @@ class GitHubCurationService {
   _getSearchRoot(path) {
     // TODO validate the path is not bogus
     return `curations/${path.split('/').slice(0, 4).join('/')}`;
-  }
-
-  // @todo update what is returned. E.g. if failure, return error messages;
-  // if valid, return the loaded curation, etc
-  isValidCuration(curation) {
-    let data = {};
-
-    try {
-      data = yaml.safeLoad(curation);
-    } catch (error) {
-      return null;
-    }
-
-    const isValid = ajv.validate(curationSchema, data);
-    if (!isValid) {
-      // @todo need to bubble these errors up as they point to the problems
-      console.error('Errors: ' + ajv.errors.map(x => x.message).join(', '));
-    }
-    return isValid;
   }
 
   // @todo perhaps validate directory structure (package coordinates)

--- a/schemas/curation.json
+++ b/schemas/curation.json
@@ -2,21 +2,47 @@
   "$id": "https://api.clearlydefined.io/schemas/curation.json#",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "curation",
-  "required": ["package", "revisions"],
+  "required": [
+    "package",
+    "revisions"
+  ],
   "type": "object",
+  "additionalProperties": false,
   "properties": {
-    "package": { "$ref": "#/definitions/package" },
-    "revisions": { "$ref": "#/definitions/revisions" }
+    "package": {
+      "$ref": "#/definitions/package"
+    },
+    "revisions": {
+      "$ref": "#/definitions/revisions"
+    }
   },
   "definitions": {
+    "type": {
+      "enum": [
+        "npm",
+        "git"
+      ]
+    },
+    "provider": {
+      "enum": [
+        "npmjs",
+        "github"
+      ]
+    },
     "package": {
-      "required": ["type", "provider", "namespace", "name"],
+      "required": [
+        "type",
+        "provider",
+        "namespace",
+        "name"
+      ],
+      "additionalProperties": false,
       "properties": {
         "type": {
-          "enum": ["npm", "git"]
+          "$ref": "#/definitions/type"
         },
         "provider": {
-          "enum": ["npmjs", "github"]
+          "$ref": "#/definitions/provider"
         },
         "namespace": {
           "type": "string"
@@ -28,9 +54,124 @@
     },
     "revisions": {
       "type": "object",
+      "additionalProperties": false,
       "patternProperties": {
-        "^.*$": {
-          "type": "object"
+        "^.+$": {
+          "$ref": "#/definitions/revision"
+        }
+      }
+    },
+    "revision": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "described": {
+          "$ref": "#/definitions/described"
+        },
+        "licensed": {
+          "$ref": "#/definitions/licensed"
+        }
+      }
+    },
+    "described": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dimensions": {
+          "additionalProperties": false,
+          "properties": {
+            "test": {
+              "$ref": "#/definitions/dimension"
+            },
+            "data": {
+              "$ref": "#/definitions/dimension"
+            }
+          }
+        },
+        "sourceLocation": {
+          "$ref": "#/definitions/sourceLocation"
+        },
+        "projectWebsite": {
+          "type": "string"
+        },
+        "issueTracker": {
+          "type": "string"
+        },
+        "releaseDate": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "dimension": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "sourceLocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "provider": {
+          "$ref": "#/definitions/provider"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "revision": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      }
+    },
+    "licensed": {
+      "additionalProperties": false,
+      "properties": {
+        "copyright": {
+          "$ref": "#/definitions/copyright"
+        },
+        "license": {
+          "$ref": "#/definitions/license"
+        }
+      }
+    },
+    "copyright": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "statements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "holders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "license": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "expression": {
+          "type": "string"
         }
       }
     }

--- a/schemas/curation.json
+++ b/schemas/curation.json
@@ -1,0 +1,38 @@
+{
+  "$id": "https://api.clearlydefined.io/schemas/curation.json#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "curation",
+  "required": ["package", "revisions"],
+  "type": "object",
+  "properties": {
+    "package": { "$ref": "#/definitions/package" },
+    "revisions": { "$ref": "#/definitions/revisions" }
+  },
+  "definitions": {
+    "package": {
+      "required": ["type", "provider", "namespace", "name"],
+      "properties": {
+        "type": {
+          "enum": ["npm", "git"]
+        },
+        "provider": {
+          "enum": ["npmjs", "github"]
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "revisions": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {
+          "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/curation-invalid.yaml
+++ b/test/fixtures/curation-invalid.yaml
@@ -1,0 +1,4 @@
+0.3.0:
+  copyright: bar
+0.2.0:
+  copyright: bar

--- a/test/fixtures/curation-invalid.yaml
+++ b/test/fixtures/curation-invalid.yaml
@@ -1,4 +1,12 @@
-0.3.0:
-  copyright: bar
-0.2.0:
-  copyright: bar
+package:
+  name: lodash
+  provider: npmjs
+  type: npm
+  namespace: "-"
+revisions:
+  4.17.4:
+    described:
+      issueTracker: "https://foobar.com/baz/1"
+  4.17.5:
+    described:
+      releaseDate: "NOT A DATE"

--- a/test/fixtures/curation-valid.yaml
+++ b/test/fixtures/curation-valid.yaml
@@ -6,7 +6,17 @@ package:
 revisions:
   4.17.4:
     described:
-      this: is some new data
+      issueTracker: "https://foobar.com/baz/1"
+    licensed:
+      copyright:
+        statements:
+          - "foo"
+          - "bar"
+        holders:
+          - "foo"
+          - "bar"
+      license:
+        expression: "MIT"
   4.17.5:
     described:
-      this: is some new data
+      releaseDate: "2018-01-18T06:00:51.556Z"

--- a/test/fixtures/curation-valid.yaml
+++ b/test/fixtures/curation-valid.yaml
@@ -1,0 +1,12 @@
+package:
+  name: lodash
+  provider: npmjs
+  type: npm
+  namespace: "-"
+revisions:
+  4.17.4:
+    described:
+      this: is some new data
+  4.17.5:
+    described:
+      this: is some new data

--- a/test/lib/curation.js
+++ b/test/lib/curation.js
@@ -1,0 +1,39 @@
+const {expect} = require('chai');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const Curation = require('../../lib/curation');
+
+function getFixture(file) {
+  return fs.readFileSync(path.join(__dirname, '../fixtures', file), {encoding: 'utf8'});
+}
+
+describe('Curations', () => {
+  it('should identify invalid yaml files', () => {
+    const content = '@#$%%';
+    const curation = Curation({content});
+    expect(curation.isValid).to.be.false;
+    expect(curation.errors[0].message).to.equal('Invalid yaml');
+  });
+
+  it('should identify invalid curations', () => {
+    const content = getFixture('curation-invalid.yaml');
+    const curation = Curation({content});
+    expect(curation.isValid).to.be.false;
+    expect(curation.errors[0].message).to.equal('Invalid curation');
+  });
+
+  it('should identify valid curations', () => {
+    const content = getFixture('curation-valid.yaml');
+    const curation = Curation({content});
+    expect(curation.isValid).to.be.true;
+    expect(curation.errors.length).to.not.be.ok;
+  });
+
+  it('should also accept yaml data objects', () => {
+    const data = yaml.safeLoad('foo: bar');
+    const curation = Curation({data});
+    expect(curation.isValid).to.be.false;
+    expect(curation.errors[0].message).to.equal('Invalid curation');
+  });
+});

--- a/test/providers/github.js
+++ b/test/providers/github.js
@@ -1,6 +1,4 @@
 const {expect} = require('chai');
-const fs = require('fs');
-const path = require('path');
 const GitHubCurationService = require('../../providers/curation/github');
 
 function createService() {
@@ -14,17 +12,11 @@ function createService() {
   });
 }
 
-function getFixture(file) {
-  return fs.readFileSync(path.join(__dirname, '../fixtures', file), {encoding: 'utf8'});
-}
 describe('Github Curation Service', () => {
   const service = createService();
 
-  it('should validate curation yaml files', () => {
-    const invalidCuration = getFixture('curation-invalid.yaml');
-    expect(service.isValidCuration(invalidCuration)).to.not.be.ok;
-
-    const validCuration = getFixture('curation-valid.yaml');
-    expect(service.isValidCuration(validCuration)).to.be.ok;
+  // @todo flesh out
+  it('should be truthy', () => {
+    expect(service).to.be.ok;
   });
 });

--- a/test/providers/github.js
+++ b/test/providers/github.js
@@ -1,0 +1,30 @@
+const {expect} = require('chai');
+const fs = require('fs');
+const path = require('path');
+const GitHubCurationService = require('../../providers/curation/github');
+
+function createService() {
+  return GitHubCurationService({
+    owner: 'foobar',
+    repo: 'foobar',
+    branch: 'foobar',
+    token: 'foobar',
+    webhookSecret: 'foobar',
+    tempLocation: '.'
+  });
+}
+
+function getFixture(file) {
+  return fs.readFileSync(path.join(__dirname, '../fixtures', file), {encoding: 'utf8'});
+}
+describe('Github Curation Service', () => {
+  const service = createService();
+
+  it('should validate curation yaml files', () => {
+    const invalidCuration = getFixture('curation-invalid.yaml');
+    expect(service.isValidCuration(invalidCuration)).to.not.be.ok;
+
+    const validCuration = getFixture('curation-valid.yaml');
+    expect(service.isValidCuration(validCuration)).to.be.ok;
+  });
+});


### PR DESCRIPTION
Made some decent progress: 
* Turns out `js-yaml` doesn't validate yaml files against a JSON schema spec file out of the box, so I had to research a bit on best way to do this. Came across `ajv` which works well in conjunction with `js-yaml`.
* Setup a couple tests and fixture files (one for a valid curation, another for an invalid curation) so I had a nice feedback loop as I updated the curation schema. LMK if you guys prefer a different directory structure for the `test` dir.
* Started building up the curation schema using @jeffmcaffer's initial schema as a guide
* Played a bit with `revisions` and `patternProperties` (thanks @iamwillbar) and that seems to work well. Next we need to define a `revision` object in greater detail (i.e. add `described`, `licensed`, etc).

Although this is a WIP, it's mergeable - the tests pass. I'll try to add to the schema definition tonight or on Friday (I have some time blocked out for ClearlyDefined on Fridays). Once the schema is a bit more fleshed out, we can break it up into multiple files so that @iamwillbar can leverage them with Swagger. 