### PR TITLE
reorg to enable invalidate on webhook merge

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,8 @@ const curations = require('./routes/curations')(curationService);
 const definitionStoreProvider = config.definition.store.provider;
 const definitionStore = require(`./providers/stores/${definitionStoreProvider}`)(config.definition.store[definitionStoreProvider]);
 const definitionService = require('./business/definitionService')(harvestStore, summaryService, aggregatorService, curationService, definitionStore);
+// Circular dependency. Reach in and set the curationService's definitionService. Sigh.
+curationService.definitionService = definitionService;
 
 const badges = require('./routes/badges').getRouter(definitionService);
 const definitions = require('./routes/definitions')(harvestStore, curationService, definitionService);

--- a/lib/curation.js
+++ b/lib/curation.js
@@ -6,9 +6,10 @@ const Ajv = require('ajv');
 const ajv = new Ajv();
 ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
 const curationSchema = require('../schemas/curation');
+const EntityCoordinates = require('./entityCoordinates');
 
 class Curation {
-  constructor({content, data = null, path = ''}) {
+  constructor(content, data = null, path = '') {
     this.errors = [];
     this.data = data;
     this.isValid = false;
@@ -39,6 +40,12 @@ class Curation {
       this.errors.push(...ajv.errors.map(error => ({message: 'Invalid curation', error})));
     }
   }
+
+  getCoordinates() {
+    const c = this.data.coordinates;
+    return Object.getOwnPropertyNames(this.data.revisions).map(key =>
+      new EntityCoordinates(c.type, c.provider, c.namespace, c.name, key));
+  }
 }
 
-module.exports = options => new Curation(options);
+module.exports = Curation;

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
     "agent-base": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-      "integrity": "sha1-gPps3kQPTc+a8mF88kYJm12Z8Mg=",
+      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
       "requires": {
         "es6-promisify": "5.0.0"
       }
@@ -88,7 +88,7 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -344,7 +344,7 @@
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
@@ -355,7 +355,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -387,7 +387,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
@@ -413,7 +413,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -436,7 +436,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "concat-map": {
@@ -458,7 +458,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -473,7 +473,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -497,7 +497,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
       "version": "0.3.1",
@@ -575,7 +575,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -583,7 +583,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.5"
@@ -628,7 +628,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU="
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
     },
     "dns-prefetch-control": {
       "version": "0.1.0",
@@ -638,7 +638,7 @@
     "doctrine": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha1-aPls6O/FbMQmUfH6rbTxdSc7AHU=",
+      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -762,7 +762,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -783,7 +783,7 @@
     "espree": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
@@ -793,7 +793,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
       "version": "1.0.0",
@@ -874,7 +874,7 @@
         "qs": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha1-jQSVTTZN7z78VbWgeT4eLIsebkk="
+          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
         },
         "statuses": {
           "version": "1.3.1",
@@ -891,7 +891,7 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -1079,7 +1079,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -1093,7 +1093,7 @@
     "globals": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
-      "integrity": "sha1-YyZERX9fDjrnEYBxg3AOvy5GM+Q=",
+      "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
       "dev": true
     },
     "globby": {
@@ -1118,7 +1118,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "har-schema": {
@@ -1189,7 +1189,7 @@
     "helmet": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.9.0.tgz",
-      "integrity": "sha1-eyzwFaLRCbyoPt55JEIHmcDmfe4=",
+      "integrity": "sha512-czCyS77TyanWlfVSoGlb9GBJV2Q2zJayKxU5uBw0N1TzDTs/qVNh1SL8Q688KU0i0Sb7lQ/oLtnaEqXzl2yWvA==",
       "requires": {
         "dns-prefetch-control": "0.1.0",
         "dont-sniff-mimetype": "1.0.0",
@@ -1208,7 +1208,7 @@
     "helmet-csp": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.6.0.tgz",
-      "integrity": "sha1-wfVZWvvF+D5fHmwV+ELwehD26gQ=",
+      "integrity": "sha512-n/oW9l6RtO4f9YvphsNzdvk1zITrSN7iRT8ojgrJu/N3mVdHl9zE4OjbiHWcR64JK32kbqx90/yshWGXcjUEhw==",
       "requires": {
         "camelize": "1.0.0",
         "content-security-policy-builder": "1.1.0",
@@ -1235,7 +1235,7 @@
     "hsts": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.1.0.tgz",
-      "integrity": "sha1-y9bJGKI4X+4d1WgL+ys6GUwBIcw="
+      "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
     },
     "http-errors": {
       "version": "1.6.2",
@@ -1261,7 +1261,7 @@
     "https-proxy-agent": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
-      "integrity": "sha1-p85DgqG6gmbuhIV4d4Ei1JEmD9k=",
+      "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
       "requires": {
         "agent-base": "4.1.2",
         "debug": "3.1.0"
@@ -1270,7 +1270,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -1280,7 +1280,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ienoopen": {
       "version": "1.0.0",
@@ -1290,7 +1290,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -1317,7 +1317,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
@@ -1385,7 +1385,7 @@
     "is-resolvable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
-      "integrity": "sha1-rMoc022+RLl0uSQyFVWnC6A7HPQ=",
+      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
       "dev": true
     },
     "is-stream": {
@@ -1423,7 +1423,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -1538,7 +1538,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -1601,7 +1601,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -1640,7 +1640,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1649,7 +1649,7 @@
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -1711,6 +1711,12 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "net": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
+      "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g=",
+      "dev": true
+    },
     "nise": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.2.tgz",
@@ -1747,6 +1753,24 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.0.0.tgz",
       "integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA="
+    },
+    "node-mocks-http": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.6.7.tgz",
+      "integrity": "sha512-0a+2ynRfWyU1tN9DQ9Pq29SC9L5QafyXfQ4ae5dA39TYP8K8j74ohKvGKzlQ2vvfbnj17MbXLi35WnmUTl9xmw==",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.4",
+        "depd": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "mime": "1.3.4",
+        "net": "1.0.2",
+        "parseurl": "1.3.2",
+        "range-parser": "1.2.0",
+        "type-is": "1.6.15"
+      }
     },
     "oauth": {
       "version": "0.9.15",
@@ -1927,7 +1951,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -2171,7 +2195,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -2204,7 +2228,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
       "version": "1.3.0",
@@ -2219,7 +2243,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "send": {
       "version": "0.15.6",
@@ -2322,7 +2346,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -2366,7 +2390,7 @@
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -2376,7 +2400,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -2430,7 +2454,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -2480,7 +2504,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -2524,7 +2548,7 @@
     "type-detect": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha1-1w5byB223io4G8rKDG4MvcdjXeI="
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ=="
     },
     "type-is": {
       "version": "1.6.15",
@@ -2583,7 +2607,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validator": {
       "version": "3.35.0",
@@ -2630,7 +2654,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "swagger-ui-express": "^2.0.13",
     "throat": "^4.1.0",
     "tmp": "0.0.33",
-    "underscore": "^1.8.3",
     "vso-node-api": "^6.2.8-preview"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^4.13.1",
-    "mocha": "^4.0.1"
+    "mocha": "^4.0.1",
+    "node-mocks-http": "^1.6.7"
   }
 }

--- a/providers/stores/azblob.js
+++ b/providers/stores/azblob.js
@@ -89,15 +89,17 @@ class AzBlobStore extends AbstractStore {
     });
   }
 
-  // TODO consider not having this. All harvest content should be written by the harvest service (e.g., crawler)
   store(coordinates, stream) {
+    const name = this._toStoragePathFromCoordinates(coordinates) + '.json';
     return new Promise((resolve, reject) => {
-      let name = this._toStoragePathFromCoordinates(coordinates);
-      if (!name.endsWith('.json')) {
-        name += '.json';
-      }
       stream.pipe(this.blobService.createWriteStreamToBlockBlob(this.containerName, name, responseOrError(resolve, reject)));
     });
+  }
+
+  delete(coordinates) {
+    const blobName = this._toStoragePathFromCoordinates(coordinates) + '.json';
+    return new Promise((resolve, reject) =>
+      this.service.deleteBlob(this.name, blobName, responseOrError(resolve, reject)));
   }
 }
 

--- a/providers/stores/file.js
+++ b/providers/stores/file.js
@@ -120,14 +120,21 @@ class FileStore extends AbstractStore {
     });
   }
 
-  // TODO consider not having this. All harvest content should be written by the harvest service (e.g., crawler)
   async store(coordinates, stream) {
     const filePath = this._toStoragePathFromCoordinates(coordinates) + '.json';
     const dirName = path.dirname(filePath);
     await promisify(mkdirp)(dirName);
     return new Promise((resolve, reject) => {
-      stream.pipe(fs.createWriteStream(filePath, resultOrError(resolve, reject)));
+      const file = fs.createWriteStream(filePath)
+        .on('finish', () => resolve())
+        .on('error', error => reject(error));
+      stream.pipe(file);
     });
+  }
+
+  delete(coordinates) {
+    const filePath = this._toStoragePathFromCoordinates(coordinates) + '.json';
+    return promisify(fs.unlink)(filePath);
   }
 }
 

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -18,7 +18,9 @@ router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(getDef
 async function getDefinition(request, response) {
   const coordinates = utils.toEntityCoordinatesFromRequest(request);
   const pr = request.params.pr;
-  const result = await definitionService.get(coordinates, pr);
+  // if running on localhost, allow a force arg for testing without webhooks to invalidate the caches
+  const force = request.hostname.includes('localhost') ? request.query.force || false : false ;
+  const result = await definitionService.get(coordinates, pr, force);
   response.status(200).send(result);
 }
 
@@ -80,7 +82,9 @@ router.post('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(async
 // the components outlined in the POST body
 router.post('/', asyncMiddleware(async (request, response) => {
   const coordinatesList = request.body.map(entry => EntityCoordinates.fromString(entry));
-  const result = await definitionService.getAll(coordinatesList);
+  // if running on localhost, allow a force arg for testing without webhooks to invalidate the caches
+  const force = request.hostname.includes('localhost') ? request.query.force || false : false ;
+  const result = await definitionService.getAll(coordinatesList, force);
   response.status(200).send(result);
 }));
 

--- a/schemas/curation.json
+++ b/schemas/curation.json
@@ -39,7 +39,7 @@
           "$ref": "#/definitions/provider"
         },
         "namespace": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "name": {
           "type": "string"

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const DefinitionService = require('../../business/definitionService');
+const EntityCoordinates = require('../../lib/entityCoordinates');
+
+describe('Definition Service', () => {
+  it('invalidates single coordinate', () => {
+    const store = { delete: sinon.stub() };
+    const service = DefinitionService(null, null, null, null, store);
+    const coordinates = EntityCoordinates.fromString('npm/npmjs/-/test/2.3');
+    service.invalidate(coordinates);
+    expect(store.delete.calledOnce).to.be.true;
+    expect(store.delete.getCall(0).args[0].name).to.be.eq('test');
+    expect(store.delete.getCall(0).args[0].tool).to.be.eq('definition');
+  });
+
+  it('invalidates array of coordinates', () => {
+    const store = { delete: sinon.stub() };
+    const service = DefinitionService(null, null, null, null, store);
+    const coordinates = [
+      EntityCoordinates.fromString('npm/npmjs/-/test0/2.3'),
+      EntityCoordinates.fromString('npm/npmjs/-/test1/2.3')
+    ];
+    service.invalidate(coordinates);
+    expect(store.delete.calledTwice).to.be.true;
+    expect(store.delete.getCall(0).args[0].name).to.be.eq('test0');
+    expect(store.delete.getCall(1).args[0].name).to.be.eq('test1');
+  });
+});

--- a/test/lib/curation.js
+++ b/test/lib/curation.js
@@ -11,49 +11,49 @@ function getFixture(file) {
 describe('Curations', () => {
   it('should identify invalid yaml files', () => {
     const content = '@#$%%';
-    const curation = Curation({content});
+    const curation = new Curation(content);
     expect(curation.isValid).to.be.false;
     expect(curation.errors[0].message).to.equal('Invalid yaml');
   });
 
   it('should identify invalid date', () => {
     const content = getFixture('curation-invalid.yaml');
-    const curation = Curation({content});
+    const curation = new Curation(content);
     expect(curation.isValid).to.be.false;
     expect(curation.errors[0].message).to.equal('Invalid curation');
   });
 
   it('should identify invalid props: unknown copyright', () => {
     const content = getFixture('curation-invalid.1.yaml');
-    const curation = Curation({content});
+    const curation = new Curation(content);
     expect(curation.isValid).to.be.false;
     expect(curation.errors[0].message).to.equal('Invalid curation');
   });
 
   it('should identify invalid props: unknown license', () => {
     const content = getFixture('curation-invalid.2.yaml');
-    const curation = Curation({content});
+    const curation = new Curation(content);
     expect(curation.isValid).to.be.false;
     expect(curation.errors[0].message).to.equal('Invalid curation');
   });
 
   it('should identify invalid props: file count', () => {
     const content = getFixture('curation-invalid.3.yaml');
-    const curation = Curation({content});
+    const curation = new Curation(content);
     expect(curation.isValid).to.be.false;
     expect(curation.errors[0].message).to.equal('Invalid curation');
   });
 
   it('should identify valid curations', () => {
     const content = getFixture('curation-valid.yaml');
-    const curation = Curation({content});
+    const curation = new Curation(content);
     expect(curation.isValid).to.be.true;
     expect(curation.errors.length).to.not.be.ok;
   });
 
   it('should also accept yaml data objects', () => {
     const data = yaml.safeLoad('foo: bar');
-    const curation = Curation({data});
+    const curation = new Curation(null, data);
     expect(curation.isValid).to.be.false;
     expect(curation.errors[0].message).to.equal('Invalid curation');
   });

--- a/test/routes/webhookTests.js
+++ b/test/routes/webhookTests.js
@@ -1,0 +1,122 @@
+// Copyright (c) 2018, The Linux Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai');
+const webhookRoutes = require('../../routes/webhook');
+const httpMocks = require('node-mocks-http');
+const sinon = require('sinon');
+
+describe('Webhook Route', () => {
+  it('handles invalid action', () => {
+    const request = createRequest('yeah, right');
+    const response = httpMocks.createResponse();
+    const logger = { error: sinon.stub() };
+    const service = createCurationService();
+    const router = webhookRoutes(service, logger, 'secret', true);
+    router._handlePost(request, response);
+    expect(response.statusCode).to.be.eq(200);
+    expect(service.handleMerge.calledOnce).to.be.false;
+    expect(service.validateCurations.calledOnce).to.be.false;
+    expect(response._getData()).to.be.eq('');
+  });
+
+  it('handles missing signature', () => {
+    const request = createRequest('yeah, right');
+    delete request.headers['x-hub-signature'];
+    const response = httpMocks.createResponse();
+    const logger = { error: sinon.stub() };
+    const service = createCurationService();
+    const router = webhookRoutes(service, logger, 'secret', true);
+    router._handlePost(request, response);
+    expect(response.statusCode).to.be.eq(400);
+    expect(service.handleMerge.calledOnce).to.be.false;
+    expect(service.validateCurations.calledOnce).to.be.false;
+    expect(response._getData().startsWith('Missing')).to.be.true;
+  });
+
+  it('handles missing event header', () => {
+    const request = createRequest('yeah, right');
+    delete request.headers['x-github-event'];
+    const response = httpMocks.createResponse();
+    const logger = { error: sinon.stub() };
+    const service = createCurationService();
+    const router = webhookRoutes(service, logger, 'secret', true);
+    router._handlePost(request, response);
+    expect(response.statusCode).to.be.eq(400);
+    expect(service.handleMerge.calledOnce).to.be.false;
+    expect(service.validateCurations.calledOnce).to.be.false;
+    expect(response._getData().startsWith('Missing')).to.be.true;
+  });
+
+  it('handles closed event that is merged', () => {
+    const request = createRequest('closed', true);
+    const response = httpMocks.createResponse();   
+    const service = createCurationService();
+    const router = webhookRoutes(service, null, 'secret', true);
+    router._handlePost(request, response);
+    expect(response.statusCode).to.be.eq(200);
+    expect(service.validateCurations.calledOnce).to.be.false;
+    expect(service.handleMerge.calledOnce).to.be.true;
+    expect(service.handleMerge.getCall(0).args[0]).to.be.eq(1);
+    expect(service.handleMerge.getCall(0).args[1]).to.be.eq('changes');
+  });
+
+  it('skips closed event that is not merged', () => {
+    const request = createRequest('closed', false);
+    const response = httpMocks.createResponse();   
+    const service = createCurationService();
+    const router = webhookRoutes(service, null, 'secret', true);
+    router._handlePost(request, response);
+    expect(response.statusCode).to.be.eq(200);
+    expect(service.handleMerge.calledOnce).to.be.false;
+    expect(service.validateCurations.calledOnce).to.be.false;
+  });
+
+  it('calls valid for PR changes', () => {
+    const request = createRequest('opened');
+    const response = httpMocks.createResponse();   
+    const service = createCurationService();
+    const router = webhookRoutes(service, null, 'secret', true);
+    router._handlePost(request, response);
+    expect(response.statusCode).to.be.eq(200);
+    expect(service.handleMerge.calledOnce).to.be.false;
+    expect(service.validateCurations.calledOnce).to.be.true;
+    expect(service.validateCurations.getCall(0).args[0]).to.be.eq(1);
+    expect(service.validateCurations.getCall(0).args[1]).to.be.eq('test pr');
+    expect(service.validateCurations.getCall(0).args[2]).to.be.eq('24');
+    expect(service.validateCurations.getCall(0).args[3]).to.be.eq('changes');
+  });
+});
+
+function createCurationService() {
+  return  {
+    handleMerge: sinon.stub(),
+    validateCurations: sinon.stub(),
+  };
+}
+
+function createRequest(action, merged) {
+  return httpMocks.createRequest({
+    method: 'POST',
+    url: '/',
+    params: {
+      id: 42
+    },
+    headers: {
+      'x-github-event': 'sure is',
+      'x-hub-signature': 'some hash'
+    },
+    body: JSON.stringify({
+      action,
+      pull_request: {
+        number: 1,
+        title: 'test pr',
+        merged,
+        head: {
+          ref: 'changes',
+          sha: '24'
+        }
+      }
+    })
+  });
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,0 @@
-const chai = require('chai');
-
-const expect = chai.expect;
-
-describe('Test', () => {
-  it('Should be true', () => {
-    expect(true).to.be.true;
-  });
-});


### PR DESCRIPTION
When a curation changes we need to invalidate any cached definitions. This change rearchitects some of the webhook and the definition computation code to make it easier.

* webhook is broken into more modular pieces and much of the logic moved to the github curation service
* The definition infrastructure gets _invalidate_ style methods
* Stores get the ability to delete
* several tests added
* add the ability to get definitions and force recomputation for use on localhost where there are no webhooks
* couple of fixes along the way
