### PR TITLE
use CD natural request body or harvest

### DIFF
--- a/lib/entityCoordinates.js
+++ b/lib/entityCoordinates.js
@@ -11,7 +11,7 @@ const toLowerCaseMap = {
   npmjs: NONE,
   mavencentral: NONE,
   mavencentralsource: NONE
-}
+};
 
 function normalize(value, provider, property) {
   if (!value)

--- a/providers/harvest/crawler.js
+++ b/providers/harvest/crawler.js
@@ -11,13 +11,19 @@ class CrawlingHarvester {
 
   async harvest(spec) {
     const headers = {
-      'X-token': this.options.authToken,
-      // Authorization: 'basic' + this.options.authToken
+      'X-token': this.options.authToken
     };
+    const body = (Array.isArray(spec) ? spec : [spec]).map(entry => {
+      return {
+        type: entry.tool,
+        url: `cd:/${entry.path}`,
+        policy: entry.policy
+      }
+    });
     return requestPromise({
       url: `${this.options.url}/requests`,
       method: 'POST',
-      body: spec,
+      body,
       headers,
       json: true
     });

--- a/providers/harvest/crawler.js
+++ b/providers/harvest/crawler.js
@@ -16,7 +16,7 @@ class CrawlingHarvester {
     const body = (Array.isArray(spec) ? spec : [spec]).map(entry => {
       return {
         type: entry.tool,
-        url: `cd:/${entry.path}`,
+        url: `cd:/${entry.coordinates}`,
         policy: entry.policy
       };
     });

--- a/providers/harvest/crawler.js
+++ b/providers/harvest/crawler.js
@@ -18,7 +18,7 @@ class CrawlingHarvester {
         type: entry.tool,
         url: `cd:/${entry.path}`,
         policy: entry.policy
-      }
+      };
     });
     return requestPromise({
       url: `${this.options.url}/requests`,

--- a/routes/swagger.yaml
+++ b/routes/swagger.yaml
@@ -319,10 +319,10 @@ components:
       description: A request to harvest a component. One of harvest.json#definitions/requests or harvest.json#definitions/request
       type: object
       example:
-        - type: package
-          url: cd:/npm/npmjs/-/redie/0.3.0
-        - type: source
-          url: cd:/git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca
+        - tool: package
+          path: npm/npmjs/-/redie/0.3.0
+        - tool: source
+          path: git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca
 
     definitionList:
       type: object


### PR DESCRIPTION
Previously we used a harvest request body that looked a lot like that of the crawler. E.g., there was as type and a url , ... that is not particularly natural for CD API users. This PR changes to use tool: and coordinates:, concepts that are natural to CD.