### PR TITLE
GitHub OAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In effect the curated data for a project is a _fork_ of the project. Like most f
 # Quick start
 
 Unless of course you are working on it, you should not need to run this service yourself. Rather, you can use
-https://dev-api.clearlydefined.io for experimental work or https://api.clearlydefined.io for working with 
+https://dev-api.clearlydefined.io for experimental work or https://api.clearlydefined.io for working with
 production data.
 
 If you do want to run the service locally, follow these steps.
@@ -17,7 +17,7 @@ If you do want to run the service locally, follow these steps.
 1. `cd` to the repo dir and run `npm install`
 1. Copy the `template.env.json` file to the **parent** directory of the repo and rename it to `env.json`. Ideally this repo is colocated with any other ClearlyDefined repos you might be using. You can share the `env.json` file but it always has to be in the parent folder of the repo. Just merge the files. Any colliding properties are meant to be shared.
 1. Clone the [harvested-data](https://github.com/clearlydefined/harvested-data.git) repo to get a mess of sample data. This is not strictly necessary but unless you have another source of ClearlyDefined harvest data, this is a great sample set. It changes over time and typically has data for the top 20 or so packages from supported different communities.
-1. After cloning/copying/merging, update the `env.json` file to have the property values for your setup. See the [Configuration](#configuration) section for more details. 
+1. After cloning/copying/merging, update the `env.json` file to have the property values for your setup. See the [Configuration](#configuration) section for more details.
 1. Run `npm start`
 
 That results in the ClearlyDefined service starting up and listening for RESTful interaction at http://localhost:4000. See the [Configuration](#configuration) section for info on how to change the port. The REST APIs are (partially) described in the Swagger at http://localhost:4000/api-docs. The APIs fall in two main buckets: curation management, and data access.
@@ -73,7 +73,7 @@ You can also get the curation for a particular component revision using one of t
 ```
 GET http://localhost:4000/curations/npm/npmjs/-/redie/0.3.0
 GET http://localhost:4000/curations/npm/npmjs/-/redie/0.3.0/pr/23
-``` 
+```
 
 ## Data access
 
@@ -125,22 +125,35 @@ See the `harvest` endpoint
 
 ## Properties
 
+### `SERVICE_ENDPOINT`
+The full origin of the service, e.g. `http://domain.com:port`.
 
-### CURATION_GITHUB_OWNER
-The GitHub user or org that owns the curation repo. This repo is assumed to be owned by `CURATION_GITHUB_OWNER`. 
+### `WEBSITE_ENDPOINT`
+The full origin of the website/UI, e.g. `http://domain.com:port`.
 
-### CURATION_GITHUB_REPO
-The GitHub curation repo to use for curations. This repo is assumed to be owned by `CURATION_GITHUB_OWNER`. 
+### `CURATION_GITHUB_OWNER`
+The GitHub user or org that owns the curation repo. This repo is assumed to be owned by `CURATION_GITHUB_OWNER`.
 
-### CURATION_GITHUB_BRANCH
+### `CURATION_GITHUB_REPO`
+The GitHub curation repo to use for curations. This repo is assumed to be owned by `CURATION_GITHUB_OWNER`.
+
+### `CURATION_GITHUB_BRANCH`
 The GitHub curation repo branch to use for curations. For testing and development, feel free to use your own. DON'T use `master` and you aren't so DO NOT use `master`.
 
+### `CURATION_GITHUB_TOKEN`
+A Personal Access Token with public_repo scope
 
-   * CURATION_GITHUB_TOKEN= personal access token with public_repo scope
+### `AUTH_GITHUB_CLIENT_ID` and `AUTH_GITHUB_CLIENT_SECRET`
+If using an OAuth application for GitHub sign-on, set these to the client ID and client secret, respectively.
+If not provided, auth will fall back to `CURATION_GITHUB_TOKEN`.
+
+### `AUTH_GITHUB_ORG`
+The name of the org the site will use for authenticating users. Checks team membership.
+
    * HARVEST_AZBLOB_CONNECTION_STRING= Azure blob connection string
    * HARVEST_AZBLOB_CONTAINER_NAME= name of container holding harvested data
    * API_TOKEN= the token to use for authorizing clients calling this service
-   * PORT= Defaults to 3000, like a lot of other dev setups. Set this if you are running more than one service that uses that port. 
+   * PORT= Defaults to 3000, like a lot of other dev setups. Set this if you are running more than one service that uses that port.
 
 
 ***

--- a/lib/config.js
+++ b/lib/config.js
@@ -41,7 +41,7 @@ module.exports = {
         containerName: config.get('HARVEST_AZBLOB_CONTAINER_NAME') || `harvest-${process.env.NODE_ENV}`
       },
       file: {
-        location: config.get('FILE_STORE_LOCATION') || process.platform === 'win32' ? 'c:/temp/cd' : '/tmp/cd'
+        location: config.get('FILE_STORE_LOCATION') || (process.platform === 'win32' ? 'c:/temp/cd' : '/tmp/cd')
       }
     }
   },
@@ -56,12 +56,24 @@ module.exports = {
         containerName: config.get('COMPONENT_AZBLOB_CONTAINER_NAME') || config.get('HARVEST_AZBLOB_CONTAINER_NAME') + '-component' || `component-${process.env.NODE_ENV}`
       },
       file: {
-        location: config.get('FILE_STORE_LOCATION') || process.platform === 'win32' ? 'c:/temp/cd' : '/tmp/cd'
+        location: config.get('FILE_STORE_LOCATION') || (process.platform === 'win32' ? 'c:/temp/cd' : '/tmp/cd')
       }
     }
   },
   auth: {
     apiToken: config.get('API_TOKEN'),
-    password: config.get('AUTH_SITE_PASSWORD')
+    password: config.get('AUTH_SITE_PASSWORD'),
+    github: {
+      clientId: config.get('AUTH_GITHUB_CLIENT_ID'),
+      clientSecret: config.get('AUTH_GITHUB_CLIENT_SECRET'),
+      org: config.get('AUTH_GITHUB_ORG') || 'clearlydefined'
+    }
+  },
+  caching: {
+    provider: config.get('CACHING_PROVIDER') || 'memory'
+  },
+  endpoints: {
+    service: config.get('SERVICE_ENDPOINT') || 'http://localhost:4000',
+    website: config.get('WEBSITE_ENDPOINT') || 'http://localhost:3000'
   }
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -66,7 +66,10 @@ module.exports = {
     github: {
       clientId: config.get('AUTH_GITHUB_CLIENT_ID'),
       clientSecret: config.get('AUTH_GITHUB_CLIENT_SECRET'),
-      org: config.get('AUTH_GITHUB_ORG') || 'clearlydefined'
+      org: config.get('AUTH_GITHUB_ORG') || 'clearlydefined',
+      timeouts: {
+        team: 10 * 60, // 10 mins
+      }
     }
   },
   caching: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -62,7 +62,6 @@ module.exports = {
   },
   auth: {
     apiToken: config.get('API_TOKEN'),
-    password: config.get('AUTH_SITE_PASSWORD'),
     github: {
       clientId: config.get('AUTH_GITHUB_CLIENT_ID'),
       clientSecret: config.get('AUTH_GITHUB_CLIENT_SECRET'),

--- a/middleware/caching.js
+++ b/middleware/caching.js
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+
+module.exports = (cacheProvider) => (req, res, next) => {
+  req.app.locals.cache = cacheProvider;
+  next();
+};

--- a/middleware/github.js
+++ b/middleware/github.js
@@ -1,3 +1,4 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
 const crypto = require('crypto');

--- a/middleware/github.js
+++ b/middleware/github.js
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 
+const crypto = require('crypto');
 const GitHubApi = require('@octokit/rest');
+
+const asyncMiddleware = require('./asyncMiddleware');
+const config = require('../lib/config');
 
 const options = {
   headers: {
@@ -13,7 +17,7 @@ const options = {
  * that is pre-configured for the current user. Also injects a cached copy
  * of relevant teams the user is a member of.
  */
-module.exports = (req, res, next) => {
+module.exports = asyncMiddleware(async (req, res, next) => {
   const authHeader = req.get('authorization');
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     res.status(401).end();
@@ -27,26 +31,58 @@ module.exports = (req, res, next) => {
     type: 'token',
     token,
   });
-  req.user = {
+  req.app.locals.user = {
     github: {
       client,
     }
   };
 
-  (async () => {
-    // check cache for team data
-    const teamCacheKey = `github.teams.${token}`;
-    let teams = await req.app.locals.cache.get(teamCacheKey);
+  // check cache for team data; hash the token so we're not storing them raw
+  const hashedToken = await crypto.createHash('sha256').update(token).digest('hex');
+  const teamCacheKey = `github.teams.${hashedToken}`;
+  let teams = await req.app.locals.cache.get(teamCacheKey);
 
-    // and fetch it otherwise
-    if (!teams) {
-      teams = await getTeams(client, req.app.locals.config.auth.github.org);
-      await req.app.locals.cache.set(teamCacheKey, teams, 10);
+  // and fetch it otherwise
+  if (!teams) {
+    try {
+      // TEMPORARY: remove once team permissions are decided on
+      await orgCheckShim(client);
+
+    } catch (err) {
+      res.status(401).send({error: err});
+      return;
     }
 
-    req.user.github.teams = teams;
-  })().then(() => next()).catch(next);
-};
+    // TEMPORARY: ideally we'd not use this, but PATs as-configured
+    // don't get access to teams. someday switch everyone to personal
+    // oauth apps?
+    try {
+      teams = await getTeams(client, config.auth.github.org);
+    } catch (err) {
+      teams = [];
+    }
+
+    await req.app.locals.cache.set(teamCacheKey, teams, config.auth.github.timeouts.team);
+  }
+
+  req.app.locals.user.github.teams = teams;
+  next();
+});
+
+// TEMPORARY: for now, just verify org membership for website access
+async function orgCheckShim(client) {
+  // except when not using oauth for dev
+  if (!config.auth.github.clientId) {
+    return;
+  }
+
+  const orgResp = await client.users.getOrgMembership({
+    org: config.auth.github.org,
+  });
+  if (orgResp.data.state !== 'active') {
+    throw new Error('membership not active');
+  }
+}
 
 /**
  * Fetch a list of teams a user belogs to filtered for the given org.

--- a/middleware/github.js
+++ b/middleware/github.js
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+
+const GitHubApi = require('@octokit/rest');
+
+const options = {
+  headers: {
+    'user-agent': 'clearlydefined.io',
+  },
+};
+
+/**
+ * GitHub convenience middleware that injects a client into the request object
+ * that is pre-configured for the current user. Also injects a cached copy
+ * of relevant teams the user is a member of.
+ */
+module.exports = (req, res, next) => {
+  const authHeader = req.get('authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).end();
+    return;
+  }
+  const token = authHeader.split(' ')[1];
+
+  // constructor and authenticate are inexpensive (just sets local state)
+  const client = new GitHubApi(options);
+  client.authenticate({
+    type: 'token',
+    token,
+  });
+  req.user = {
+    github: {
+      client,
+    }
+  };
+
+  (async () => {
+    // check cache for team data
+    const teamCacheKey = `github.teams.${token}`;
+    let teams = await req.app.locals.cache.get(teamCacheKey);
+
+    // and fetch it otherwise
+    if (!teams) {
+      teams = await getTeams(client, req.app.locals.config.auth.github.org);
+      await req.app.locals.cache.set(teamCacheKey, teams, 10);
+    }
+
+    req.user.github.teams = teams;
+  })().then(() => next()).catch(next);
+};
+
+/**
+ * Fetch a list of teams a user belogs to filtered for the given org.
+ * @param {object} client - GitHubApi client
+ * @param {string} org - org name to filter teams
+ * @returns {Promise<Array<string>>} - list of teams
+ */
+async function getTeams(client, org) {
+  const resp = await client.users.getTeams();
+  return resp.data
+    .filter(entry => entry.organization.login === org)
+    .map(entry => entry.name);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,31 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@octokit/rest": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-14.0.3.tgz",
+      "integrity": "sha512-r0AbDS6aVYGQEyW5w4NIV1+ikTUq53gDXVutFo9bW88wC/ce/pGoNI5+2tmKJ5s2tPmQh/iqUpdfua2ssFVwqQ==",
+      "requires": {
+        "before-after-hook": "1.1.0",
+        "debug": "3.1.0",
+        "dotenv": "4.0.0",
+        "https-proxy-agent": "2.1.1",
+        "is-stream": "1.1.0",
+        "lodash": "4.17.4",
+        "proxy-from-env": "1.0.0",
+        "url-template": "2.0.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -226,6 +251,11 @@
       "requires": {
         "tweetnacl": "0.14.5"
       }
+    },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
     },
     "body-parser": {
       "version": "1.18.2",
@@ -479,6 +509,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
+    "cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -629,6 +668,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -1022,6 +1066,7 @@
         "debug": "3.1.0",
         "dotenv": "4.0.0",
         "https-proxy-agent": "2.1.1",
+        "is-stream": "1.1.0",
         "lodash": "4.17.4",
         "proxy-from-env": "1.0.0",
         "url-template": "2.0.8"
@@ -1345,6 +1390,11 @@
       "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
       "dev": true
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -1496,6 +1546,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -1643,6 +1698,11 @@
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.0.0.tgz",
       "integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA="
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -1722,6 +1782,39 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
+    "passport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "requires": {
+        "passport-strategy": "1.0.0",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-github": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/passport-github/-/passport-github-1.1.0.tgz",
+      "integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=",
+      "requires": {
+        "passport-oauth2": "1.4.0"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz",
+      "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0=",
+      "requires": {
+        "oauth": "0.9.15",
+        "passport-strategy": "1.0.0",
+        "uid2": "0.0.3",
+        "utils-merge": "1.0.0"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1744,6 +1837,11 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "performance-now": {
       "version": "0.2.0",
@@ -1886,6 +1984,32 @@
           }
         }
       }
+    },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "requires": {
+        "double-ended-queue": "2.1.0-0",
+        "redis-commands": "1.3.1",
+        "redis-parser": "2.6.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
+      "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
+    },
+    "redis-mock": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/redis-mock/-/redis-mock-0.20.0.tgz",
+      "integrity": "sha1-lKOVhlurvOv1OLa1mUFyPkgHMBA=",
+      "dev": true
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
     "referrer-policy": {
       "version": "1.1.0",
@@ -2328,6 +2452,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "underscore": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^4.13.1",
-    "mocha": "^4.0.1",
-    "redis-mock": "^0.20.0"
+    "mocha": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
+    "@octokit/rest": "^14.0.0",
     "ajv": "^6.0.1",
     "azure-storage": "^2.7.0",
     "base-64": "^0.1.0",
@@ -14,18 +15,21 @@
     "crypto": "^1.0.1",
     "debug": "~2.6.9",
     "express": "~4.15.5",
-    "express-basic-auth": "^1.1.3",
     "extend": "^3.0.1",
-    "github": "^13.0.1",
+    "github": "^13.1.0",
     "helmet": "^3.9.0",
     "js-yaml": "^3.10.0",
+    "memory-cache": "^0.2.0",
     "minimatch": "^3.0.4",
     "mkdirp": "^0.5.1",
     "moment": "^2.19.4",
     "morgan": "~1.9.0",
     "painless-config": "^0.1.0",
+    "passport": "^0.4.0",
+    "passport-github": "^1.1.0",
     "readdirp": "^2.1.0",
     "recursive-readdir": "^2.2.1",
+    "redis": "^2.8.0",
     "request-id": "^0.11.1",
     "request-promise-native": "^1.0.5",
     "semver": "^5.4.1",
@@ -38,6 +42,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^4.13.1",
-    "mocha": "^4.0.1"
+    "mocha": "^4.0.1",
+    "redis-mock": "^0.20.0"
   }
 }

--- a/providers/caching/memory.js
+++ b/providers/caching/memory.js
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+const Cache = require('memory-cache').Cache;
+
+class MemoryCache {
+
+  constructor() {
+    this.cache = new Cache();
+  }
+
+  async get(item) {
+    return this.cache.get(item);
+  }
+
+  async set(item, value, expirationSeconds) {
+    this.cache.put(item, value, 1000 * expirationSeconds);
+  }
+
+}
+
+module.exports = () => new MemoryCache();

--- a/providers/caching/memory.js
+++ b/providers/caching/memory.js
@@ -1,3 +1,4 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
 const Cache = require('memory-cache').Cache;

--- a/providers/caching/redis.js
+++ b/providers/caching/redis.js
@@ -1,3 +1,4 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
 const redis = require('redis');
@@ -6,7 +7,7 @@ const util = require('util');
 class RedisCache {
 
   constructor(options) {
-    this.redis = redisLib.createClient(options);
+    this.redis = redis.createClient(options);
     this._redisGet = util.promisify(this.redis.get);
     this._redisSet = util.promisify(this.redis.set);
   }

--- a/providers/caching/redis.js
+++ b/providers/caching/redis.js
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+const redis = require('redis');
+const util = require('util');
+
+class RedisCache {
+
+  constructor(options) {
+    this.redis = redisLib.createClient(options);
+    this._redisGet = util.promisify(this.redis.get);
+    this._redisSet = util.promisify(this.redis.set);
+  }
+
+  async get(item) {
+    return await this._redisGet(item);
+  }
+
+  async set(item, value, expirationSeconds) {
+    await this._redisSet(item, value, 'EX', expirationSeconds);
+  }
+
+}
+
+module.exports = (options) => new RedisCache(options);

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -34,7 +34,7 @@ class GitHubCurationService {
   addOrUpdate(githubUserClient, coordinates, patch) {
     if (!patch.patch)
       throw new Error('Cannot add or update an empty patch. Did you forget to put it in a "patch" property?');
-    const github = githubUserClient; // XXX Github.getClient(this.options);
+    const github = githubUserClient;
     const { owner, repo, branch } = this.options;
     const path = this._getCurationPath(coordinates);
     const prBranch = this._getBranchName(coordinates);

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -31,10 +31,10 @@ class GitHubCurationService {
     };
   }
 
-  addOrUpdate(coordinates, patch) {
+  addOrUpdate(githubUserClient, coordinates, patch) {
     if (!patch.patch)
       throw new Error('Cannot add or update an empty patch. Did you forget to put it in a "patch" property?');
-    const github = Github.getClient(this.options);
+    const github = githubUserClient; // XXX Github.getClient(this.options);
     const { owner, repo, branch } = this.options;
     const path = this._getCurationPath(coordinates);
     const prBranch = this._getBranchName(coordinates);
@@ -74,7 +74,7 @@ class GitHubCurationService {
             const sha = masterBranch.data.commit.sha;
             return github.gitdata.createReference({ owner, repo, ref: `refs/heads/${prBranch}`, sha });
           })
-          .then(() => updatedPatch);
+          .then(() => updatedPatch)
       })
       .then(updatedPatch => {
         const message = `Update ${path} ${coordinates.revision}`;

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -74,7 +74,7 @@ class GitHubCurationService {
             const sha = masterBranch.data.commit.sha;
             return github.gitdata.createReference({ owner, repo, ref: `refs/heads/${prBranch}`, sha });
           })
-          .then(() => updatedPatch)
+          .then(() => updatedPatch);
       })
       .then(updatedPatch => {
         const message = `Update ${path} ${coordinates.revision}`;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+const express = require('express');
+const passport = require('passport');
+const GitHubStrategy = require('passport-github').Strategy;
+
+const config = require('../lib/config');
+const utils = require('../lib/utils');
+const asyncMiddleware = require('../middleware/asyncMiddleware');
+
+const router = express.Router();
+
+router.get('/github',
+  passport.authenticate('github', { session: false })
+);
+
+router.get('/github/finalize',
+  passport.authenticate('github', { session: false }),
+  (req, res) => {
+    const safeToken = encodeURIComponent(req.user.githubAccessToken);
+
+    // passing in the 'website' endpoint below is very important;
+    // using '*' instead means this page will gladly send out a
+    // user's token to any site that asks for it. see:
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+    res.status(200).send(`<script>
+      window.opener.postMessage({
+        type: 'github-token',
+        token: '${safeToken}',
+      }, '${config.endpoints.website}');
+      window.close();
+    </script>`);
+  }
+);
+
+function setup() {
+  return router;
+}
+
+setup.getStrategy = () => {
+  return new GitHubStrategy({
+    clientID: config.auth.github.clientId,
+    clientSecret: config.auth.github.clientSecret,
+    // this needs to match the callback url on the oauth app on github
+    callbackURL: `${config.endpoints.service}/auth/github/finalize`,
+    scope: ['repo', 'user']
+  },
+  function (access, refresh, profile, done) {
+    // this only lives for one request; see the 'finalize' endpoint
+    done(null, { githubAccessToken: access });
+  });
+};
+
+module.exports = setup;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,3 +1,4 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT
 
 const express = require('express');

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -35,7 +35,7 @@ router.get('/:type?/:provider?/:namespace?/:name?', asyncMiddleware(async (reque
 // Create a patch for a specific revision of a package
 router.patch('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async (request, response) => {
   const packageCoordinates = utils.toPackageCoordinates(request);
-  return curationService.addOrUpdate(request.user.github.client, packageCoordinates, request.body).then(() =>
+  return curationService.addOrUpdate(request.app.locals.user.github.client, packageCoordinates, request.body).then(() =>
     response.sendStatus(200));
 }));
 

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -35,7 +35,7 @@ router.get('/:type?/:provider?/:namespace?/:name?', asyncMiddleware(async (reque
 // Create a patch for a specific revision of a package
 router.patch('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async (request, response) => {
   const packageCoordinates = utils.toPackageCoordinates(request);
-  return curationService.addOrUpdate(packageCoordinates, request.body).then(() =>
+  return curationService.addOrUpdate(request.user.github.client, packageCoordinates, request.body).then(() =>
     response.sendStatus(200));
 }));
 


### PR DESCRIPTION
Ready for review. See clearlydefined/website#37 for the frontend portion.

This change:
* Adds GitHub authentication endpoints so that users can sign in with their GitHub account
* Adds GitHub middleware that injects a user-aware GitHub API client into the request context
* Injects the current user's GitHub teams into the request context
* Adds caching provider/middleware

Small items left to finish before merging:
* [x] Clean up app.js; I made a mess in there
* [x] Add token fallback so that every dev doesn't need an OAuth app registered to test 😃 
* [x] Finish up the website changes (login/out workflow is ugly)
* [x] Replace `'*'` in auth postMessage with the hostname of the real website; as far as I can tell the service is not "aware" of where the UI endpoint is located. It needs to be aware of that to avoid leaking the token to third-parties.

In future PRs:
* Check teams & enforce permissions
* Offload more GitHub operations to the currently signed-in user; right now it's just PRs