### PR TITLE
Allow localhost to access dev-api

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const logger = require('morgan');
 const bodyParser = require('body-parser');
+const cookieParser = require('cookie-parser');
 const cors = require('cors');
 const RateLimit = require('express-rate-limit');
 const helmet = require('helmet');
@@ -56,6 +57,7 @@ const cachingMiddleware = require('./middleware/caching');
 const app = express();
 app.use(cors());
 app.options('*', cors());
+app.use(cookieParser());
 app.use(helmet());
 app.use(requestId());
 app.use(cachingMiddleware(caching()));

--- a/package-lock.json
+++ b/package-lock.json
@@ -509,6 +509,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
+    "cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "azure-storage": "^2.7.0",
     "base-64": "^0.1.0",
     "body-parser": "~1.18.2",
+    "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",
     "crypto": "^1.0.1",
     "debug": "~2.6.9",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -4,6 +4,7 @@
 const express = require('express');
 const passport = require('passport');
 const GitHubStrategy = require('passport-github').Strategy;
+const { URL } = require('url');
 
 const config = require('../lib/config');
 
@@ -24,17 +25,46 @@ function passportOrPat() {
   };
 }
 
-router.get('/github', passportOrPat(), (req, res) => {
+router.get('/github', (req, res) => {
+  // a shim to allow for a localhost UI to point to dev-api.
+  // without this, /github/finalize won't be able to postMessage due to
+  // cross-origin constraints. we're checking if the referrer (UI) is on
+  // localhost, and if so, store the full origin (incl. port) in a cookie
+  // to be read during /github/finalize.
+  const referrer = req.get('Referrer');
+  if (referrer) {
+    try {
+      const url = new URL(referrer);
+
+      if (url.hostname === 'localhost') {
+        res.cookie('localhostOrigin', url.origin);
+      }
+    } catch (err) {
+      console.warn('Referrer parsing error, ignoring', err);
+    }
+  }
+
+  res.redirect('github/start');
+});
+
+router.get('/github/start', passportOrPat(), (req, res) => {
   // this only runs if passport didn't kick in above, but double
   // check for sanity in case upstream changes
   if (!config.auth.github.clientId) {
-    res.redirect('github/finalize');
+    res.redirect('finalize');
   }
 });
 
 router.get('/github/finalize', passportOrPat(),
   (req, res) => {
     const safeToken = encodeURIComponent(req.user.githubAccessToken);
+    let origin = config.endpoints.website;
+
+    // allow for sending auth responses to localhost on dev site; see /github
+    // route above. real origin is stored in cookie.
+    if (config.endpoints.service.includes('dev-api') && req.cookies.localhostOrigin) {
+      origin = req.cookies.localhostOrigin;
+    }
 
     // passing in the 'website' endpoint below is very important;
     // using '*' instead means this page will gladly send out a
@@ -44,7 +74,7 @@ router.get('/github/finalize', passportOrPat(),
       window.opener.postMessage({
         type: 'github-token',
         token: '${safeToken}',
-      }, '${config.endpoints.website}');
+      }, '${origin}');
       window.close();
     </script>`);
   }


### PR DESCRIPTION
This is accomplished by checking if the referrer is localhost, and then
setting a cookie with the real localhost origin. This cookie is read on
finalize and substituted for the real UI in postMessage.