### PR TITLE
add "origin" search endpoints

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,6 +50,9 @@ app.use(logger('dev'));
 app.use(configMiddleware);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDoc));
 app.use('/webhook', bodyParser.raw({ limit: '5mb', type: '*/*' }), webhook);
+app.use('/origins/github', require('./routes/originGitHub')());
+app.use('/origins/npm', require('./routes/originNpm')());
+
 app.use(basicAuth({
   users: {
     'token': config.auth.apiToken,

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
     "agent-base": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-      "integrity": "sha1-gPps3kQPTc+a8mF88kYJm12Z8Mg=",
+      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
       "requires": {
         "es6-promisify": "5.0.0"
       }
@@ -63,7 +63,7 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -319,7 +319,7 @@
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
@@ -330,7 +330,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -362,7 +362,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
@@ -388,7 +388,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -411,7 +411,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "concat-map": {
@@ -433,7 +433,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -448,7 +448,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -472,7 +472,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
       "version": "0.3.1",
@@ -550,7 +550,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -558,7 +558,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.5"
@@ -603,7 +603,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
     "dns-prefetch-control": {
@@ -614,7 +614,7 @@
     "doctrine": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha1-aPls6O/FbMQmUfH6rbTxdSc7AHU=",
+      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -733,7 +733,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -754,7 +754,7 @@
     "espree": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
@@ -764,7 +764,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
       "version": "1.0.0",
@@ -845,7 +845,7 @@
         "qs": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha1-jQSVTTZN7z78VbWgeT4eLIsebkk="
+          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
         },
         "statuses": {
           "version": "1.3.1",
@@ -857,7 +857,7 @@
     "express-basic-auth": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.1.3.tgz",
-      "integrity": "sha1-GJJMAv7xjZ7+WOIoR+4x4kB0nzM=",
+      "integrity": "sha512-+tYtERHfl46Y1sPexskNcnIgYCmEnvj4Hp8/19dfByMUQAAWKEQ/Ik1taQ+Kj9LLJP1ItuXa95Ta8e8LtyltVQ==",
       "requires": {
         "basic-auth": "1.1.0"
       }
@@ -870,7 +870,7 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -1017,7 +1017,7 @@
     "github": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/github/-/github-13.0.1.tgz",
-      "integrity": "sha1-TM9KQd9mL5I2fnekdGdOq7G2x40=",
+      "integrity": "sha512-rApJzcnzy6E3WXhjGlSeRlWKnKM/yoi0fAxNjcOuq+1fjX4dMsiS/AWakrrhpMV3ZHi+mbNgNopS5d3go2AopQ==",
       "requires": {
         "debug": "3.1.0",
         "dotenv": "4.0.0",
@@ -1030,7 +1030,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -1040,7 +1040,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -1054,7 +1054,7 @@
     "globals": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
-      "integrity": "sha1-YyZERX9fDjrnEYBxg3AOvy5GM+Q=",
+      "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
       "dev": true
     },
     "globby": {
@@ -1079,7 +1079,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "har-schema": {
@@ -1151,7 +1151,7 @@
     "helmet": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.9.0.tgz",
-      "integrity": "sha1-eyzwFaLRCbyoPt55JEIHmcDmfe4=",
+      "integrity": "sha512-czCyS77TyanWlfVSoGlb9GBJV2Q2zJayKxU5uBw0N1TzDTs/qVNh1SL8Q688KU0i0Sb7lQ/oLtnaEqXzl2yWvA==",
       "requires": {
         "dns-prefetch-control": "0.1.0",
         "dont-sniff-mimetype": "1.0.0",
@@ -1170,7 +1170,7 @@
     "helmet-csp": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.6.0.tgz",
-      "integrity": "sha1-wfVZWvvF+D5fHmwV+ELwehD26gQ=",
+      "integrity": "sha512-n/oW9l6RtO4f9YvphsNzdvk1zITrSN7iRT8ojgrJu/N3mVdHl9zE4OjbiHWcR64JK32kbqx90/yshWGXcjUEhw==",
       "requires": {
         "camelize": "1.0.0",
         "content-security-policy-builder": "1.1.0",
@@ -1197,7 +1197,7 @@
     "hsts": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.1.0.tgz",
-      "integrity": "sha1-y9bJGKI4X+4d1WgL+ys6GUwBIcw="
+      "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
     },
     "http-errors": {
       "version": "1.6.2",
@@ -1223,7 +1223,7 @@
     "https-proxy-agent": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
-      "integrity": "sha1-p85DgqG6gmbuhIV4d4Ei1JEmD9k=",
+      "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
       "requires": {
         "agent-base": "4.1.2",
         "debug": "3.1.0"
@@ -1232,7 +1232,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -1242,7 +1242,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ienoopen": {
       "version": "1.0.0",
@@ -1252,7 +1252,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -1279,7 +1279,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
@@ -1342,7 +1342,7 @@
     "is-resolvable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
-      "integrity": "sha1-rMoc022+RLl0uSQyFVWnC6A7HPQ=",
+      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
       "dev": true
     },
     "is-typedarray": {
@@ -1375,7 +1375,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -1475,7 +1475,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -1533,7 +1533,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -1572,7 +1572,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1581,7 +1581,7 @@
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -1779,7 +1779,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -1988,7 +1988,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -2021,7 +2021,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sax": {
       "version": "0.5.2",
@@ -2031,7 +2031,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "send": {
       "version": "0.15.6",
@@ -2110,7 +2110,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -2154,7 +2154,7 @@
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -2164,7 +2164,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -2218,7 +2218,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -2258,7 +2258,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -2302,7 +2302,7 @@
     "type-detect": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha1-1w5byB223io4G8rKDG4MvcdjXeI=",
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
       "dev": true
     },
     "type-is": {
@@ -2357,7 +2357,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validator": {
       "version": "3.35.0",
@@ -2404,7 +2404,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"

--- a/routes/originGitHub.js
+++ b/routes/originGitHub.js
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const asyncMiddleware = require('../middleware/asyncMiddleware');
+const router = require('express').Router();
+const Github = require('../lib/github');
+
+function getClient(request) {
+  // return request.user.github.client;
+  // TODO reaching in and using the curation token for right now. When the GitHub Auth work is done
+  // delete the code below and uncomment the line above.
+  const token = request.app.locals.config.curation.store.github.token;
+  return Github.getClient({ token });
+}
+
+router.get('/:login/:repo/revisions', asyncMiddleware(async (request, response) => {
+  try {
+    const { login, repo } = request.params;
+    const github = getClient(request);
+    const answer = await github.gitdata.getTags({ owner: login, repo, per_page: 100 });
+    const result = answer.data.map(item => {
+      return { tag: item.ref.slice(10), sha: item.object.sha }
+    });
+    return response.status(200).send(result);
+  } catch (error) {
+    if (error.code === 404)
+      return response.status(200).send([]);
+      // TODO what to do on non-404 errors? Log for sure but what do we give back to the caller?
+    return response.status(200).send([]);
+  }
+}));
+
+router.get('/:login/:repo?', asyncMiddleware(async (request, response) => {
+  const { login, repo } = request.params;
+  const github = getClient(request);
+  if (request.path.indexOf('/', 1) > 0) {
+    const answer = await github.search.repos({ q: `${repo || ''}+user:${login}+in:name+fork:true`, sort: 'stars', per_page: 100 });
+    const result = answer.data.items.map(item => { return { id: item.full_name } });
+    return response.status(200).send(result);
+  }
+  const answer = await github.search.users({ q: `${login}+repos:>0`, sort: 'repositories', per_page: 30 })
+  const result = answer.data.items.map(item => { return { id: item.login } });
+  return response.status(200).send(result);
+}));
+
+function setup() {
+  return router;
+}
+
+module.exports = setup;

--- a/routes/originGitHub.js
+++ b/routes/originGitHub.js
@@ -19,7 +19,7 @@ router.get('/:login/:repo/revisions', asyncMiddleware(async (request, response) 
     const github = getClient(request);
     const answer = await github.gitdata.getTags({ owner: login, repo, per_page: 100 });
     const result = answer.data
-      .map(item => { return { tag: item.ref.slice(10), sha: item.object.sha } })
+      .map(item => { return { tag: item.ref.slice(10), sha: item.object.sha }; })
       .sort((a, b) => a.tag < b.tag ? 1 : (a.tag > b.tag) ? -1 : 0);
     return response.status(200).send(result);
   } catch (error) {
@@ -35,11 +35,11 @@ router.get('/:login/:repo?', asyncMiddleware(async (request, response) => {
   const github = getClient(request);
   if (request.path.indexOf('/', 1) > 0) {
     const answer = await github.search.repos({ q: `${repo || ''}+user:${login}+in:name+fork:true`, sort: 'stars', per_page: 100 });
-    const result = answer.data.items.map(item => { return { id: item.full_name } });
+    const result = answer.data.items.map(item => { return { id: item.full_name }; });
     return response.status(200).send(result);
   }
-  const answer = await github.search.users({ q: `${login}+repos:>0`, sort: 'repositories', per_page: 30 })
-  const result = answer.data.items.map(item => { return { id: item.login } });
+  const answer = await github.search.users({ q: `${login}+repos:>0`, sort: 'repositories', per_page: 30 });
+  const result = answer.data.items.map(item => { return { id: item.login }; });
   return response.status(200).send(result);
 }));
 

--- a/routes/originGitHub.js
+++ b/routes/originGitHub.js
@@ -18,14 +18,14 @@ router.get('/:login/:repo/revisions', asyncMiddleware(async (request, response) 
     const { login, repo } = request.params;
     const github = getClient(request);
     const answer = await github.gitdata.getTags({ owner: login, repo, per_page: 100 });
-    const result = answer.data.map(item => {
-      return { tag: item.ref.slice(10), sha: item.object.sha }
-    });
+    const result = answer.data
+      .map(item => { return { tag: item.ref.slice(10), sha: item.object.sha } })
+      .sort((a, b) => a.tag < b.tag ? 1 : (a.tag > b.tag) ? -1 : 0);
     return response.status(200).send(result);
   } catch (error) {
     if (error.code === 404)
       return response.status(200).send([]);
-      // TODO what to do on non-404 errors? Log for sure but what do we give back to the caller?
+    // TODO what to do on non-404 errors? Log for sure but what do we give back to the caller?
     return response.status(200).send([]);
   }
 }));

--- a/routes/originNpm.js
+++ b/routes/originNpm.js
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const asyncMiddleware = require('../middleware/asyncMiddleware');
+const router = require('express').Router();
+const requestPromise = require('request-promise-native');
+
+router.get('/:namespace?/:name/revisions', asyncMiddleware(async (request, response) => {
+  const baseUrl = 'https://registry.npmjs.com';
+  const { namespace, name } = request.params;
+  const fullName = namespace ? `${namespace}/${name}` : name;
+  const url = `${baseUrl}/${encodeURIComponent(fullName).replace('%40', '@')}` // npmjs doesn't handle the escaped version
+  const answer = await requestPromise({ url, method: 'GET', json: true });
+  const result = Object.getOwnPropertyNames(answer.versions);
+  return response.status(200).send(result);
+}));
+
+router.get('/:namespace/:name?', asyncMiddleware(async (request, response) => {
+  const { namespace, name } = request.params;
+  // TODO decide if we want to tone down their scoring effect
+  const searchTerm = name ? `${namespace}/${name}` : namespace
+  const url = `https://api.npms.io/v2/search?q=${searchTerm}`;
+  const answer = await requestPromise({ url, method: 'GET', json: true });
+  const result = answer.results.map(entry => { return { id: entry.package.name } })
+  return response.status(200).send(result);
+}));
+
+function setup() {
+  return router;
+}
+
+module.exports = setup;

--- a/routes/originNpm.js
+++ b/routes/originNpm.js
@@ -11,7 +11,7 @@ router.get('/:namespace?/:name/revisions', asyncMiddleware(async (request, respo
   const fullName = namespace ? `${namespace}/${name}` : name;
   const url = `${baseUrl}/${encodeURIComponent(fullName).replace('%40', '@')}` // npmjs doesn't handle the escaped version
   const answer = await requestPromise({ url, method: 'GET', json: true });
-  const result = Object.getOwnPropertyNames(answer.versions);
+  const result = Object.getOwnPropertyNames(answer.versions).sort((a, b) => a < b ? 1 : (a > b) ? -1 : 0);
   return response.status(200).send(result);
 }));
 

--- a/routes/originNpm.js
+++ b/routes/originNpm.js
@@ -9,7 +9,7 @@ router.get('/:namespace?/:name/revisions', asyncMiddleware(async (request, respo
   const baseUrl = 'https://registry.npmjs.com';
   const { namespace, name } = request.params;
   const fullName = namespace ? `${namespace}/${name}` : name;
-  const url = `${baseUrl}/${encodeURIComponent(fullName).replace('%40', '@')}` // npmjs doesn't handle the escaped version
+  const url = `${baseUrl}/${encodeURIComponent(fullName).replace('%40', '@')}`; // npmjs doesn't handle the escaped version
   const answer = await requestPromise({ url, method: 'GET', json: true });
   const result = Object.getOwnPropertyNames(answer.versions).sort((a, b) => a < b ? 1 : (a > b) ? -1 : 0);
   return response.status(200).send(result);
@@ -18,10 +18,10 @@ router.get('/:namespace?/:name/revisions', asyncMiddleware(async (request, respo
 router.get('/:namespace/:name?', asyncMiddleware(async (request, response) => {
   const { namespace, name } = request.params;
   // TODO decide if we want to tone down their scoring effect
-  const searchTerm = name ? `${namespace}/${name}` : namespace
+  const searchTerm = name ? `${namespace}/${name}` : namespace;
   const url = `https://api.npms.io/v2/search?q=${searchTerm}`;
   const answer = await requestPromise({ url, method: 'GET', json: true });
-  const result = answer.results.map(entry => { return { id: entry.package.name } })
+  const result = answer.results.map(entry => { return { id: entry.package.name }; });
   return response.status(200).send(result);
 }));
 


### PR DESCRIPTION
Originally the web UI was fetching the candidate github repos and NPM modules directly from the respective origins. This had a number of issues

* some of the apis do not work for CORS calls
* It was a little challenging to manage ratelimits and caching
* There was no opportunity for unify or augmenting results

This PR implements origin searching for GitHub and NPM as pretty much straight pass throughs. There is still work to do

* augment with info like what we already have
* structure the data in a more uniform way to simplify the consumer experience
* caching
* update to use the new GitHub API token coming via auth

As it is, this is fine to release and follow up with the outlined changes.
