### PR TITLE
rationalize copyright info

### DIFF
--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -32,6 +32,7 @@ class ScanCodeSummarizer {
           holders: Array.from(copyrightHolders).sort(),
           missing: missingHolders
         },
+        files: filteredFiles.length,
         license: {
           expression: this._licenseSetToExpression(licenseExpressions),
           missing: missingLicenses

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -52,7 +52,7 @@ class ScanCodeSummarizer {
     let hasHolders = false;
     for (let copyright of copyrights) {
       this._addArrayToSet(copyright.holders, holders);
-      hasHolders = hasHolders || copyright.holders.length
+      hasHolders = hasHolders || copyright.holders.length;
     }
     return hasHolders;
   }

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -1,24 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-// Responsible for summarizing tool-specific format to a normalized summary schema:
-//   package:
-//     type: string
-//     name: string
-//     provider: string
-//     revision: string
-//   source_location:
-//     provider: string
-//     url: string
-//     revision: string
-//     path: string
-//   copyright:
-//     statements: string[]
-//     holders: string[]
-//     authors: string[]
-//   license:
-//     expression: string
-
 class ScanCodeSummarizer {
 
   constructor(options) {
@@ -30,9 +12,7 @@ class ScanCodeSummarizer {
       throw new Error('Not valid ScanCode data');
 
     const data = harvested.content;
-    const copyrightStatements = new Set();
     const copyrightHolders = new Set();
-    const copyrightAuthors = new Set();
     const licenseExpressions = new Set();
 
     const filteredFiles = filter ? data.files.filter(file => filter(file.path)) : data.files;
@@ -45,9 +25,7 @@ class ScanCodeSummarizer {
       package: packageCoordinates,
       licensed: {
         copyright: {
-          statements: Array.from(copyrightStatements).sort(),
           holders: Array.from(copyrightHolders).sort(),
-          authors: Array.from(copyrightAuthors).sort()
         },
         license: this._licenseSetToExpression(licenseExpressions)
       }
@@ -55,16 +33,14 @@ class ScanCodeSummarizer {
   }
 
   _licenseSetToExpression(licenses) {
-    return Array.from(licenses).join(' AND ');
+    return Array.from(licenses).join(' and ');
   }
 
   _normalizeCopyrights(copyrights, statements, holders, authors) {
     if (!copyrights || !copyrights.length)
       return;
     for (let copyright of copyrights) {
-      this._addArrayToSet(copyright.statements, statements);
       this._addArrayToSet(copyright.holders, holders);
-      this._addArrayToSet(copyright.authors, authors);
     }
   }
 

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -7,41 +7,53 @@ class ScanCodeSummarizer {
     this.options = options;
   }
 
-  summarize(packageCoordinates, harvested, filter = null) {
+  summarize(coordinates, harvested, filter = null) {
     if (!harvested || !harvested.content || !harvested.content.scancode_version)
       throw new Error('Not valid ScanCode data');
 
     const data = harvested.content;
     const copyrightHolders = new Set();
     const licenseExpressions = new Set();
+    let missingHolders = 0;
+    let missingLicenses = 0;
 
     const filteredFiles = filter ? data.files.filter(file => filter(file.path)) : data.files;
     for (let file of filteredFiles) {
-      this._addArrayToSet(file.licenses, licenseExpressions, (license) => { return license.spdx_license_key; });
-      this._normalizeCopyrights(file.copyrights, copyrightStatements, copyrightHolders, copyrightAuthors);
+      this._addArrayToSet(file.licenses, licenseExpressions, license => license.spdx_license_key);
+      (!file.licenses || file.licenses.length === 0) && missingLicenses++;
+      const hasHolders = this._normalizeCopyrights(file.copyrights, copyrightHolders);
+      !hasHolders && missingHolders++;
     }
 
     return {
-      package: packageCoordinates,
+      package: coordinates,
       licensed: {
         copyright: {
           holders: Array.from(copyrightHolders).sort(),
+          missing: missingHolders
         },
-        license: this._licenseSetToExpression(licenseExpressions)
+        license: {
+          expression: this._licenseSetToExpression(licenseExpressions),
+          missing: missingLicenses
+        }
       }
     };
   }
 
   _licenseSetToExpression(licenses) {
-    return Array.from(licenses).join(' and ');
+    const licenseArray =Array.from(licenses).filter(e => e);
+    return licenseArray.length ? licenseArray.join(' and ') : null;
   }
 
-  _normalizeCopyrights(copyrights, statements, holders, authors) {
+  _normalizeCopyrights(copyrights, holders) {
     if (!copyrights || !copyrights.length)
-      return;
+      return false;
+    let hasHolders = false;
     for (let copyright of copyrights) {
       this._addArrayToSet(copyright.holders, holders);
+      hasHolders = hasHolders || copyright.holders.length
     }
+    return hasHolders;
   }
 
   _addArrayToSet(array, set, valueExtractor) {

--- a/schemas/curation.json
+++ b/schemas/curation.json
@@ -18,16 +18,10 @@
   },
   "definitions": {
     "type": {
-      "enum": [
-        "npm",
-        "git"
-      ]
+      "enum": ["npm", "git", "maven"]
     },
     "provider": {
-      "enum": [
-        "npmjs",
-        "github"
-      ]
+      "enum": ["npmjs", "github", "mavencentral", "mavencentralsource"]
     },
     "package": {
       "required": [

--- a/schemas/curation.json
+++ b/schemas/curation.json
@@ -146,19 +146,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "statements": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "holders": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "authors": {
           "type": "array",
           "items": {
             "type": "string"

--- a/test/fixtures/curation-invalid.1.yaml
+++ b/test/fixtures/curation-invalid.1.yaml
@@ -1,0 +1,13 @@
+package:
+  name: lodash
+  provider: npmjs
+  type: npm
+  namespace: "-"
+revisions:
+  4.17.4:
+    licensed:
+      copyright:
+        holders:
+          - "foo"
+          - "bar"
+        missing: 3  # this prop is not allowed

--- a/test/fixtures/curation-invalid.2.yaml
+++ b/test/fixtures/curation-invalid.2.yaml
@@ -1,0 +1,10 @@
+package:
+  name: lodash
+  provider: npmjs
+  type: npm
+  namespace: "-"
+revisions:
+  4.17.4:
+    licensed:
+      license:
+        missing: 3  # this prop is not allowed

--- a/test/fixtures/curation-invalid.3.yaml
+++ b/test/fixtures/curation-invalid.3.yaml
@@ -1,0 +1,9 @@
+package:
+  name: lodash
+  provider: npmjs
+  type: npm
+  namespace: "-"
+revisions:
+  4.17.4:
+    licensed:
+      files: 13  # this prop is not allowed

--- a/test/fixtures/curation-valid.yaml
+++ b/test/fixtures/curation-valid.yaml
@@ -9,9 +9,6 @@ revisions:
       issueTracker: "https://foobar.com/baz/1"
     licensed:
       copyright:
-        statements:
-          - "foo"
-          - "bar"
         holders:
           - "foo"
           - "bar"

--- a/test/lib/curation.js
+++ b/test/lib/curation.js
@@ -16,8 +16,29 @@ describe('Curations', () => {
     expect(curation.errors[0].message).to.equal('Invalid yaml');
   });
 
-  it('should identify invalid curations', () => {
+  it('should identify invalid date', () => {
     const content = getFixture('curation-invalid.yaml');
+    const curation = Curation({content});
+    expect(curation.isValid).to.be.false;
+    expect(curation.errors[0].message).to.equal('Invalid curation');
+  });
+
+  it('should identify invalid props: missing copyright', () => {
+    const content = getFixture('curation-invalid.1.yaml');
+    const curation = Curation({content});
+    expect(curation.isValid).to.be.false;
+    expect(curation.errors[0].message).to.equal('Invalid curation');
+  });
+
+  it('should identify invalid props: missing license', () => {
+    const content = getFixture('curation-invalid.2.yaml');
+    const curation = Curation({content});
+    expect(curation.isValid).to.be.false;
+    expect(curation.errors[0].message).to.equal('Invalid curation');
+  });
+
+  it('should identify invalid props: file count', () => {
+    const content = getFixture('curation-invalid.3.yaml');
     const curation = Curation({content});
     expect(curation.isValid).to.be.false;
     expect(curation.errors[0].message).to.equal('Invalid curation');

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -107,9 +107,7 @@ function buildFile(path, license, holders) {
     path,
     licenses: license ? [{ spdx_license_key: license }] : null,
     copyrights: holders
-      ? holders.map(entry => {
-          return { holders: entry };
-        })
+      ? holders.map(entry => { return { holders: entry }; })
       : null
   };
 }

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai');
+const Summarizer = require('../../providers/summary/scancode');
+
+describe('ScanCode summarizer', () => {
+  it('has the right package info', () => {
+    const harvested = buildOutput([]);
+    const summarizer = Summarizer();
+    const coordinates = 'npm/npmjs/-/test/1.0';
+    const summary = summarizer.summarize(coordinates, harvested);
+    expect(summary.package).to.eq(coordinates);
+  });
+
+  it('gets all the copyright holders', () => {
+    const harvested = buildOutput([
+      buildFile('/foo.txt', 'MIT', [['Bob', 'Fred']]),
+      buildFile('/bar.txt', 'MIT', [['Jane', 'Fred']])
+    ]);
+    const summarizer = Summarizer();
+    const coordinates = 'npm/npmjs/-/test/1.0';
+    const summary = summarizer.summarize(coordinates, harvested);
+    const copyright = summary.licensed.copyright;
+    expect(copyright.holders.length).to.eq(3);
+    expect(copyright.holders).to.include('Bob');
+    expect(copyright.holders).to.include('Jane');
+    expect(copyright.holders).to.include('Fred');
+    expect(copyright.missing).to.eq(0);
+  });
+
+  it('gets all the licenses', () => {
+    const harvested = buildOutput([
+      buildFile('/foo.txt', 'MIT', []),
+      buildFile('/bar.txt', 'GPL', [])
+    ]);
+    const summarizer = Summarizer();
+    const coordinates = 'npm/npmjs/-/test/1.0';
+    const summary = summarizer.summarize(coordinates, harvested);
+    const license = summary.licensed.license;
+    expect(license.expression).to.include('MIT');
+    expect(license.expression).to.include('GPL');
+    expect(license.missing).to.eq(0);
+  });
+
+  it('records missing licenses and holders', () => {
+    const harvested = buildOutput([
+      buildFile('/foo.txt', null, [['bob']]),
+      buildFile('/bar.txt', 'GPL', [])
+    ]);
+    const summarizer = Summarizer();
+    const coordinates = 'npm/npmjs/-/test/1.0';
+    const summary = summarizer.summarize(coordinates, harvested);
+    const copyright = summary.licensed.copyright;
+    expect(copyright.holders.length).to.eq(1);
+    expect(copyright.holders).to.include('bob');
+    expect(copyright.missing).to.eq(1);
+    const license = summary.licensed.license;
+    expect(license.expression).to.eq('GPL');
+    expect(license.missing).to.eq(1);
+  });
+
+  it('handles files with no data', () => {
+    const harvested = buildOutput([
+      buildFile('/foo.txt', null, null),
+      buildFile('/bar.txt', null, null)
+    ]);
+    const summarizer = Summarizer();
+    const coordinates = 'npm/npmjs/-/test/1.0';
+    const summary = summarizer.summarize(coordinates, harvested);
+    const copyright = summary.licensed.copyright;
+    expect(copyright.holders.length).to.eq(0);
+    expect(copyright.missing).to.eq(2);
+    const license = summary.licensed.license;
+    expect(license.expression).to.eq(null);
+    expect(license.missing).to.eq(2);
+  });
+
+  it('handles scan with no files', () => {
+    const harvested = buildOutput([]);
+    const summarizer = Summarizer();
+    const coordinates = 'npm/npmjs/-/test/1.0';
+    const summary = summarizer.summarize(coordinates, harvested);
+    const copyright = summary.licensed.copyright;
+    expect(copyright.holders.length).to.eq(0);
+    expect(copyright.missing).to.eq(0);
+    const license = summary.licensed.license;
+    expect(license.expression).to.eq(null);
+    expect(license.missing).to.eq(0);
+  });
+});
+
+function buildOutput(files) {
+  return {
+    content: {
+      scancode_version: '2.2.1',
+      files
+    }
+  };
+}
+
+function buildFile(path, license, holders) {
+  return {
+    path,
+    licenses: license ? [{ spdx_license_key: license }] : null,
+    copyrights: holders
+      ? holders.map(entry => {
+          return { holders: entry };
+        })
+      : null
+  };
+}

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -21,6 +21,7 @@ describe('ScanCode summarizer', () => {
     const summarizer = Summarizer();
     const coordinates = 'npm/npmjs/-/test/1.0';
     const summary = summarizer.summarize(coordinates, harvested);
+    expect(summary.licensed.files).to.eq(2);
     const copyright = summary.licensed.copyright;
     expect(copyright.holders.length).to.eq(3);
     expect(copyright.holders).to.include('Bob');
@@ -68,6 +69,7 @@ describe('ScanCode summarizer', () => {
     const summarizer = Summarizer();
     const coordinates = 'npm/npmjs/-/test/1.0';
     const summary = summarizer.summarize(coordinates, harvested);
+    expect(summary.licensed.files).to.eq(2);
     const copyright = summary.licensed.copyright;
     expect(copyright.holders.length).to.eq(0);
     expect(copyright.missing).to.eq(2);
@@ -81,6 +83,7 @@ describe('ScanCode summarizer', () => {
     const summarizer = Summarizer();
     const coordinates = 'npm/npmjs/-/test/1.0';
     const summary = summarizer.summarize(coordinates, harvested);
+    expect(summary.licensed.files).to.eq(0);
     const copyright = summary.licensed.copyright;
     expect(copyright.holders.length).to.eq(0);
     expect(copyright.missing).to.eq(0);


### PR DESCRIPTION
The summary (and curation) schema had too much copyright info
* remove statements and authors
* add `missing` counts for holders and licenses
* add total license related file count
* add a mess of tests