### PR TITLE
Path name issues

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,14 @@
       "request": "launch",
       "name": "Mocha Tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "args": ["-u", "tdd", "--timeout", "999999", "--colors", "${workspaceFolder}/test/**/*.js"],
+      "args": [
+        "-u",
+        "tdd",
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/test/**/*.js"
+      ],
       "internalConsoleOptions": "openOnSessionStart"
     },
     {

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -153,7 +153,6 @@ class DefinitionService {
       list.map(
         throat(10, async coordinates => {
           const definition = await this.get(coordinates, null, recompute)
-          // if we are recomputing then the index will automatically be updated so no need to store again
           if (recompute) return Promise.resolve(null)
           return this.search.store(definition)
         })

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -93,7 +93,7 @@ class DefinitionService {
             await this.definitionStore.delete(definitionCoordinates)
             return this.search.delete(definitionCoordinates)
           } catch (error) {
-            if (!error.code === 'ENOENT') throw error
+            if (error.code !== 'ENOENT') throw error
           }
         })
       )
@@ -155,7 +155,7 @@ class DefinitionService {
           const definition = await this.get(coordinates, null, recompute)
           // if we are recomputing then the index will automatically be updated so no need to store again
           if (recompute) return Promise.resolve(null)
-          return this.search.store(entries)
+          return this.search.store(definition)
         })
       )
     )

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -149,7 +149,7 @@ class DefinitionService {
     const recompute = mode === 'definitions'
     const baseList = coordinatesList || (await this.list(new EntityCoordinates(), recompute))
     const list = baseList.map(entry => EntityCoordinates.fromString(entry))
-    await Promise.all(
+    return await Promise.all(
       list.map(
         throat(10, async coordinates => {
           const definition = await this.get(coordinates, null, recompute)
@@ -159,8 +159,6 @@ class DefinitionService {
         })
       )
     )
-    // don't forget to store anything left over
-    return this.search.store(indexes)
   }
 
   /**

--- a/providers/stores/file.js
+++ b/providers/stores/file.js
@@ -19,7 +19,7 @@ class FileStore extends AbstractStore {
 
   async list(coordinates, type = 'entity') {
     try {
-      const paths = await recursive(this._toStoragePathFromCoordinates(coordinates))
+      const paths = await recursive(this._toStoragePathFromCoordinates(coordinates), ['.DS_Store'])
       const list = new Set()
       paths.forEach(entry => {
         const value = this._getEntry(entry, type)
@@ -103,7 +103,7 @@ class FileStore extends AbstractStore {
     // b) fit in one list call (i.e., <5000)
     let files = null
     try {
-      files = await recursive(root)
+      files = await recursive(root, ['.DS_Store'])
     } catch (error) {
       if (error.code === 'ENOENT') return []
       throw error

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -5,6 +5,7 @@ const asyncMiddleware = require('../middleware/asyncMiddleware')
 const express = require('express')
 const router = express.Router()
 const utils = require('../lib/utils')
+const Github = require('../lib/github')
 
 // Get a proposed patch for a specific revision of a component
 router.get(
@@ -44,8 +45,23 @@ router.patch(
   '/:type/:provider/:namespace/:name/:revision',
   asyncMiddleware(async (request, response) => {
     const coordinates = utils.toEntityCoordinatesFromRequest(request)
+    const token = request.app.locals.config.curation.store.github.token
+    const serviceGithub = Github.getClient({ token })
+    const userGithub = request.app.locals.user.github.client
     return curationService
-      .addOrUpdate(request.app.locals.user.github.client, coordinates, request.body)
+      .addOrUpdate(userGithub, serviceGithub, coordinates, request.body)
+      .then(() => response.sendStatus(200))
+  })
+)
+
+router.patch(
+  '',
+  asyncMiddleware(async (request, response) => {
+    const token = request.app.locals.config.curation.store.github.token
+    const serviceGithub = Github.getClient({ token })
+    const userGithub = request.app.locals.user.github.client
+    return curationService
+      .addOrUpdate(userGithub, serviceGithub, request.body)
       .then(() => response.sendStatus(200))
   })
 )

--- a/routes/swagger.yaml
+++ b/routes/swagger.yaml
@@ -218,20 +218,25 @@ paths:
             application/json:
               schema:
                 $ref: '#components/bodies/definitionList'
-
-  /definitions/{type}/{provider}/{namespace}/{name}:
     get:
-      summary: Gets components that have definitions (i.e,. have been harveted and/or curated).
+      summary: Gets the coordinates for all definitions that match the given pattern in the specified part of the definition.
       tags:
         - definitions
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
+        - in: query
+          name: pattern
+          schema:
+            type: string
+          required: true
+          description: The string to search for in definition coordinates
+        - in: query
+          name: type
+          schema:
+            type: string
+          description: The part of the definition to search for the given pattern. Valid values are 'coordinates' (default) and 'copyrights'.
       responses:
         200:
-          description: List of definitions that have definitions.
+      description: List of definitions that have definitions.
   /definitions/{type}/{provider}/{namespace}/{name}/{revision}:
     get:
       summary: Gets the definition for a component revision.


### PR DESCRIPTION
Fixed the path name issues for 'git ls-files -s' command. Couldn't perform git operations from outside the repo file so a cd command is executed after the repo is cloned.
Fixed the .yaml file pathnames by removing extra '/' before the '.yaml'.