### PR TITLE
invalidate definitions on crawler webhook calls

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,7 +44,9 @@ const badges = require('./routes/badges').getRouter(definitionService);
 const definitions = require('./routes/definitions')(harvestStore, curationService, definitionService);
 
 const appLogger = console; // @todo add real logger
-const webhook = require('./routes/webhook')(curationService, appLogger, config.curation.store.github.webhookSecret);
+const githubSecret = config.webhook.githubSecret;
+const crawlerSecret = config.webhook.crawlerSecret;
+const webhook = require('./routes/webhook')(curationService, definitionService, appLogger, githubSecret, crawlerSecret);
 
 const cachingProvider = config.caching.provider;
 const caching = require(`./providers/caching/${cachingProvider}`);

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -65,9 +65,14 @@ class DefinitionService {
    */
   invalidate(coordinates) {
     const coordinateList = Array.isArray(coordinates) ? coordinates : [coordinates];
-    return Promise.all(coordinateList.map(throat(10, coordinates => {
+    return Promise.all(coordinateList.map(throat(10, async coordinates => {
       const definitionCoordinates = this._getDefinitionCoordinates(coordinates);
-      return this.definitionStore.delete(definitionCoordinates);
+      try {
+        return await this.definitionStore.delete(definitionCoordinates);
+      } catch(error) {
+        if (!error.code === 'ENOENT')
+          throw error;
+      }
     })));
   }
   

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,6 @@ module.exports = {
         repo: config.get('CURATION_GITHUB_REPO') || 'curated-data',
         branch: config.get('CURATION_GITHUB_BRANCH') || process.env.NODE_ENV,
         token: config.get('CURATION_GITHUB_TOKEN'),
-        webhookSecret: config.get('CURATION_GITHUB_WEBHOOK_SECRET'),
         tempLocation: config.get('CURATION_TEMP_LOCATION') || (process.platform === 'win32' ? 'c:/temp' : '/tmp'),
         curationFreshness: config.get('CURATION_FRESHNESS') || 600000
       }
@@ -73,5 +72,9 @@ module.exports = {
   endpoints: {
     service: config.get('SERVICE_ENDPOINT') || 'http://localhost:4000',
     website: config.get('WEBSITE_ENDPOINT') || 'http://localhost:3000'
+  },
+  webhook: {
+    githubSecret: config.get('WEBHOOK_GITHUB_SECRET'),
+    crawlerSecret: config.get('CRAWLER_WEBHOOK_SECRET') || 'secret'
   }
 };

--- a/lib/entityCoordinates.js
+++ b/lib/entityCoordinates.js
@@ -29,6 +29,13 @@ class EntityCoordinates {
     return new EntityCoordinates(type, provider, namespace, name, revision);
   }
 
+  static fromUrn(urn) {
+    // eslint-disable-next-line no-unused-vars
+    const [scheme, type, provider, namespaceSpec, name, revToken, revision] = urn.split(':');
+    const namespace = namespaceSpec === '-' ? null : namespaceSpec;
+    return new EntityCoordinates(type, provider, namespace, name, revision);
+  }
+
   constructor(type, provider, namespace, name, revision) {
     this.type = type && type.toLowerCase();
     this.provider = provider && provider.toLowerCase();

--- a/test/providers/github.js
+++ b/test/providers/github.js
@@ -9,7 +9,6 @@ function createService(definitionService = null) {
     repo: 'foobar',
     branch: 'foobar',
     token: 'foobar',
-    webhookSecret: 'foobar',
     tempLocation: '.'
   }, definitionService);
 }

--- a/test/routes/webhookCrawlerTests.js
+++ b/test/routes/webhookCrawlerTests.js
@@ -1,0 +1,67 @@
+// Copyright (c) 2018, The Linux Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai');
+const webhookRoutes = require('../../routes/webhook');
+const httpMocks = require('node-mocks-http');
+const sinon = require('sinon');
+
+describe('Webhook Route for Crawler calls', () => {
+
+  it('handles basic header signature', () => {
+    const request = createRequest('urn:npm:npmjs:-:test:revision:0.1.0');
+    const response = httpMocks.createResponse();
+    const logger = { error: sinon.stub() };
+    const service = createDefinitionService();
+    const router = webhookRoutes(null, service, logger, 'secret', 'secret', true);
+    router._handlePost(request, response);
+    expect(response.statusCode).to.be.eq(200);
+    expect(service.invalidate.calledOnce).to.be.true;
+    expect(service.invalidate.getCall(0).args[0].name).to.be.eq('test');
+  });
+
+  it('handles missing self', () => {
+    const request = createRequest();
+    const response = httpMocks.createResponse(null, null);
+    const logger = { error: sinon.stub() };
+    const service = createDefinitionService();
+    const router = webhookRoutes(null, service, logger, 'secret', 'secret', true);
+    router._handlePost(request, response);
+    expect(response.statusCode).to.be.eq(400);
+    expect(service.invalidate.calledOnce).to.be.false;
+    expect(logger.error.calledOnce).to.be.true;
+  });
+
+  it('handles incorrect token', () => {
+    const request = createRequest('urn:npm:npmjs:-:test:revision:0.1.0');
+    const response = httpMocks.createResponse();
+    const logger = { error: sinon.stub() };
+    const service = createDefinitionService();
+    const router = webhookRoutes(null, service, logger, 'secret', 'different', true);
+    router._handlePost(request, response);
+    expect(response.statusCode).to.be.eq(400);
+    expect(service.invalidate.calledOnce).to.be.false;
+    expect(logger.error.calledOnce).to.be.true;
+  });
+});
+
+function createDefinitionService() {
+  return  {
+    invalidate: sinon.stub()
+  };
+}
+
+function createRequest(urn, links) {
+  return httpMocks.createRequest({
+    method: 'POST',
+    url: '/',
+    headers: {
+      'x-crawler': 'secret'
+    },
+    body: JSON.stringify({
+      _metadata: {
+        links: links || { self: { href: urn } }
+      }      
+    })
+  });
+}

--- a/test/routes/webhookGitHubTests.js
+++ b/test/routes/webhookGitHubTests.js
@@ -6,13 +6,13 @@ const webhookRoutes = require('../../routes/webhook');
 const httpMocks = require('node-mocks-http');
 const sinon = require('sinon');
 
-describe('Webhook Route', () => {
+describe('Webhook Route for GitHub calls', () => {
   it('handles invalid action', () => {
     const request = createRequest('yeah, right');
     const response = httpMocks.createResponse();
     const logger = { error: sinon.stub() };
     const service = createCurationService();
-    const router = webhookRoutes(service, logger, 'secret', true);
+    const router = webhookRoutes(service, null, logger, 'secret', 'secret', true);
     router._handlePost(request, response);
     expect(response.statusCode).to.be.eq(200);
     expect(service.handleMerge.calledOnce).to.be.false;
@@ -26,7 +26,7 @@ describe('Webhook Route', () => {
     const response = httpMocks.createResponse();
     const logger = { error: sinon.stub() };
     const service = createCurationService();
-    const router = webhookRoutes(service, logger, 'secret', true);
+    const router = webhookRoutes(service, null, logger, 'secret', 'secret', true);
     router._handlePost(request, response);
     expect(response.statusCode).to.be.eq(400);
     expect(service.handleMerge.calledOnce).to.be.false;
@@ -40,7 +40,7 @@ describe('Webhook Route', () => {
     const response = httpMocks.createResponse();
     const logger = { error: sinon.stub() };
     const service = createCurationService();
-    const router = webhookRoutes(service, logger, 'secret', true);
+    const router = webhookRoutes(service, null, logger, 'secret', 'secret', true);
     router._handlePost(request, response);
     expect(response.statusCode).to.be.eq(400);
     expect(service.handleMerge.calledOnce).to.be.false;
@@ -52,7 +52,7 @@ describe('Webhook Route', () => {
     const request = createRequest('closed', true);
     const response = httpMocks.createResponse();   
     const service = createCurationService();
-    const router = webhookRoutes(service, null, 'secret', true);
+    const router = webhookRoutes(service, null, null, 'secret', 'secret', true);
     router._handlePost(request, response);
     expect(response.statusCode).to.be.eq(200);
     expect(service.validateCurations.calledOnce).to.be.false;
@@ -65,7 +65,7 @@ describe('Webhook Route', () => {
     const request = createRequest('closed', false);
     const response = httpMocks.createResponse();   
     const service = createCurationService();
-    const router = webhookRoutes(service, null, 'secret', true);
+    const router = webhookRoutes(service, null, null, 'secret', 'secret', true);
     router._handlePost(request, response);
     expect(response.statusCode).to.be.eq(200);
     expect(service.handleMerge.calledOnce).to.be.false;
@@ -76,7 +76,7 @@ describe('Webhook Route', () => {
     const request = createRequest('opened');
     const response = httpMocks.createResponse();   
     const service = createCurationService();
-    const router = webhookRoutes(service, null, 'secret', true);
+    const router = webhookRoutes(service, null, null, 'secret', 'secret', true);
     router._handlePost(request, response);
     expect(response.statusCode).to.be.eq(200);
     expect(service.handleMerge.calledOnce).to.be.false;


### PR DESCRIPTION
When a crawler output changes the crawler will fire a webhook. Hook into that and invalidate the definition for the corresponding entity. This should be best effort and not cause any processing to fail.