### PR TITLE
Improve versions comparison in getLatestVersion

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,7 +35,10 @@ function getLatestVersion(versions) {
   if (versions.length === 1) return versions[0]
   return versions
     .filter(v => semver.prerelease(v) === null)
-    .reduce((max, current) => (semver.gt(current, max) ? current : max), versions[0])
+    .reduce(
+      (max, current) => (semver.gt(semver.coerce(current).version, semver.coerce(max).version) ? current : max),
+      versions[0]
+    )
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -667,7 +667,7 @@
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
       "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "diagnostic-channel-publishers": {
@@ -790,7 +790,7 @@
         "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
@@ -2299,9 +2299,9 @@
       "integrity": "sha1-c1/6o5oc/4/7lZjwIjq9sDqfsuo="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "send": {
       "version": "0.15.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "redis": "^2.8.0",
     "request-id": "^0.11.1",
     "request-promise-native": "^1.0.5",
-    "semver": "^5.4.1",
+    "semver": "^5.5.0",
     "serialize-error": "^2.1.0",
     "sinon": "^4.2.2",
     "swagger-ui-express": "^2.0.13",


### PR DESCRIPTION
This change is necessary as a preparation for supporting scancode 2.9.0b1. See issue https://github.com/clearlydefined/crawler/issues/81.