### PR TITLE
Add support for listing sets available harvest results

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ The name of the org the site will use for authenticating users. Checks team memb
 
    * HARVEST_AZBLOB_CONNECTION_STRING= Azure blob connection string
    * HARVEST_AZBLOB_CONTAINER_NAME= name of container holding harvested data
-   * API_TOKEN= the token to use for authorizing clients calling this service
    * PORT= Defaults to 3000, like a lot of other dev setups. Set this if you are running more than one service that uses that port.
 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -61,7 +61,6 @@ module.exports = {
     }
   },
   auth: {
-    apiToken: config.get('API_TOKEN'),
     github: {
       clientId: config.get('AUTH_GITHUB_CLIENT_ID'),
       clientSecret: config.get('AUTH_GITHUB_CLIENT_SECRET'),

--- a/lib/entityCoordinates.js
+++ b/lib/entityCoordinates.js
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+class EntityCoordinates {
+
+  static fromString(path) {
+    path = path.startsWith('/') ? path.slice(1) : path;
+    const [type, provider, namespaceSpec, name, revision] = path.split('/');
+    const namespace = namespaceSpec === '-' ? null : namespaceSpec;
+    return new EntityCoordinates(type, provider, namespace, name, revision);
+  }
+
+  constructor(type, provider, namespace, name, revision) {
+    this.type = type.toLowerCase();
+    this.provider = provider.toLowerCase();
+    this.namespace = namespace;
+    this.name = name;
+    this.revision = revision;
+  }
+
+  toString() {
+    // if there is a provider then consider the namespace otherwise there can't be one so ignore null
+    const namespace = this.provider ? this.namespace || '-' : null
+    // TODO validate that there are no intermediate nulls
+    return [this.type, this.provider, namespace, this.name, this.revision].filter(s => s).join('/');
+  }
+
+  asRevisionless() {
+    return new EntityCoordinates(this.type, this.provider, this.namespace, this.name);
+  }
+
+  asEntityCoordinates() {
+    return this;
+  }
+}
+
+module.exports = EntityCoordinates;

--- a/lib/entityCoordinates.js
+++ b/lib/entityCoordinates.js
@@ -11,8 +11,8 @@ class EntityCoordinates {
   }
 
   constructor(type, provider, namespace, name, revision) {
-    this.type = type.toLowerCase();
-    this.provider = provider.toLowerCase();
+    this.type = type && type.toLowerCase();
+    this.provider = provider && provider.toLowerCase();
     this.namespace = namespace;
     this.name = name;
     this.revision = revision;
@@ -20,7 +20,7 @@ class EntityCoordinates {
 
   toString() {
     // if there is a provider then consider the namespace otherwise there can't be one so ignore null
-    const namespace = this.provider ? this.namespace || '-' : null
+    const namespace = this.provider ? this.namespace || '-' : null;
     // TODO validate that there are no intermediate nulls
     return [this.type, this.provider, namespace, this.name, this.revision].filter(s => s).join('/');
   }

--- a/lib/resultCoordinates.js
+++ b/lib/resultCoordinates.js
@@ -14,17 +14,17 @@ class ResultCoordinates {
 
   constructor(type, provider, namespace, name, revision, tool, toolVersion) {
     this.type = type;
-    this.provider = provider.toLowerCase();
-    this.namespace = namespace.toLowerCase();
+    this.provider = provider && provider.toLowerCase();
+    this.namespace = namespace && namespace.toLowerCase();
     this.name = name;
     this.revision = revision;
-    this.tool = tool.toLowerCase();
+    this.tool = tool && tool.toLowerCase();
     this.toolVersion = toolVersion;
   }
 
   toString() {
     // if there is a provider then consider the namespace otherwise there can't be one so ignore null
-    const namespace = this.provider ? this.namespace || '-' : null
+    const namespace = this.provider ? this.namespace || '-' : null;
     // TODO validate that there are no intermediate nulls
     return [this.type, this.provider, namespace, this.name, this.revision, this.tool, this.toolVersion].filter(s => s).join('/');
   }

--- a/lib/resultCoordinates.js
+++ b/lib/resultCoordinates.js
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const EntityCoordinates = require('./entityCoordinates');
+
+class ResultCoordinates {
+
+  static fromString(path) {
+    path = path.startsWith('/') ? path.slice(1) : path;
+    const [type, provider, namespaceSpec, name, revision, tool, toolVersion] = path.split('/');
+    const namespace = namespaceSpec === '-' ? null : namespaceSpec;
+    return new ResultCoordinates(type, provider, namespace, name, revision, tool, toolVersion);
+  }
+
+  constructor(type, provider, namespace, name, revision, tool, toolVersion) {
+    this.type = type;
+    this.provider = provider.toLowerCase();
+    this.namespace = namespace.toLowerCase();
+    this.name = name;
+    this.revision = revision;
+    this.tool = tool.toLowerCase();
+    this.toolVersion = toolVersion;
+  }
+
+  toString() {
+    // if there is a provider then consider the namespace otherwise there can't be one so ignore null
+    const namespace = this.provider ? this.namespace || '-' : null
+    // TODO validate that there are no intermediate nulls
+    return [this.type, this.provider, namespace, this.name, this.revision, this.tool, this.toolVersion].filter(s => s).join('/');
+  }
+
+  asEntityCoordinates() {
+    return new EntityCoordinates(this.type, this.provider, this.namespace, this.name, this.revision);
+  }
+}
+
+module.exports = ResultCoordinates;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,25 +2,31 @@
 // SPDX-License-Identifier: MIT
 
 const semver = require('semver');
+const EntityCoordinates = require('./entityCoordinates');
+const ResultCoordinates = require('./resultCoordinates');
 
-function toPackageCoordinates(request) {
-  return {
-    type: request.params.type,
-    provider: request.params.provider,
-    namespace: request.params.namespace === '-' ? null : request.params.namespace,
-    name: request.params.name,
-    revision: request.params.revision,
-    tool: request.params.tool,
-    toolVersion: request.params.toolVersion
-  };
+function toResultCoordinatesFromRequest(request) {
+  return new ResultCoordinates(
+    request.params.type,
+    request.params.provider,
+    request.params.namespace === '-' ? null : request.params.namespace,
+    request.params.name,
+    request.params.revision,
+    request.params.tool,
+    request.params.toolVersion
+  );
 }
 
-function toPathFromCoordinates(packageCoordinates) {
-  const c = packageCoordinates;
-  const revisionPart = c.revision ? `revision/${c.revision}` : null;
-  const toolVersionPart = c.toolVersion ? c.toolVersion : null;
-  const toolPart = c.tool ? `tool/${c.tool}` : null;
-  return [c.type, c.provider, c.namespace || '-', c.name, revisionPart, toolPart, toolVersionPart].filter(s => s).join('/');
+function toEntityCoordinatesFromRequest(request) {
+  return new EntityCoordinates(
+    request.params.type,
+    request.params.provider,
+    request.params.namespace === '-' ? null : request.params.namespace,
+    request.params.name,
+    request.params.revision,
+    request.params.tool,
+    request.params.toolVersion
+  );
 }
 
 function getLatestVersion(versions) {
@@ -36,7 +42,7 @@ function getLatestVersion(versions) {
 }
 
 module.exports = {
-  toPackageCoordinates,
-  toPathFromCoordinates,
+  toEntityCoordinatesFromRequest,
+  toResultCoordinatesFromRequest,
   getLatestVersion
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,11 +238,6 @@
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
     },
-    "basic-auth": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
-      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ="
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -508,15 +503,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-    },
-    "cookie-parser": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
-      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
-      "requires": {
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6"
-      }
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -898,14 +884,6 @@
         }
       }
     },
-    "express-basic-auth": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.1.3.tgz",
-      "integrity": "sha512-+tYtERHfl46Y1sPexskNcnIgYCmEnvj4Hp8/19dfByMUQAAWKEQ/Ik1taQ+Kj9LLJP1ItuXa95Ta8e8LtyltVQ==",
-      "requires": {
-        "basic-auth": "1.1.0"
-      }
-    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -1059,9 +1037,9 @@
       }
     },
     "github": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/github/-/github-13.0.1.tgz",
-      "integrity": "sha512-rApJzcnzy6E3WXhjGlSeRlWKnKM/yoi0fAxNjcOuq+1fjX4dMsiS/AWakrrhpMV3ZHi+mbNgNopS5d3go2AopQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/github/-/github-13.1.0.tgz",
+      "integrity": "sha512-xCen2waPsGF4MT9nE4gDwXYSD+ktmDyhQX3l/7cJcfZ0H6hjetkTZh8vzX39q/8sLtRS6iA01Mt5UIGQG9qJng==",
       "requires": {
         "debug": "3.1.0",
         "dotenv": "4.0.0",
@@ -2000,12 +1978,6 @@
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
       "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
     },
-    "redis-mock": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/redis-mock/-/redis-mock-0.20.0.tgz",
-      "integrity": "sha1-lKOVhlurvOv1OLa1mUFyPkgHMBA=",
-      "dev": true
-    },
     "redis-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
@@ -2372,6 +2344,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "throat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "semver": "^5.4.1",
     "serialize-error": "^2.1.0",
     "swagger-ui-express": "^2.0.13",
+    "throat": "^4.1.0",
     "tmp": "0.0.33",
     "underscore": "^1.8.3",
     "vso-node-api": "^6.2.8-preview"

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -202,12 +202,12 @@ class GitHubCurationService {
 
   /**
    * Given a partial spec, return the list of full spec urls for each curated version of the spec'd components
-   * @param {string} searchPattern - a partial path that describes the sort of curation to look for.
-   * @returns {[URL]} - Array of URLs describing he available curations
+   * @param {EntityCoordinates} coordinates - the partial coordinates that describe the sort of curation to look for.
+   * @returns {[URL]} - Array of URLs describing the available curations
    */
-  async list(searchPattern) {
+  async list(coordinates) {
     await this.ensureCurations();
-    const root = `${this.tempLocation.name}/${this.options.repo}/${this._getSearchRoot(searchPattern)}`;
+    const root = `${this.tempLocation.name}/${this.options.repo}/${this._getSearchRoot(coordinates)}`;
     if (!fs.existsSync(root))
       return [];
     return new Promise((resolve, reject) => {
@@ -259,7 +259,7 @@ class GitHubCurationService {
   _getPrTitle(coordinates) {
     const c = coordinates;
     // Structure the PR title to match the entity coordinates so we can hackily reverse engineer that to build a URL... :-/
-    return `${c.type.toLowerCase()}/${c.provider.toLowerCase()}/${c.namespace || '-'}/${c.name}/${c.revision}`;
+    return coordinates.toString();
   }
 
   _getBranchName(coordinates) {
@@ -268,13 +268,13 @@ class GitHubCurationService {
   }
 
   _getCurationPath(coordinates) {
-    const c = coordinates;
-    return `curations/${c.type.toLowerCase()}/${c.provider.toLowerCase()}/${c.namespace || '-'}/${c.name}.yaml`;
+    const path = coordinates.asRevisionless().toString();
+    return `curations/${path}.yaml`;
   }
 
-  _getSearchRoot(path) {
-    // TODO validate the path is not bogus
-    return `curations/${path.split('/').slice(0, 4).join('/')}`;
+  _getSearchRoot(coordinates) {
+    const path = coordinates.asRevisionless().toString();
+    return `curations/${path ? path + '/' : ''}`;
   }
 
   // @todo perhaps validate directory structure (package coordinates)

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -257,7 +257,6 @@ class GitHubCurationService {
   }
 
   _getPrTitle(coordinates) {
-    const c = coordinates;
     // Structure the PR title to match the entity coordinates so we can hackily reverse engineer that to build a URL... :-/
     return coordinates.toString();
   }

--- a/providers/harvest/vsts.js
+++ b/providers/harvest/vsts.js
@@ -23,12 +23,7 @@ class Vsts {
   }
 
   harvest(spec) {
-    return this._queueBuild(spec);
-  }
-
-  _queueBuild(spec) {
-    const self = this;
-    return this.vstsBuild.getDefinitions(self.project, self.buildDefinitionName).then(definitions => {
+    return this.vstsBuild.getDefinitions(this.project, this.buildDefinitionName).then(definitions => {
       if (!definitions[0] || !definitions[0].id) {
         return Promise.reject(new Error('Build definition does not exist.'));
       }
@@ -36,9 +31,9 @@ class Vsts {
         definition: {
           id: definitions[0].id
         },
-        parameters: JSON.stringify({ [self.buildVariableName]: JSON.stringify(spec) })
+        parameters: JSON.stringify({ [this.buildVariableName]: JSON.stringify(spec) })
       };
-      return this.vstsBuild.queueBuild(build, self.project);
+      return this.vstsBuild.queueBuild(build, this.project);
     });
   }
 }

--- a/providers/stores/abstractStore.js
+++ b/providers/stores/abstractStore.js
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-const semver = require('semver');
 const throat = require('throat');
 const _ = require('lodash');
 const EntityCoordinates = require('../../lib/entityCoordinates');
@@ -42,7 +41,7 @@ class AbstractStore {
     const result = list
       .map(path => {
         if (type === 'entity')
-          return this._toEntityCoordinatesFromStoragePath(path)
+          return this._toEntityCoordinatesFromStoragePath(path);
         if (type === 'result')
           return this._toResultCoordinatesFromStoragePath(path);
         throw new Error(`Invalid list type: ${type}`);
@@ -51,11 +50,11 @@ class AbstractStore {
     return _.uniqWith(filtered, _.isEqual);
   }
 
-  _list(path) {
+  _list() {
     throw new Error('subclasses must implement "_list"');
   }
 
-  _filter(list) {
+  _filter() {
     throw new Error('subclasses must implement "_filter"');
   }
 
@@ -86,7 +85,7 @@ class AbstractStore {
     const toolVersionPart = c.toolVersion ? c.toolVersion : null;
     const toolPart = c.tool ? `tool/${c.tool}` : null;
     // if there is a provider then consider the namespace otherwise there can't be one so ignore null
-    const namespace = c.provider ? c.namespace || '-' : null
+    const namespace = c.provider ? c.namespace || '-' : null;
     // TODO validate that there are no intermediate nulls
     return [c.type, c.provider, namespace, c.name, revisionPart, toolPart, toolVersionPart].filter(s => s).join('/');
   }

--- a/providers/stores/abstractStore.js
+++ b/providers/stores/abstractStore.js
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const semver = require('semver');
+const throat = require('throat');
+const _ = require('lodash');
+const EntityCoordinates = require('../../lib/entityCoordinates');
+const ResultCoordinates = require('../../lib/resultCoordinates');
+
+class AbstractStore {
+  
+  /**
+   * List all of the tool results available for the given coordinates. The coordinates can be 
+   * arbitrarily loose. The result will have an entry per discovered component. That entry will 
+   * itself have an entry per tool with the value being the array of versions of the tool for
+   * which there are result.
+   * 
+   * @param {*} coordinatesList - an array of coordinate paths to list
+   * @returns A list of all components that have results and the results present
+   */
+  async listAll(coordinatesList, type = 'entity') {
+    const result = {};
+    const promises = coordinatesList.map(throat(10, async coordinates => {
+      const list = await this.list(coordinates, type);
+      list.forEach(entry => {
+        if (entry.length === 0)
+          return;
+        const spec = entry.asEntityCoordinates().toString();
+        const component = result[spec] = result[spec] || {};
+        if (type === 'result') {
+          const current = component[entry.tool] = component[entry.toolVersion] || [];
+          current.push(entry.toolVersion);
+        }
+      });
+    }));
+    await Promise.all(promises);
+    return result;
+  }
+
+  async list(coordinates, type = 'entity') {
+    const list = await this._list(coordinates);
+    const result = list
+      .map(path => {
+        if (type === 'entity')
+          return this._toEntityCoordinatesFromStoragePath(path)
+        if (type === 'result')
+          return this._toResultCoordinatesFromStoragePath(path);
+        throw new Error(`Invalid list type: ${type}`);
+      });
+    const filtered = this._filter(result);
+    return _.uniqWith(filtered, _.isEqual);
+  }
+
+  _list(path) {
+    throw new Error('subclasses must implement "_list"');
+  }
+
+  _filter(list) {
+    throw new Error('subclasses must implement "_filter"');
+  }
+
+  _toResultCoordinatesFromStoragePath(path) {
+    const trimmed = this._trimStoragePath(path);
+    return ResultCoordinates.fromString(trimmed);
+  }
+
+  // Extract the entity coordinates from the storage path
+  _toEntityCoordinatesFromStoragePath(path) {
+    const trimmed = this._trimStoragePath(path);
+    return EntityCoordinates.fromString(trimmed);
+  }
+
+  _trimStoragePath(path) {
+    const normalized = path.replace(/\\/g, '/').replace('.json', '');
+    const rawSegments = normalized.split('/');
+    const segments = rawSegments[0] === '' ? rawSegments.slice(1) : rawSegments;
+    const name = segments.slice(0, 4);
+    const revision = segments.slice(5, 6);
+    const toolSpec = segments.slice(7, 9);
+    return name.concat(revision, toolSpec).join('/');
+  }
+
+  _toStoragePathFromCoordinates(coordinates) {
+    const c = coordinates;
+    const revisionPart = c.revision ? `revision/${c.revision}` : null;
+    const toolVersionPart = c.toolVersion ? c.toolVersion : null;
+    const toolPart = c.tool ? `tool/${c.tool}` : null;
+    // if there is a provider then consider the namespace otherwise there can't be one so ignore null
+    const namespace = c.provider ? c.namespace || '-' : null
+    // TODO validate that there are no intermediate nulls
+    return [c.type, c.provider, namespace, c.name, revisionPart, toolPart, toolVersionPart].filter(s => s).join('/');
+  }
+}
+
+module.exports = AbstractStore;

--- a/providers/stores/azblob.js
+++ b/providers/stores/azblob.js
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-const utils = require('../../lib/utils');
 const azure = require('azure-storage');
 const AbstractStore = require('./abstractStore');
 

--- a/providers/stores/azblob.js
+++ b/providers/stores/azblob.js
@@ -3,21 +3,14 @@
 
 const utils = require('../../lib/utils');
 const azure = require('azure-storage');
-
-// Responsible for storing and retrieving harvested data
-//
-// Return format should be:
-//
-// {
-// toolA: { /* tool-specific data format },
-// toolB/2.0: { /* tool-specific data format }
-// }
+const AbstractStore = require('./abstractStore');
 
 const resultOrError = (resolve, reject) => (error, result) => error ? reject(error) : resolve(result);
 const responseOrError = (resolve, reject) => (error, result, response) => error ? reject(error) : resolve(response);
 
-class AzBlobStore {
+class AzBlobStore extends AbstractStore {
   constructor(options) {
+    super();
     this.options = options;
     this.containerName = options.containerName;
   }
@@ -29,18 +22,31 @@ class AzBlobStore {
     return this.blobService;
   }
 
-  list(pattern) {
-    return new Promise((resolve, reject) => {
-      const name = pattern.startsWith('/') ? pattern.slice(1) : pattern;
+  async _list(coordinates) {
+    const result = await new Promise((resolve, reject) => {
+      const name = this._toStoragePathFromCoordinates(coordinates);
       this.blobService.listBlobsSegmentedWithPrefix(this.containerName, name, null, resultOrError(resolve, reject));
-    }).then(result => result.entries.map(entry => entry.name).filter(entry => !entry.startsWith('deadletter')));
+    });
+    return result.entries.map(entry => entry.name);
   }
 
-  get(packageCoordinates, stream) {
-    let name = utils.toPathFromCoordinates(packageCoordinates);
-    if (!name.endsWith('.json')) {
+  _filter(list) {
+    return list.filter(entry => entry.type !== 'deadletter');
+  }
+
+  /**
+   * Get the results of running the tool specified in the coordinates on the entty specified
+   * in the coordinates. If a stream is given, write the content directly on the stream and close.
+   * Otherwise, return an object that represents the result.
+   *   
+   * @param {ResultCoordinates} coordinates - The coordinates of the result to get 
+   * @param {WriteStream} [stream] - The stream onto which the result is written, if specified
+   * @returns The result object if no stream is specified, otherwise the return value is unspecified. 
+   */
+  get(coordinates, stream) {
+    let name = this._toStoragePathFromCoordinates(coordinates);
+    if (!name.endsWith('.json'))
       name += '.json';
-    }
     if (stream)
       return new Promise((resolve, reject) => {
         this.blobService.getBlobToStream(this.containerName, name, stream, responseOrError(resolve, reject));
@@ -51,8 +57,14 @@ class AzBlobStore {
       JSON.parse(result));
   }
 
-  getAll(packageCoordinates) {
-    const name = utils.toPathFromCoordinates(packageCoordinates);
+  /**
+   * Get all of the tool results for the given coordinates. The coordinates must be all the way down
+   * to a revision. 
+   * @param {EntityCoordinates} coordinates - The component revision to report on
+   * @returns An object with a property for each tool and tool version
+   */
+  getAll(coordinates) {
+    const name = this._toStoragePathFromCoordinates(coordinates);
     // Note that here we are assuming the number of blobs will be small-ish (<10) and
     // a) all fit in memory reasonably, and
     // b) fit in one list call (i.e., <5000)
@@ -70,9 +82,7 @@ class AzBlobStore {
     });
     return contents.then(entries => {
       return entries.reduce((result, entry) => {
-        const segments = entry.name.split('/');
-        const tool = segments[segments.length - 2];
-        const toolVersion = segments[segments.length - 1].replace('.json', '');
+        const { tool, toolVersion } = this._toResultCoordinatesFromStoragePath(entry.name);
         const current = result[tool] = result[tool] || {};
         current[toolVersion] = entry.content;
         return result;
@@ -80,9 +90,10 @@ class AzBlobStore {
     });
   }
 
-  store(packageCoordinates, stream) {
+  // TODO consider not having this. All harvest content should be written by the harvest service (e.g., crawler)
+  store(coordinates, stream) {
     return new Promise((resolve, reject) => {
-      let name = utils.toPathFromCoordinates(packageCoordinates);
+      let name = this._toStoragePathFromCoordinates(coordinates);
       if (!name.endsWith('.json')) {
         name += '.json';
       }

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -6,20 +6,20 @@ const express = require('express');
 const router = express.Router();
 const utils = require('../lib/utils');
 
-// Get a proposed patch for a specific revision of a package
+// Get a proposed patch for a specific revision of a component
 router.get('/:type/:provider/:namespace/:name/:revision/pr/:pr', asyncMiddleware(async (request, response) => {
-  const packageCoordinates = utils.toPackageCoordinates(request);
-  return curationService.get(packageCoordinates, request.params.pr).then(result => {
+  const coordinates = utils.toEntityCoordinatesFromRequest(request);
+  return curationService.get(coordinates, request.params.pr).then(result => {
     if (result)
       return response.status(200).send(result);
     response.sendStatus(404);
   });
 }));
 
-// Get an existing patch for a specific revision of a package
+// Get an existing patch for a specific revision of a component
 router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async (request, response) => {
-  const packageCoordinates = utils.toPackageCoordinates(request);
-  return curationService.get(packageCoordinates).then(result => {
+  const coordinates = utils.toEntityCoordinatesFromRequest(request);
+  return curationService.get(coordinates).then(result => {
     if (result)
       return response.status(200).send(result);
     response.sendStatus(404);
@@ -28,14 +28,15 @@ router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async 
 
 // Search for any patches related to the given path, as much as is given
 router.get('/:type?/:provider?/:namespace?/:name?', asyncMiddleware(async (request, response) => {
-  return curationService.list(request.path).then(result =>
+  const coordinates = utils.toEntityCoordinatesFromRequest(request);
+  return curationService.list(coordinates).then(result =>
     response.status(200).send(result));
 }));
 
-// Create a patch for a specific revision of a package
+// Create a patch for a specific revision of a component
 router.patch('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async (request, response) => {
-  const packageCoordinates = utils.toPackageCoordinates(request);
-  return curationService.addOrUpdate(request.app.locals.user.github.client, packageCoordinates, request.body).then(() =>
+  const coordinates = utils.toEntityCoordinatesFromRequest(request);
+  return curationService.addOrUpdate(request.app.locals.user.github.client, coordinates, request.body).then(() =>
     response.sendStatus(200));
 }));
 

--- a/routes/harvest.js
+++ b/routes/harvest.js
@@ -5,26 +5,27 @@ const asyncMiddleware = require('../middleware/asyncMiddleware');
 const router = require('express').Router();
 const minimatch = require('minimatch');
 const utils = require('../lib/utils');
+const EntityCoordinates = require('../lib/entityCoordinates');
 const bodyParser = require('body-parser');
 
 // Gets a given harvested file
 router.get('/:type/:provider/:namespace/:name/:revision/:tool/:toolVersion', asyncMiddleware(async (request, response) => {
-  const packageCoordinates = utils.toPackageCoordinates(request);
+  const coordinates = utils.toResultCoordinatesFromRequest(request);
   switch ((request.query.form || 'summary').toLowerCase()) {
     case 'streamed':
     case 'raw': {
-      const result = await harvestStore.get(packageCoordinates, response);
+      const result = await harvestStore.get(coordinates, response);
       // some harvest services will stream on the response and trigger sending
       return response.headersSent ? null : response.status(200).send(result);
     }
     case 'summary': {
-      const raw = await harvestStore.get(packageCoordinates);
-      const filter = await getFilter(packageCoordinates);
-      const result = await summarizeService.summarize(packageCoordinates, filter, raw);
+      const raw = await harvestStore.get(coordinates);
+      const filter = await getFilter(coordinates);
+      const result = await summarizeService.summarize(coordinates, filter, raw);
       return response.status(200).send(result);
     }
     case 'list': {
-      const result = await harvestStore.list(request.path);
+      const result = await harvestStore.list(coordinates);
       return response.status(200).send(result);
     }
     default:
@@ -32,9 +33,9 @@ router.get('/:type/:provider/:namespace/:name/:revision/:tool/:toolVersion', asy
   }
 }));
 
-async function getFilter(packageCoordinates) {
+async function getFilter(coordinates) {
   try {
-    const descriptionCoordinates = { ...packageCoordinates, tool: 'clearlydescribed' };
+    const descriptionCoordinates = { ...coordinates, tool: 'clearlydescribed' };
     const rawDescription = await harvestStore.get(descriptionCoordinates);
     return buildFilter(rawDescription.dimensions);
   } catch (error) {
@@ -51,21 +52,21 @@ function buildFilter(dimensions) {
 
 // Gets ALL the harvested data for a given component revision
 router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async (request, response) => {
-  const packageCoordinates = utils.toPackageCoordinates(request);
+  const coordinates = utils.toEntityCoordinatesFromRequest(request);
   switch ((request.query.form || 'summary').toLowerCase()) {
     case 'streamed':
     case 'raw': {
-      const result = await harvestStore.getAll(packageCoordinates);
+      const result = await harvestStore.getAll(coordinates);
       return response.status(200).send(result);
     }
     case 'summary': {
-      const raw = await harvestStore.getAll(packageCoordinates);
-      const filter = await getFilter(packageCoordinates);
-      const summarized = await summarizeService.summarizeAll(packageCoordinates, filter, raw);
+      const raw = await harvestStore.getAll(coordinates);
+      const filter = await getFilter(coordinates);
+      const summarized = await summarizeService.summarizeAll(coordinates, filter, raw);
       return response.status(200).send(summarized);
     }
     case 'list': {
-      const list = await harvestStore.list(request.path);
+      const list = await harvestStore.list(coordinates);
       return response.status(200).send(list);
     }
     default:
@@ -76,24 +77,25 @@ router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async 
 // Get a list of the harvested data that we have that matches the url as a prefix
 router.get('/:type?/:provider?/:namespace?/:name?/:revision?/:tool?', asyncMiddleware(async (request, response) => {
   if (request.query.form.toLowerCase() === 'list') {
-    const result = await harvestStore.list(request.path);
+    const coordinates = utils.toResultCoordinatesFromRequest(request);
+    const result = await harvestStore.list(coordinates);
     return response.status(200).send(result);
   }
   throw new Error(`Invalid request form: ${request.query.form}`);
 }));
 
-// Puts harvested file
-router.put('/:type/:provider/:namespace/:name/:revision/:tool/:toolVersion?', asyncMiddleware(async (request, response) => {
-  const packageCoordinates = utils.toPackageCoordinates(request);
-  await harvestStore.store(packageCoordinates, request);
-  response.sendStatus(201);
+// post a request to create a resoruce that is the summary of all harvested data available for 
+// the components outlined in the POST body
+router.post('/status', bodyParser.json(), asyncMiddleware(async (request, response) => {
+  const coordinatesList = request.body.map(entry => EntityCoordinates.fromString(entry));
+  const result = await harvestStore.listAll(coordinatesList, 'result');
+  response.status(200).send(result);
 }));
 
-// Post a component to be harvested
-// TODO not sure this is needed or needed in this form...
+// Post a (set of) component to be harvested
 router.post('/', bodyParser.json(), asyncMiddleware(async (request, response) => {
-  const result = await harvestService.harvest(request.body);
-  response.status(201).send(Object.assign(request.body, { build: { id: result.id } }));
+  await harvestService.harvest(request.body);
+  response.sendStatus(201);
 }));
 
 let harvestService;

--- a/routes/swagger.yaml
+++ b/routes/swagger.yaml
@@ -69,13 +69,39 @@ paths:
           description: Nothing. TODO - this should be 204 or return something.
   /harvest:
     post:
-      deprecated: true
-      summary: Obsolete?
+      summary: Post the given components to be harvested
       tags:
         - harvest
+      requestBody:
+        description: A single or array of requests
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/bodies/request'
       responses:
         201:
           description: Harvested file has been accepted.
+  /harvest/status:
+    post:
+      summary: Request the creation of a resoruce that is the summary of all harvested data available for the components outlined in the POST body
+      tags:
+        - harvest
+      requestBody:
+        description: List of components to report on.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/bodies/componentList'
+      responses:
+        200:
+          description: Status request has been accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#components/bodies/resultSummaryList'
+
   /harvest/{type}/{provider}/{namespace}/{name}/{revision}:
     get:
       summary: Get all the harvested data for a component revision.
@@ -245,6 +271,40 @@ tags:
 
 
 components:
+  bodies:
+    componentList:
+      name: componentList
+      description: A list of components to operate on. Each entry is a path describing a component, potentially with a version.
+      type: array
+      items: string
+      example:
+        - git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca
+        - npm/npmjs/-/redie/0.3.0
+    request:
+      name: request
+      description: A request to harvest a component. One of harvest.json#definitions/requests or harvest.json#definitions/request
+      type: object
+      example:
+        - type: package
+          url: cd:/npm/npmjs/-/redie/0.3.0
+        - type: source
+          url: cd:/git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca
+
+    resultSummaryList:
+      type: object
+      description: A list of harvest results that are available (see harvest.json#definitions/componentResultSummaryList)
+      example: 
+        'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca':
+          clearlydescribed: 
+            - 1
+          scancode: 
+            - 2.2.1
+        'npm/npmjs/-/redie/0.3.0':
+          clearlydescribed:
+            - 1
+          scancode:
+            - 2.2.1
+
   parameters:
     type:
       name: type

--- a/schemas/harvest.json
+++ b/schemas/harvest.json
@@ -1,0 +1,136 @@
+{
+  "$id": "https://api.clearlydefined.io/schemas/harvest.json#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "harvest",
+  "type": "object",
+  "definitions": {
+    "type": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "request": {
+      "required": [
+        "type",
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "url": {
+          "$ref": "#/definitions/url"
+        },
+        "policy": {
+          "type": "string"
+        }
+      }
+    },
+    "requests": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/request"
+      }
+    },
+    "componentResultSummaryList": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        ".*": {
+          "patternProperties": {
+            ".*": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "results": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/resultList"
+        }
+      }
+    },
+    "resultList": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/result"
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "_metadata": {
+          "$ref": "#/definitions/_metadata"
+        },
+        "content": {
+          "type": "object"
+        }
+      }
+    },
+    "_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dimensions": {
+          "additionalProperties": false,
+          "properties": {
+            "fetchedAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "processedAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "type": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "links": {
+              "$ref": "#definitions/links"
+            }
+          }
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/link"
+        }
+      }
+    },
+    "link": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "href": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
To support scenarios involving batches of results, add a harvest endpoint to get the statuses of a set of components.

along the way, clean up a mess of coordinate/path design and add some schema/swagger.