### PR TITLE
Handle special characters in copyright attribution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1298,8 +1298,7 @@
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
     "helmet": {
       "version": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "express-rate-limit": "^2.11.0",
     "extend": "^3.0.1",
     "github": "^13.1.0",
+    "he": "^1.1.1",
     "helmet": "^3.9.0",
     "js-yaml": "^3.10.0",
     "lodash": "4.17.5",

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
+const he = require('he')
 const { get, remove, set, first, pullAllWith, isEqual } = require('lodash')
 const minimatch = require('minimatch')
 const { extractDate } = require('../../lib/utils')
@@ -155,7 +156,16 @@ class ScanCodeSummarizer {
 
   _collectAttributions(copyrights) {
     if (!copyrights || !copyrights.length) return null
-    return this._setToArray(copyrights.reduce((result, entry) => this._addArrayToSet(entry.statements, result), new Set()))
+    const set = new Set()
+    for (let copyright of copyrights) {
+      if (!copyright.statements) continue
+      const statements = copyright.statements.map(statement => he.decode(statement)
+        .replace(/(\\[nr]|[\n\r])/g, ' ')
+        .replace(/ +/g, ' ')
+        .trim())
+      this._addArrayToSet(statements, set)
+    }
+    return this._setToArray(set)
   }
 
   _addArrayToSet(array, set, valueExtractor) {

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -40,6 +40,33 @@ describe('ScanCode summarizer', () => {
     expect(core.attribution.unknown).to.eq(0)
   })
 
+  it('handle special characters', () => {
+    const harvested = buildOutput([
+      buildFile('foo.txt', 'MIT', [[
+        '&#60;Bob&gt;',
+        'Bob\\n',
+        'Bob\\r',
+        'Bob\r',
+        'Bob\n',
+        'Bob\n',
+        'Bob ',
+        'Bob  Bobberson'
+      ]])
+    ])
+    const summarizer = Summarizer()
+    const coordinates = 'npm/npmjs/-/test/1.0'
+    const summary = summarizer.summarize(coordinates, harvested)
+    validate(summary)
+    const core = summary.licensed.facets.core
+    expect(core.files).to.eq(1)
+    expect(core.attribution.parties.length).to.eq(3)
+    expect(core.attribution.parties).to.deep.equalInAnyOrder([
+      'Copyright <Bob>',
+      'Copyright Bob',
+      'Copyright Bob Bobberson'
+    ])
+  })
+
   it('gets all the discovered licenses', () => {
     const harvested = buildOutput([buildFile('foo.txt', 'MIT', []), buildFile('bar.txt', 'GPL', [])])
     const summarizer = Summarizer()


### PR DESCRIPTION
This change handles html entities and literal instances of `\n` that
appear in the copyright attribution by replacing them with more
appropriate strings.

Issue: #162 
Dependency: #166