### PR TITLE
Rate-limit authenticated routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const express = require('express');
 const logger = require('morgan');
 const bodyParser = require('body-parser');
 const cors = require('cors');
+const RateLimit = require('express-rate-limit');
 const helmet = require('helmet');
 const serializeError = require('serialize-error');
 const requestId = require('request-id/express');
@@ -71,6 +72,14 @@ if (config.auth.github.clientId) {
 }
 app.use('/auth', auth());
 app.use(githubMiddleware);
+
+// rate-limit the remaining routes
+app.set('trust-proxy', true);
+app.use(new RateLimit({
+  windowMs: config.limits.windowSeconds * 1000,
+  max: config.limits.max,
+  delayAfter: 0
+}));
 
 app.use('/', index);
 app.use('/origins/github', require('./routes/originGitHub')());

--- a/lib/config.js
+++ b/lib/config.js
@@ -73,6 +73,10 @@ module.exports = {
     service: config.get('SERVICE_ENDPOINT') || 'http://localhost:4000',
     website: config.get('WEBSITE_ENDPOINT') || 'http://localhost:3000'
   },
+  limits: {
+    windowSeconds: config.get('RATE_LIMIT_WINDOW') || 1,
+    max: config.get('RATE_LIMIT_MAX') || 0
+  },
   webhook: {
     githubSecret: config.get('WEBHOOK_GITHUB_SECRET'),
     crawlerSecret: config.get('CRAWLER_WEBHOOK_SECRET') || 'secret'

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
     "agent-base": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
+      "integrity": "sha1-gPps3kQPTc+a8mF88kYJm12Z8Mg=",
       "requires": {
         "es6-promisify": "5.0.0"
       }
@@ -405,6 +405,11 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clone": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -595,6 +600,14 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "1.0.3"
+      }
+    },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -762,7 +775,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -881,6 +894,14 @@
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
           "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
         }
+      }
+    },
+    "express-rate-limit": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-2.11.0.tgz",
+      "integrity": "sha512-KMZayDxj3Wr7zYuwTuDZj5hMW0nhnyJVBVCwMEVKwMdW6CkYh4vnfnUbRJYhKC0v6UuIbPerwKY0dqWmEzFjKA==",
+      "requires": {
+        "defaults": "1.0.3"
       }
     },
     "extend": {
@@ -1640,7 +1661,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1649,7 +1670,7 @@
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "crypto": "^1.0.1",
     "debug": "~2.6.9",
     "express": "~4.15.5",
+    "express-rate-limit": "^2.11.0",
     "extend": "^3.0.1",
     "github": "^13.1.0",
     "helmet": "^3.9.0",


### PR DESCRIPTION
Disabled by default, to enable set:

* `RATE_LIMIT_WINDOW` to the number of seconds you want to monitor a given IP for
* `RATE_LIMIT_MAX` to the maximum number of requests from an IP during the window

Note the `'trust-proxy'` setting -- I added this with the assumption that CloudFlare is fronting the request. If this isn't set, rate limits will be too aggressive as it'll think that CloudFlare's internal IP is the requester IP. This is derived from `X-Forwarded-For`; see https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-