### PR TITLE
Use copyright statements when getting attributions

### DIFF
--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -153,9 +153,9 @@ class ScanCodeSummarizer {
     return result.length === 0 ? null : result
   }
 
-  _collectAttributions(copyrights, holders) {
+  _collectAttributions(copyrights) {
     if (!copyrights || !copyrights.length) return null
-    return this._setToArray(copyrights.reduce((result, entry) => this._addArrayToSet(entry.holders, result), new Set()))
+    return this._setToArray(copyrights.reduce((result, entry) => this._addArrayToSet(entry.statements, result), new Set()))
   }
 
   _addArrayToSet(array, set, valueExtractor) {

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -32,7 +32,11 @@ describe('ScanCode summarizer', () => {
     const core = summary.licensed.facets.core
     expect(core.files).to.eq(2)
     expect(core.attribution.parties.length).to.eq(3)
-    expect(core.attribution.parties).to.deep.equalInAnyOrder(['Bob', 'Jane', 'Fred'])
+    expect(core.attribution.parties).to.deep.equalInAnyOrder([
+      'Copyright Bob',
+      'Copyright Jane',
+      'Copyright Fred'
+    ])
     expect(core.attribution.unknown).to.eq(0)
   })
 
@@ -54,7 +58,7 @@ describe('ScanCode summarizer', () => {
     const summary = summarizer.summarize(coordinates, harvested)
     validate(summary)
     const core = summary.licensed.facets.core
-    expect(core.attribution.parties).to.deep.eq(['bob'])
+    expect(core.attribution.parties).to.deep.eq(['Copyright bob'])
     expect(core.attribution.unknown).to.eq(1)
     expect(core.discovered.expressions).to.deep.eq(['GPL'])
     expect(core.discovered.unknown).to.eq(1)
@@ -271,9 +275,10 @@ function buildOutput(files) {
 
 function buildFile(path, license, holders) {
   const wrapHolders = holders =>
-    holders.map(entry => {
-      return { holders: entry }
-    })
+    holders.map(entry => ({
+      holders: entry,
+      statements: entry.map(holder => `Copyright ${holder}`)
+    }))
   return {
     path,
     licenses: license ? [{ spdx_license_key: license }] : null,


### PR DESCRIPTION
Rather than using the copyright holders as the attributions value, this
change uses the copyright statements in order to better support
scenarios like NOTICE file generation.

#161