### PR TITLE
support anonymous users with no token

### DIFF
--- a/middleware/github.js
+++ b/middleware/github.js
@@ -20,73 +20,42 @@ const options = {
  */
 module.exports = asyncMiddleware(async (req, res, next) => {
   const authHeader = req.get('authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+  // if there is an auth header, it had better be Bearer
+  if (authHeader && !authHeader.startsWith('Bearer ')) {
     res.status(401).end();
     return;
   }
-  const token = authHeader.split(' ')[1];
 
+  const token = authHeader ? authHeader.split(' ')[1] : null;
+  const client = setupClient(req, token);
+  await setupTeams(req, token, client);
+  next();
+});
+
+// Create and configure a GitHub client and attach it to the request
+function setupClient(req, token = null) {
   // constructor and authenticate are inexpensive (just sets local state)
   const client = new GitHubApi(options);
-  client.authenticate({
-    type: 'token',
-    token,
-  });
-  req.app.locals.user = {
-    github: {
-      client,
-    }
-  };
+  token && client.authenticate({ type: 'token', token });
+  req.app.locals.user = { github: { client } };
+  return client;
+}
+
+// get the user's teams (from GitHub or the cache) and attach them to the request
+async function setupTeams(req, token, client = null) {
+  // anonymous users are not members of any team
+  if (!token)
+    return req.app.locals.user.github.teams = [];
 
   // check cache for team data; hash the token so we're not storing them raw
   const hashedToken = await crypto.createHash('sha256').update(token).digest('hex');
   const teamCacheKey = `github.teams.${hashedToken}`;
   let teams = await req.app.locals.cache.get(teamCacheKey);
-
-  // and fetch it otherwise
   if (!teams) {
-    try {
-      // TEMPORARY: remove once team permissions are decided on
-      await orgCheckShim(client);
-
-    } catch (err) {
-      res.status(401).send({error: err});
-      return;
-    }
-
-    try {
-      teams = await getTeams(client, config.auth.github.org);
-    } catch (err) {
-      if (err.code === 404) {
-        console.error('GitHub returned a 404 when trying to read team data. ' +
-          'You probably need to re-configure your CURATION_GITHUB_TOKEN token with the `read:org` scope. (This only affects local development.)');
-      } else {
-        // XXX: Better logging situation?
-        console.error(err);
-      }
-      teams = [];
-    }
-
+    teams = await getTeams(client, config.auth.github.org);
     await req.app.locals.cache.set(teamCacheKey, teams, config.auth.github.timeouts.team);
   }
-
   req.app.locals.user.github.teams = teams;
-  next();
-});
-
-// TEMPORARY: for now, just verify org membership for website access
-async function orgCheckShim(client) {
-  // except when not using oauth for dev
-  if (!config.auth.github.clientId) {
-    return;
-  }
-
-  const orgResp = await client.users.getOrgMembership({
-    org: config.auth.github.org,
-  });
-  if (orgResp.data.state !== 'active') {
-    throw new Error('membership not active');
-  }
 }
 
 /**
@@ -96,8 +65,23 @@ async function orgCheckShim(client) {
  * @returns {Promise<Array<string>>} - list of teams
  */
 async function getTeams(client, org) {
-  const resp = await client.users.getTeams();
-  return resp.data
-    .filter(entry => entry.organization.login === org)
-    .map(entry => entry.name);
+  try {
+    const resp = await client.users.getTeams();
+    return resp.data
+      .filter(entry => entry.organization.login === org)
+      .map(entry => entry.name);
+  } catch (err) {
+    if (err.code === 404) {
+      console.error('GitHub returned a 404 when trying to read team data. ' +
+        'You probably need to re-configure your CURATION_GITHUB_TOKEN token with the `read:org` scope. (This only affects local development.)');
+    } else if (err.code === 401 && err.message === 'Bad credentials') {
+      // the token was bad. trickle up the problem so the user can fix 
+      throw err;
+    } else {
+      // XXX: Better logging situation?
+      console.error(err);
+    }
+    // in all other error cases assume the user has no teams. If they do then they can try again after the timeout
+    return [];
+  }
 }


### PR DESCRIPTION
This proposal separates anonymous, logged in and team users.
* anonymous -- they get a client on the req but no token. their requests will be ratelimited by GH. If we want, we can add our own token there...
* logged in -- users that have a valid GH token but are not members of any team. Their req will have a token but there will be certain operations they cannot do.
* team members -- valid GH token and they are member of a CD team. They can do various special operations.