### PR TITLE
make team perms configurable and remove some checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ The name of the org the site will use for authenticating users. Checks team memb
    * HARVEST_AZBLOB_CONTAINER_NAME= name of container holding harvested data
    * PORT= Defaults to 3000, like a lot of other dev setups. Set this if you are running more than one service that uses that port.
 
+### `AUTH_CURATION_TEAM`
+The GitHub team whose members have permission to programmatically write to the curation repo for this environment (e.g., merge pull requests). If left unset, **anyone** can do these operations.
+
+### `AUTH_HARVEST_TEAM`
+The GitHub team whose members have permission to programmatically queue requests to harvest data. That is, they can POST to the /harvest endpoint. If left unset, **anyone** can do these operations.
+
 
 ***
 ***

--- a/lib/config.js
+++ b/lib/config.js
@@ -69,8 +69,8 @@ module.exports = {
         team: 10 * 60, // 10 mins
       },
       permissions: {
-        harvest: ['harvesters'],
-        curate: ['curators'],
+        harvest: [config.get('AUTH_HARVEST_TEAM')].filter(e => e),
+        curate: [config.get('AUTH_CURATION_TEAM')].filter(e => e)
       }
     }
   },

--- a/middleware/permissions.js
+++ b/middleware/permissions.js
@@ -11,7 +11,7 @@ function permissionCheck(permission) {
     const userTeams = req.app.locals.user.github.teams;
     const requiredTeams = req.app.locals.config.auth.github.permissions[permission]; // whew!
     const intersection = requiredTeams.filter(t => userTeams.includes(t));
-    if (intersection.length > 0) {
+    if (requiredTeams.length === 0 || intersection.length > 0) {
       next();
     } else {
       const err = new Error(`No permission to '${permission}' (needs team membership)`);

--- a/middleware/permissions.js
+++ b/middleware/permissions.js
@@ -18,7 +18,7 @@ function permissionCheck(permission) {
       err.status = 401;
       next(err);
     }
-  }
+  };
 }
 
 module.exports = {

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -5,7 +5,6 @@ const asyncMiddleware = require('../middleware/asyncMiddleware');
 const express = require('express');
 const router = express.Router();
 const utils = require('../lib/utils');
-const { permissionCheck } = require('../middleware/permissions');
 
 // Get a proposed patch for a specific revision of a component
 router.get('/:type/:provider/:namespace/:name/:revision/pr/:pr', asyncMiddleware(async (request, response) => {

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -35,7 +35,7 @@ router.get('/:type?/:provider?/:namespace?/:name?', asyncMiddleware(async (reque
 }));
 
 // Create a patch for a specific revision of a component
-router.patch('/:type/:provider/:namespace/:name/:revision', permissionCheck('curate'), asyncMiddleware(async (request, response) => {
+router.patch('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async (request, response) => {
   const coordinates = utils.toEntityCoordinatesFromRequest(request);
   return curationService.addOrUpdate(request.app.locals.user.github.client, coordinates, request.body).then(() =>
     response.sendStatus(200));

--- a/routes/harvest.js
+++ b/routes/harvest.js
@@ -84,7 +84,7 @@ router.get('/:type?/:provider?/:namespace?/:name?/:revision?/:tool?', asyncMiddl
 
 // post a request to create a resoruce that is the summary of all harvested data available for
 // the components outlined in the POST body
-router.post('/status', permissionCheck('harvest'), bodyParser.json(), asyncMiddleware(async (request, response) => {
+router.post('/status', bodyParser.json(), asyncMiddleware(async (request, response) => {
   const coordinatesList = request.body.map(entry => EntityCoordinates.fromString(entry));
   const result = await harvestStore.listAll(coordinatesList, 'result');
   response.status(200).send(result);

--- a/test/providers/store/fileScan.js
+++ b/test/providers/store/fileScan.js
@@ -42,7 +42,7 @@ describe('list a tool result ', () => {
   it('throws original error when not ENOENT', async () => {
     const fileStore = FileStore({ location: '/foo' });
     try {
-      const result = await fileStore.list(new EntityCoordinates('npm', 'npmjs', null, 'error', '0.0'));
+      await fileStore.list(new EntityCoordinates('npm', 'npmjs', null, 'error', '0.0'));
       assert.fail('should have thrown error');
     } catch (error) {
       assert.equal(error.message, 'test error');


### PR DESCRIPTION
* make the perms teams configurable externally (env vars) to allow different environments (dev, prod, ...) to use different teams
* remove a couple of the permissions checks to make the system a little more open. Others will be added in as we add more function 