### PR TITLE
npm license type fix

### DIFF
--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -65,9 +65,15 @@ class ClearlyDescribedSummarizer {
     result.described.projectWebsite = data.registryData.manifest.homepage
     result.described.issueTracker = data.registryData.manifest.bugs
     result.described.releaseDate = extractDate(data.registryData.releaseDate)
-    result.licensed = {
-      declared: data.registryData.manifest.license
-    }
+    const license = data.registryData.manifest.license
+    if (license && typeof license != 'string')
+      result.licensed = {
+        declared: license.type
+      }
+    else
+      result.licensed = {
+        declared: license
+      }
   }
 
   addGemData(result, data) {

--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -66,14 +66,7 @@ class ClearlyDescribedSummarizer {
     result.described.issueTracker = data.registryData.manifest.bugs
     result.described.releaseDate = extractDate(data.registryData.releaseDate)
     const license = data.registryData.manifest.license
-    if (license && typeof license != 'string')
-      result.licensed = {
-        declared: license.type
-      }
-    else
-      result.licensed = {
-        declared: license
-      }
+    if (license) result.licensed = { declared: typeof license === 'string' ? license : license.type }
   }
 
   addGemData(result, data) {


### PR DESCRIPTION
Addressing issue #178. Based on https://docs.npmjs.com/files/package.json#license there can be a license object where the spdx license is stored in the type field.