### PR TITLE
Add team/permission checks for harvesting and curation

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -67,6 +67,10 @@ module.exports = {
       org: config.get('AUTH_GITHUB_ORG') || 'clearlydefined',
       timeouts: {
         team: 10 * 60, // 10 mins
+      },
+      permissions: {
+        harvest: ['harvesters'],
+        curate: ['curators'],
       }
     }
   },

--- a/middleware/github.js
+++ b/middleware/github.js
@@ -54,12 +54,16 @@ module.exports = asyncMiddleware(async (req, res, next) => {
       return;
     }
 
-    // TEMPORARY: ideally we'd not use this, but PATs as-configured
-    // don't get access to teams. someday switch everyone to personal
-    // oauth apps?
     try {
       teams = await getTeams(client, config.auth.github.org);
     } catch (err) {
+      if (err.code === 404) {
+        console.error('GitHub returned a 404 when trying to read team data. ' +
+          'You probably need to re-configure your CURATION_GITHUB_TOKEN token with the `read:org` scope. (This only affects local development.)');
+      } else {
+        // XXX: Better logging situation?
+        console.error(err);
+      }
       teams = [];
     }
 

--- a/middleware/permissions.js
+++ b/middleware/permissions.js
@@ -1,0 +1,26 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Middleware that checks for team membership.
+ *
+ * Usage: `app.get('/some/route', teamCheck('harvesters'), (req, res) => ...)`
+ */
+function permissionCheck(permission) {
+  return (req, res, next) => {
+    const userTeams = req.app.locals.user.github.teams;
+    const requiredTeams = req.app.locals.config.auth.github.permissions[permission]; // whew!
+    const intersection = requiredTeams.filter(t => userTeams.includes(t));
+    if (intersection.length > 0) {
+      next();
+    } else {
+      const err = new Error(`No permission to '${permission}' (needs team membership)`);
+      err.status = 401;
+      next(err);
+    }
+  }
+}
+
+module.exports = {
+  permissionCheck
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
     "agent-base": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
+      "integrity": "sha1-gPps3kQPTc+a8mF88kYJm12Z8Mg=",
       "requires": {
         "es6-promisify": "5.0.0"
       }
@@ -762,7 +762,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1640,7 +1640,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1649,7 +1649,7 @@
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -60,7 +60,7 @@ setup.getStrategy = () => {
     clientSecret: config.auth.github.clientSecret,
     // this needs to match the callback url on the oauth app on github
     callbackURL: `${config.endpoints.service}/auth/github/finalize`,
-    scope: ['repo', 'user']
+    scope: ['public_repo', 'read:user', 'read:org']
   },
   function (access, refresh, profile, done) {
     // this only lives for one request; see the 'finalize' endpoint

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -5,6 +5,7 @@ const asyncMiddleware = require('../middleware/asyncMiddleware');
 const express = require('express');
 const router = express.Router();
 const utils = require('../lib/utils');
+const { permissionCheck } = require('../middleware/permissions');
 
 // Get a proposed patch for a specific revision of a component
 router.get('/:type/:provider/:namespace/:name/:revision/pr/:pr', asyncMiddleware(async (request, response) => {
@@ -34,7 +35,7 @@ router.get('/:type?/:provider?/:namespace?/:name?', asyncMiddleware(async (reque
 }));
 
 // Create a patch for a specific revision of a component
-router.patch('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async (request, response) => {
+router.patch('/:type/:provider/:namespace/:name/:revision', permissionCheck('curate'), asyncMiddleware(async (request, response) => {
   const coordinates = utils.toEntityCoordinatesFromRequest(request);
   return curationService.addOrUpdate(request.app.locals.user.github.client, coordinates, request.body).then(() =>
     response.sendStatus(200));

--- a/routes/harvest.js
+++ b/routes/harvest.js
@@ -7,6 +7,7 @@ const minimatch = require('minimatch');
 const utils = require('../lib/utils');
 const EntityCoordinates = require('../lib/entityCoordinates');
 const bodyParser = require('body-parser');
+const { permissionCheck } = require('../middleware/permissions');
 
 // Gets a given harvested file
 router.get('/:type/:provider/:namespace/:name/:revision/:tool/:toolVersion', asyncMiddleware(async (request, response) => {
@@ -81,16 +82,16 @@ router.get('/:type?/:provider?/:namespace?/:name?/:revision?/:tool?', asyncMiddl
   return response.status(200).send(result);
 }));
 
-// post a request to create a resoruce that is the summary of all harvested data available for 
+// post a request to create a resoruce that is the summary of all harvested data available for
 // the components outlined in the POST body
-router.post('/status', bodyParser.json(), asyncMiddleware(async (request, response) => {
+router.post('/status', permissionCheck('harvest'), bodyParser.json(), asyncMiddleware(async (request, response) => {
   const coordinatesList = request.body.map(entry => EntityCoordinates.fromString(entry));
   const result = await harvestStore.listAll(coordinatesList, 'result');
   response.status(200).send(result);
 }));
 
 // Post a (set of) component to be harvested
-router.post('/', bodyParser.json(), asyncMiddleware(async (request, response) => {
+router.post('/', permissionCheck('harvest'), bodyParser.json(), asyncMiddleware(async (request, response) => {
   await harvestService.harvest(request.body);
   response.sendStatus(201);
 }));


### PR DESCRIPTION
Note the two team names in config. These can be changed; they just have to match teams in the clearlydefined org.