### PR TITLE
Remove "All Rights Reserved."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: MIT
 
 # FROM node:8-alpine

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 const express = require('express');
 const logger = require('morgan');

--- a/bin/www
+++ b/bin/www
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 /**

--- a/business/aggregator.js
+++ b/business/aggregator.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 // Responsible for taking multiple summarized responses and aggregating them into a single response

--- a/business/badgeCalculator.js
+++ b/business/badgeCalculator.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Linux Foundation. All rights reserved.
+// Copyright (c) 2018, The Linux Foundation.
 // SPDX-License-Identifier: MIT
 
 // Responsible for calculating what badge a component/definition has.

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const Readable = require('stream').Readable;

--- a/business/summarizer.js
+++ b/business/summarizer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const summarizers = require('../providers/summary');

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 const config = require('painless-config');
 

--- a/lib/curation.js
+++ b/lib/curation.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, The Linux Foundation. All rights reserved.
+// Copyright (c) 2017, The Linux Foundation.
 // SPDX-License-Identifier: MIT
 
 const yaml = require('js-yaml');

--- a/lib/entityCoordinates.js
+++ b/lib/entityCoordinates.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const NAMESPACE = 0x4;

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const GitHubApi = require('github');

--- a/lib/resultCoordinates.js
+++ b/lib/resultCoordinates.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const EntityCoordinates = require('./entityCoordinates');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const semver = require('semver');

--- a/middleware/asyncMiddleware.js
+++ b/middleware/asyncMiddleware.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 module.exports = func =>

--- a/middleware/config.js
+++ b/middleware/config.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 const config = require('../lib/config');
 

--- a/middleware/github.js
+++ b/middleware/github.js
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates.
 // SPDX-License-Identifier: MIT
 
 const crypto = require('crypto');

--- a/middleware/permissions.js
+++ b/middleware/permissions.js
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates.
 // SPDX-License-Identifier: MIT
 
 /**

--- a/providers/caching/memory.js
+++ b/providers/caching/memory.js
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates.
 // SPDX-License-Identifier: MIT
 
 const Cache = require('memory-cache').Cache;

--- a/providers/caching/redis.js
+++ b/providers/caching/redis.js
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates.
 // SPDX-License-Identifier: MIT
 
 const redis = require('redis');

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const _ = require('lodash');

--- a/providers/harvest/crawler.js
+++ b/providers/harvest/crawler.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const requestPromise = require('request-promise-native');

--- a/providers/stores/abstractStore.js
+++ b/providers/stores/abstractStore.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const throat = require('throat');

--- a/providers/stores/azblob.js
+++ b/providers/stores/azblob.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const azure = require('azure-storage');

--- a/providers/stores/file.js
+++ b/providers/stores/file.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const utils = require('../../lib/utils');

--- a/providers/summary/cdsource.js
+++ b/providers/summary/cdsource.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 class CdSourceSummarizer {

--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const _ = require('lodash');

--- a/providers/summary/index.js
+++ b/providers/summary/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 module.exports = {

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const { get, remove, set } = require('lodash');

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates.
 // SPDX-License-Identifier: MIT
 
 const express = require('express');

--- a/routes/badges.js
+++ b/routes/badges.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Linux Foundation. All rights reserved.
+// Copyright (c) 2018, The Linux Foundation.
 // SPDX-License-Identifier: MIT
 
 const asyncMiddleware = require('../middleware/asyncMiddleware');

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const asyncMiddleware = require('../middleware/asyncMiddleware');

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const asyncMiddleware = require('../middleware/asyncMiddleware');

--- a/routes/harvest.js
+++ b/routes/harvest.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const asyncMiddleware = require('../middleware/asyncMiddleware');

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 const express = require('express');
 const router = express.Router();

--- a/routes/originGitHub.js
+++ b/routes/originGitHub.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const asyncMiddleware = require('../middleware/asyncMiddleware');

--- a/routes/originMaven.js
+++ b/routes/originMaven.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const asyncMiddleware = require('../middleware/asyncMiddleware');

--- a/routes/originNpm.js
+++ b/routes/originNpm.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const asyncMiddleware = require('../middleware/asyncMiddleware');

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, The Linux Foundation. All rights reserved.
+// Copyright (c) 2017, The Linux Foundation.
 // SPDX-License-Identifier: MIT
 
 const express = require('express');

--- a/test/business/badgeCalculator.js
+++ b/test/business/badgeCalculator.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Linux Foundation. All rights reserved.
+// Copyright (c) 2018, The Linux Foundation.
 // SPDX-License-Identifier: MIT
 
 const {expect} = require('chai');

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const { expect } = require('chai');

--- a/test/providers/store/file.js
+++ b/test/providers/store/file.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const sinon = require('sinon');

--- a/test/providers/store/fileScan.js
+++ b/test/providers/store/fileScan.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 // These tests are in a separate file (from file.js) to allow for proxying `recursive-readdir`

--- a/test/routes/badges.js
+++ b/test/routes/badges.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Linux Foundation. All rights reserved.
+// Copyright (c) 2018, The Linux Foundation.
 // SPDX-License-Identifier: MIT
 
 const { expect } = require('chai');

--- a/test/routes/webhookCrawlerTests.js
+++ b/test/routes/webhookCrawlerTests.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Linux Foundation. All rights reserved.
+// Copyright (c) 2018, The Linux Foundation.
 // SPDX-License-Identifier: MIT
 
 const { expect } = require('chai');

--- a/test/routes/webhookGitHubTests.js
+++ b/test/routes/webhookGitHubTests.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, The Linux Foundation. All rights reserved.
+// Copyright (c) 2018, The Linux Foundation.
 // SPDX-License-Identifier: MIT
 
 const { expect } = require('chai');

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const { expect } = require('chai');

--- a/test/summary/summarizer.js
+++ b/test/summary/summarizer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const { expect } = require('chai');


### PR DESCRIPTION
After discussion at the TODO hackathon, it was agreed to remove
"All Rights Reserved" statements from copyright notices in order
to reduce potential confusion.