### PR TITLE
update the definition schema to include per file info

### DIFF
--- a/schemas/curation.json
+++ b/schemas/curation.json
@@ -21,6 +21,7 @@
       "enum": ["npmjs", "github", "mavencentral", "mavencentralsource"]
     },
     "coordinates": {
+      "type": "object",
       "required": ["type", "provider", "namespace", "name"],
       "additionalProperties": false,
       "properties": {
@@ -56,6 +57,31 @@
         },
         "licensed": {
           "$ref": "#/definitions/licensed"
+        }
+      }
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path"],
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The absolute path of the file as found in the component."
+          },
+          "license": {
+            "type": "string",
+            "description": "The SPDX license expression, if any, as found in the file."
+          },
+          "attributions": {
+            "type": "array",
+            "description": "The list of attributions (e.g., copyright statements) discovered in the file.",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -127,76 +153,16 @@
       }
     },
     "licensed": {
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "declared": {
           "$ref": "#/definitions/declared"
-        },
-        "facets": {
-          "$ref": "#/definitions/facets"
-        }
-      }
-    },
-    "facets": {
-      "additionalProperties": false,
-      "properties": {
-        "core": {
-          "$ref": "#/definitions/facet"
-        },
-        "data": {
-          "$ref": "#/definitions/facet"
-        },
-        "dev": {
-          "$ref": "#/definitions/facet"
-        },
-        "doc": {
-          "$ref": "#/definitions/facet"
-        },
-        "examples": {
-          "$ref": "#/definitions/facet"
-        },
-        "tests": {
-          "$ref": "#/definitions/facet"
-        }
-      }
-    },
-    "facet": {
-      "additionalProperties": false,
-      "properties": {
-        "attribution": {
-          "$ref": "#/definitions/attribution"
-        },
-        "discovered": {
-          "$ref": "#/definitions/discovered"
-        }
-      }
-    },
-    "attribution": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "parties": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         }
       }
     },
     "declared": {
       "type": "string"
-    },
-    "discovered": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "expressions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
     }
   }
 }

--- a/schemas/definition.json
+++ b/schemas/definition.json
@@ -9,10 +9,13 @@
     "coordinates": {
       "$ref": "#/definitions/coordinates"
     },
+    "files": {
+      "$ref": "#/definitions/files"
+    },
     "described": {
       "$ref": "#/definitions/described"
     },
-    "licenesed": {
+    "licensed": {
       "$ref": "#/definitions/licensed"
     }
   },
@@ -24,6 +27,7 @@
       "enum": ["npmjs", "github", "mavencentral", "mavencentralsource"]
     },
     "coordinates": {
+      "type": "object",
       "required": ["type", "provider", "namespace", "name", "revision"],
       "additionalProperties": false,
       "properties": {
@@ -44,11 +48,49 @@
         }
       }
     },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path"],
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The absolute path of the file as found in the component."
+          },
+          "license": {
+            "type": "string",
+            "description": "The SPDX license expression, if any, as found in the file."
+          },
+          "attributions": {
+            "type": "array",
+            "description": "The list of attributions (e.g., copyright statements) discovered in the file.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "facets": {
+            "type": "array",
+            "description": "The facets in which this file exists.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "content": {
+            "type": "string",
+            "description":
+              "An opaque token representing the content of this file. This value can be presented to the system's API to get the content if stored by the system"
+          }
+        }
+      }
+    },
     "described": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "facets": {
+          "type": "object",
           "additionalProperties": false,
           "properties": {
             "data": {
@@ -119,6 +161,7 @@
       }
     },
     "licensed": {
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "declared": {
@@ -130,6 +173,7 @@
       }
     },
     "facets": {
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "core": {
@@ -153,6 +197,7 @@
       }
     },
     "facet": {
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "files": {


### PR DESCRIPTION
PROPOSAL: DO NOT MERGE

In an effort to support more usecases, this PR updates the schema for definitions and curations to be based on a data for a list of files rather than aggregates of that data. So rather than having a list of facets each of which as aggregated list of license and copyrights for their files, the data is now expressed on individual files. That per-file data can then be aggregated into per-facet data.

Also allow for curation of the data on a per file basis.

Note that as a consequence of this approach, we are now able to have ClearlyDefined retain the actual content of specific files (e.g., LICENSE) for use in notice file generation and the like.

Once the schema changes are agreed to, the summarization code will be updated and likely added to this PR.