### PR TITLE
round out scancode definition sumarization

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,10 @@ const definitionStore = require(`./providers/stores/${definitionStoreProvider}`)
 )
 const searchProvider = config.search.provider
 const search = require(`./providers/search/${searchProvider}`)(config.search[searchProvider])
-initializers.push(() => search.initialize())
+initializers.push(() => {
+  search.initialize()
+  if (searchProvider === 'memory') definitionService.reload('definitions')
+})
 
 const definitionService = require('./business/definitionService')(
   harvestStore,

--- a/lib/curation.js
+++ b/lib/curation.js
@@ -4,7 +4,6 @@
 const yaml = require('js-yaml')
 const Ajv = require('ajv')
 const ajv = new Ajv()
-ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
 const curationSchema = require('../schemas/curation')
 const EntityCoordinates = require('./entityCoordinates')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,13 +70,26 @@
       }
     },
     "ajv": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.0.1.tgz",
-      "integrity": "sha1-KJhYCp8971+chd/q16IiPvE889o=",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
+      "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
       "requires": {
-        "fast-deep-equal": "1.0.0",
+        "fast-deep-equal": "2.0.1",
         "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
       }
     },
     "ajv-keywords": {
@@ -623,6 +636,24 @@
         "type-detect": "4.0.5"
       }
     },
+    "deep-equal-in-any-order": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-1.0.10.tgz",
+      "integrity": "sha512-hzh3IwlIKwT885r5b/b4bXCXxzR7S9N+Dreuoommdykcnvlg0A+pS81wMU4ZsFz98CH4KBI8eWbAfDHWl7akTg==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10",
+        "sort-any": "1.1.12"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -683,7 +714,8 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
     },
     "dns-prefetch-control": {
       "version": "0.1.0",
@@ -987,7 +1019,8 @@
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -1080,6 +1113,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
       "requires": {
         "samsam": "1.3.0"
       }
@@ -1238,7 +1272,8 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "hash-base": {
       "version": "3.0.4",
@@ -1531,7 +1566,8 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -1583,7 +1619,8 @@
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -1603,7 +1640,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.reduce": {
       "version": "4.6.0",
@@ -1613,7 +1651,8 @@
     "lolex": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -1801,6 +1840,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.2.tgz",
       "integrity": "sha512-rvxf+PSZeCKtP0DgmwMmNf1G3I6X1r4WHiP2H88PlIkOkt7mGqufdokjS8caoHBgZzVx0ee/5ytGcGHbZaUw8w==",
+      "dev": true,
       "requires": {
         "formatio": "1.2.0",
         "just-extend": "1.1.27",
@@ -1812,17 +1852,20 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         },
         "lolex": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
         },
         "path-to-regexp": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
           "requires": {
             "isarray": "0.0.1"
           }
@@ -2313,7 +2356,8 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
     },
     "sax": {
       "version": "0.5.2",
@@ -2403,6 +2447,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.2.2.tgz",
       "integrity": "sha512-BEa593xl+IkIc94nKo0O0LauQC/gQy8Gyv4DkzPwF/9DweC5phr1y+42zibCpn9abfkdHxt9r8AhD0R6u9DE/Q==",
+      "dev": true,
       "requires": {
         "diff": "3.3.1",
         "formatio": "1.2.0",
@@ -2417,6 +2462,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
           "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -2438,6 +2484,15 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
         "hoek": "2.16.3"
+      }
+    },
+    "sort-any": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-1.1.12.tgz",
+      "integrity": "sha512-RaVPeOjzn5tjhAfvQstA34gPiG/HT+1MefSsG0KHIMhXjLlZREYSIkxlYaCRvdwLKNgpsgM6nvpLEY1Y0Ja9FQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.5"
       }
     },
     "sprintf-js": {
@@ -2562,7 +2617,8 @@
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
@@ -2628,7 +2684,8 @@
     "type-detect": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ=="
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.15",
@@ -2668,6 +2725,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
     },
     "url-template": {
       "version": "2.0.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^14.0.0",
-    "ajv": "^6.0.1",
+    "ajv": "^6.5.1",
     "applicationinsights": "^1.0.2",
     "azure-storage": "^2.7.0",
     "base-64": "^0.1.0",
@@ -47,7 +47,6 @@
     "request-promise-native": "^1.0.5",
     "semver": "^5.4.1",
     "serialize-error": "^2.1.0",
-    "sinon": "^4.2.2",
     "swagger-ui-express": "^2.0.13",
     "throat": "^4.1.0",
     "tmp": "0.0.33",
@@ -55,8 +54,10 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
+    "deep-equal-in-any-order": "^1.0.10",
     "eslint": "^4.13.1",
     "mocha": "^4.0.1",
-    "node-mocks-http": "^1.6.7"
+    "node-mocks-http": "^1.6.7",
+    "sinon": "^4.2.2"
   }
 }

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const { get, remove, set, last } = require('lodash')
+const { get, remove, set, last, pullAllWith, isEqual } = require('lodash')
 const minimatch = require('minimatch')
 
 class ScanCodeSummarizer {
@@ -15,7 +15,7 @@ class ScanCodeSummarizer {
    * data, if any.
    * @param {EntitySpec} coordinates - The entity for which we are summarizing
    * @param {*} harvested - the set of raw tool ouptuts related to the idenified entity
-   * @param {Facets} foo - an object detailing the facets to group by.
+   * @param {Facets} facets - an object detailing the facets to group by.
    * @returns {Definition} - a summary of the given raw information
    */
   summarize(coordinates, harvested, facets = {}) {
@@ -27,14 +27,13 @@ class ScanCodeSummarizer {
       return {}
     const result = {}
     this.addDescribedInfo(result, coordinates, harvested)
-    const declaredLicenses = this._summarizeDeclaredLicenseInfo(harvested.content.files)
-    const packageLicenses = this._summarizePackageInfo(harvested.content.files)
-    set(result, 'licensed.declared', this._toExpression(declaredLicenses || packageLicenses))
+    const declaredLicense =
+      this._summarizeDeclaredLicenseInfo(harvested.content.files) || this._summarizePackageInfo(harvested.content.files)
+    this._setIfValue(result, 'licensed.declared', declaredLicense)
     result.files = this._summarizeFileInfo(harvested.content.files)
-    const buckets = this.computeFileBuckets(harvested.content.files, facets)
-    for (const key in buckets) {
-      set(result, `licensed.facets.${key}`, this._summarizeDiscoveredLicenseInfo(buckets[key]))
-    }
+    const buckets = this.computeFileBuckets([...result.files], facets)
+    for (const facet in buckets)
+      this._setIfValue(result, `licensed.facets.${facet}`, this._summarizeFacetInfo(facet, buckets[facet]))
     return result
   }
 
@@ -42,14 +41,14 @@ class ScanCodeSummarizer {
     const facetList = Object.getOwnPropertyNames(facets)
     remove(facetList, 'core')
     if (facetList.length === 0) return { core: files }
-    const result = {}
+    const result = { core: [...files] }
     for (const facet in facetList) {
       const facetKey = facetList[facet]
       const filters = facets[facetKey]
       if (!filters || filters.length === 0) break
-      result[facetKey] = remove(files, file => filters.some(filter => minimatch(file.path, filter)))
+      result[facetKey] = files.filter(file => filters.some(filter => minimatch(file.path, filter)))
+      pullAllWith(result.core, result[facetKey], isEqual)
     }
-    result.core = files
     return result
   }
 
@@ -58,79 +57,88 @@ class ScanCodeSummarizer {
     if (releaseDate) result.described = { releaseDate: releaseDate.trim() }
   }
 
-  _summarizeDiscoveredLicenseInfo(files) {
-    const copyrightHolders = new Set()
+  _summarizeFacetInfo(facet, facetFiles) {
+    if (!facetFiles || facetFiles.length === 0) return null
+    const attributions = new Set()
     const licenseExpressions = new Set()
     let unknownParties = 0
     let unknownLicenses = 0
-    for (let file of files) {
-      this._addArrayToSet(file.licenses, licenseExpressions, license => license.spdx_license_key)
-      const asserted = get(file, 'packages[0].asserted_licenses')
-      if (!asserted) {
-        if (!file.licenses || file.licenses.length === 0) unknownLicenses++
-        const hasHolders = this._normalizeCopyrights(file.copyrights, copyrightHolders)
-        !hasHolders && unknownParties++
-      }
+    for (let file of facetFiles) {
+      file.license ? licenseExpressions.add(file.license) : unknownLicenses++
+      file.attributions ? this._addArrayToSet(file.attributions, attributions) : unknownParties++
+      // tag the file with the current facet
+      file.facets = file.facets || []
+      file.facets.push(facet)
     }
-    return {
+    const result = {
       attribution: {
-        parties: this._setToArray(copyrightHolders),
         unknown: unknownParties
       },
       discovered: {
-        expressions: this._setToArray(licenseExpressions),
         unknown: unknownLicenses
       },
-      files: files.length
+      files: facetFiles.length
     }
+    this._setIfValue(result, 'attribution.parties', this._setToArray(attributions))
+    this._setIfValue(result, 'discovered.expressions', this._setToArray(licenseExpressions))
+    return result
+  }
+
+  _setIfValue(target, path, value) {
+    if (!value) return
+    set(target, path, value)
   }
 
   _summarizeDeclaredLicenseInfo(files) {
-    const declaredLicenses = new Set()
-    for (const fileIdx in files) {
-      const file = files[fileIdx]
+    for (let file of files) {
       const pathArray = file.path.split('/')
       const baseName = last(pathArray)
       const isLicense = ['license', 'license.txt', 'license.md', 'license.html'].includes(baseName.toLowerCase())
       if (isLicense && file.licenses) {
-        // Find first license file and return
-        file.licenses.forEach(license => declaredLicenses.add(license.spdx_license_key))
-        return declaredLicenses
+        // Find the first license file and treat it as the authority
+        const declaredLicenses = this._addArrayToSet(file.licenses, new Set(), license => license.spdx_license_key)
+        return this._toExpression(declaredLicenses)
       }
     }
-    // Did not find license file so returning empty set (no declared license)
-    return declaredLicenses
+    return null
   }
 
   _summarizePackageInfo(files) {
-    const packageLicenses = new Set()
-    for (const fileIdx in files) {
-      const file = files[fileIdx]
+    for (let file of files) {
       const asserted = get(file, 'packages[0].asserted_licenses')
+      // Find the first package file and treat it as the authority
       if (asserted) {
-        // File first package file and return
-        this._addArrayToSet(asserted, packageLicenses, license => license.license || license.spdx_license_key)
-        return packageLicenses
+        const packageLicenses = this._addArrayToSet(
+          asserted,
+          new Set(),
+          license => license.license || license.spdx_license_key
+        )
+        return this._toExpression(packageLicenses)
       }
     }
-    // Did not find package file
-    return packageLicenses
+    return null
   }
 
   _summarizeFileInfo(files) {
-    const fileArray = []
-    for (const fileIdx in files) {
-      const file = files[fileIdx]
-      const licenses = new Set()
-      this._addArrayToSet(file.licenses, licenses, license => license.license || license.spdx_license_key)
+    return files.map(file => {
+      const asserted = get(file, 'packages[0].asserted_licenses')
+      const fileLicense = asserted || file.licenses
+      const licenses = this._addArrayToSet(
+        fileLicense,
+        new Set(),
+        license => license.license || license.spdx_license_key
+      )
       const licenseExpression = this._toExpression(licenses)
-      const fileObject = { path: file.path, license: licenseExpression, attributions: file.copyrights }
-      fileArray.push(fileObject)
-    }
-    return fileArray
+      const attributions = this._collectAttributions(file.copyrights)
+      const result = { path: file.path }
+      this._setIfValue(result, 'license', licenseExpression)
+      this._setIfValue(result, 'attributions', attributions)
+      return result
+    })
   }
 
   _toExpression(licenses) {
+    if (!licenses) return null
     const list = this._setToArray(licenses)
     return list ? list.join(' and ') : null
   }
@@ -142,23 +150,17 @@ class ScanCodeSummarizer {
     return result.length === 0 ? null : result
   }
 
-  _normalizeCopyrights(copyrights, holders) {
-    if (!copyrights || !copyrights.length) return false
-    let hasHolders = false
-    for (let copyright of copyrights) {
-      this._addArrayToSet(copyright.holders, holders)
-      hasHolders = hasHolders || copyright.holders.length
-    }
-    return hasHolders
+  _collectAttributions(copyrights, holders) {
+    if (!copyrights || !copyrights.length) return null
+    return this._setToArray(copyrights.reduce((result, entry) => this._addArrayToSet(entry.holders, result), new Set()))
   }
 
   _addArrayToSet(array, set, valueExtractor) {
-    if (!array || !array.length) return
+    if (!array || !array.length) return set
 
     valueExtractor = valueExtractor || (value => value)
-    for (let entry of array) {
-      set.add(valueExtractor(entry))
-    }
+    for (let entry of array) set.add(valueExtractor(entry))
+    return set
   }
 }
 

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -66,9 +66,11 @@ class ScanCodeSummarizer {
     for (let file of facetFiles) {
       file.license ? licenseExpressions.add(file.license) : unknownLicenses++
       file.attributions ? this._addArrayToSet(file.attributions, attributions) : unknownParties++
-      // tag the file with the current facet
-      file.facets = file.facets || []
-      file.facets.push(facet)
+      if (facet !== 'core') {
+        // tag the file with the current facet if not core
+        file.facets = file.facets || []
+        file.facets.push(facet)
+      }
     }
     const result = {
       attribution: {

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const { get, remove, set, last, pullAllWith, isEqual } = require('lodash')
+const { get, remove, set, first, pullAllWith, isEqual } = require('lodash')
 const minimatch = require('minimatch')
 
 class ScanCodeSummarizer {
@@ -92,7 +92,7 @@ class ScanCodeSummarizer {
   _summarizeDeclaredLicenseInfo(files) {
     for (let file of files) {
       const pathArray = file.path.split('/')
-      const baseName = last(pathArray)
+      const baseName = first(pathArray)
       const isLicense = ['license', 'license.txt', 'license.md', 'license.html'].includes(baseName.toLowerCase())
       if (isLicense && file.licenses) {
         // Find the first license file and treat it as the authority

--- a/schemas/curation.json
+++ b/schemas/curation.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://api.clearlydefined.io/schemas/curation.json#",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "curation",
   "required": ["coordinates", "revisions"],
   "type": "object",

--- a/schemas/definition.json
+++ b/schemas/definition.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://api.clearlydefined.io/schemas/definition.json#",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "definition",
   "required": ["coordinates"],
   "type": "object",
@@ -28,7 +28,7 @@
     },
     "coordinates": {
       "type": "object",
-      "required": ["type", "provider", "namespace", "name", "revision"],
+      "required": ["type", "provider", "name", "revision"],
       "additionalProperties": false,
       "properties": {
         "type": {
@@ -72,7 +72,8 @@
           },
           "facets": {
             "type": "array",
-            "description": "The facets in which this file exists.",
+            "description":
+              "The facets in which this file exists, if any. Note that the absence of facets implies the 'core' facet.",
             "items": {
               "type": "string"
             }

--- a/schemas/harvest.json
+++ b/schemas/harvest.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://api.clearlydefined.io/schemas/harvest.json#",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "harvest",
   "type": "object",
   "definitions": {
@@ -11,10 +11,7 @@
       "type": "string"
     },
     "request": {
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "additionalProperties": false,
       "properties": {
         "type": {
@@ -114,9 +111,7 @@
     },
     "link": {
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false,
       "properties": {
         "type": {

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -22,8 +22,8 @@ describe('ScanCode summarizer', () => {
 
   it('gets all the attribution parties', () => {
     const harvested = buildOutput([
-      buildFile('/foo.txt', 'MIT', [['Bob', 'Fred']]),
-      buildFile('/bar.txt', 'MIT', [['Jane', 'Fred']])
+      buildFile('foo.txt', 'MIT', [['Bob', 'Fred']]),
+      buildFile('bar.txt', 'MIT', [['Jane', 'Fred']])
     ])
     const summarizer = Summarizer()
     const coordinates = 'npm/npmjs/-/test/1.0'
@@ -37,7 +37,7 @@ describe('ScanCode summarizer', () => {
   })
 
   it('gets all the discovered licenses', () => {
-    const harvested = buildOutput([buildFile('/foo.txt', 'MIT', []), buildFile('/bar.txt', 'GPL', [])])
+    const harvested = buildOutput([buildFile('foo.txt', 'MIT', []), buildFile('bar.txt', 'GPL', [])])
     const summarizer = Summarizer()
     const coordinates = 'npm/npmjs/-/test/1.0'
     const summary = summarizer.summarize(coordinates, harvested)
@@ -48,7 +48,7 @@ describe('ScanCode summarizer', () => {
   })
 
   it('records unknown licenses and parties', () => {
-    const harvested = buildOutput([buildFile('/foo.txt', null, [['bob']]), buildFile('/bar.txt', 'GPL', [])])
+    const harvested = buildOutput([buildFile('foo.txt', null, [['bob']]), buildFile('bar.txt', 'GPL', [])])
     const summarizer = Summarizer()
     const coordinates = 'npm/npmjs/-/test/1.0'
     const summary = summarizer.summarize(coordinates, harvested)
@@ -61,7 +61,7 @@ describe('ScanCode summarizer', () => {
   })
 
   it('handles files with no data', () => {
-    const harvested = buildOutput([buildFile('/foo.txt', null, null), buildFile('/bar.txt', null, null)])
+    const harvested = buildOutput([buildFile('foo.txt', null, null), buildFile('bar.txt', null, null)])
     const summarizer = Summarizer()
     const coordinates = 'npm/npmjs/-/test/1.0'
     const summary = summarizer.summarize(coordinates, harvested)
@@ -114,8 +114,22 @@ describe('ScanCode summarizer', () => {
     expect(core.discovered.unknown).to.eq(0)
   })
 
-  it('handles scan with asserted license file', () => {
-    const harvested = buildOutput([buildPackageFile('package.json', 'MIT', [])])
+  it('skips license files in subdirectories', () => {
+    const harvested = buildOutput([buildFile('/foo/LICENSE.md', 'MIT', []), buildFile('LICENSE.foo', 'GPL', [])])
+    const summarizer = Summarizer()
+    const coordinates = 'npm/npmjs/-/test/1.0'
+    const summary = summarizer.summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.files.length).to.eq(2)
+    expect(summary.licensed.declared).to.be.undefined
+    const core = summary.licensed.facets.core
+    expect(core.files).to.eq(2)
+    expect(core.discovered.expressions).to.deep.equalInAnyOrder(['MIT', 'GPL'])
+    expect(core.discovered.unknown).to.eq(0)
+  })
+
+  it('handles scan with asserted license file even in a subdirectory', () => {
+    const harvested = buildOutput([buildPackageFile('package/package.json', 'MIT', [])])
     const summarizer = Summarizer()
     const coordinates = 'npm/npmjs/-/test/1.0'
     const summary = summarizer.summarize(coordinates, harvested)

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -107,6 +107,8 @@ describe('ScanCode summarizer', () => {
     const summary = summarizer.summarize(coordinates, harvested)
     validate(summary)
     expect(summary.files.length).to.eq(2)
+    expect(summary.files[0].facets).to.be.undefined
+    expect(summary.files[1].facets).to.be.undefined
     expect(summary.licensed.declared).to.eq('MIT')
     const core = summary.licensed.facets.core
     expect(core.files).to.eq(2)


### PR DESCRIPTION
update the definition schema and enhance scancode summarization as follows

* ensure props are set only if they have values
* associate all facets with each applicable file
* support license files only in the root
* update and enhance the tests 