### PR TITLE
refactor facet computation

### DIFF
--- a/business/aggregator.js
+++ b/business/aggregator.js
@@ -44,7 +44,7 @@ class AggregationService {
     const order = this.workingPrecedence
     const tools = []
     order.forEach(tool => {
-      const data = this.findData(tool, summarized)
+      const data = this._findData(tool, summarized)
       if (data) {
         tools.push(data.toolSpec)
         extend(true, result, data.summary)
@@ -56,7 +56,7 @@ class AggregationService {
   }
 
   // search the summarized data for an entry that best matches the given tool spec
-  findData(toolSpec, summarized) {
+  _findData(toolSpec, summarized) {
     const [tool, toolVersion] = toolSpec.split('/')
     if (!summarized[tool]) return null
     if (toolVersion) return { toolSpec, summary: summarized[tool][toolVersion] }

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -3,8 +3,9 @@
 
 const Readable = require('stream').Readable
 const throat = require('throat')
-const { get, union } = require('lodash')
+const { get, union, remove } = require('lodash')
 const EntityCoordinates = require('../lib/entityCoordinates')
+const { setIfValue, setToArray, addArrayToSet } = require('../lib/utils')
 
 class DefinitionService {
   constructor(harvest, summary, aggregator, curation, store, search) {
@@ -123,10 +124,10 @@ class DefinitionService {
   async compute(coordinates, curationSpec) {
     const curation = await this.curationService.get(coordinates, curationSpec)
     const raw = await this.harvestService.getAll(coordinates)
-    const facets = await this._computeFacets(coordinates, raw, curation)
-    const summarized = await this.summaryService.summarizeAll(coordinates, raw, facets || {})
+    const summarized = await this.summaryService.summarizeAll(coordinates, raw)
     const aggregated = await this.aggregationService.process(coordinates, summarized)
     const definition = await this.curationService.apply(coordinates, curation, aggregated)
+    this._ensureFacets(coordinates, definition)
     this._ensureCurationInfo(definition, curation)
     this._ensureSourceLocation(coordinates, definition)
     this._ensureCoordinates(coordinates, definition)
@@ -176,22 +177,60 @@ class DefinitionService {
     )
   }
 
-  /**
-   * Compute facets related to an entity and a curation of that entity. This is essentially a light
-   * weight pre-compute so we know what groupings to use in the real summarization.
-   *
-   * @param {EntitySpec} coordinates - The entity for which we are looking for a curation
-   * @param {*} raw - the set of raw tool ouptuts related to the idenified entity
-   * @param {Definition)} [curation] - an actual curation object to apply.
-   * @returns {Facets} The `facets` portion of the component's described definition
-   */
-  async _computeFacets(coordinates, raw, curation) {
-    // TODO we might be able to a more effecient computation here since all we need are the facets
-    // for example, some tool outputs just will never have facets to there is no point in summarizing them.
-    const summarized = await this.summaryService.summarizeFacets(coordinates, raw)
-    const aggregated = await this.aggregationService.process(coordinates, summarized)
-    const definition = await this.curationService.apply(coordinates, curation, aggregated)
-    return get(definition, 'described.facets')
+  // ensure all the right facet information has been computed and added to the given definition
+  _ensureFacets(coordinates, definition) {
+    if (!definition.files) return
+    const facetFiles = this._computeFacetFiles([...definition.files], definition.described.facets)
+    for (const facet in facetFiles)
+      setIfValue(definition, `licensed.facets.${facet}`, this._summarizeFacetInfo(facet, facetFiles[facet]))
+  }
+
+  // figure out which files are in which facets
+  _computeFacetFiles(files, facets = {}) {
+    const facetList = Object.getOwnPropertyNames(facets)
+    remove(facetList, 'core')
+    if (facetList.length === 0) return { core: files }
+    const result = { core: [...files] }
+    for (const facet in facetList) {
+      const facetKey = facetList[facet]
+      const filters = facets[facetKey]
+      if (!filters || filters.length === 0) break
+      result[facetKey] = files.filter(file => filters.some(filter => minimatch(file.path, filter)))
+      pullAllWith(result.core, result[facetKey], isEqual)
+    }
+    return result
+  }
+
+  // create the data object for the identified facet containing the given files. Also destructively brand
+  // the individual file objects with the facet
+  _summarizeFacetInfo(facet, facetFiles) {
+    if (!facetFiles || facetFiles.length === 0) return null
+    const attributions = new Set()
+    const licenseExpressions = new Set()
+    let unknownParties = 0
+    let unknownLicenses = 0
+    // accummulate all the licenses and attributions, and count anything that's missing
+    for (let file of facetFiles) {
+      file.license ? licenseExpressions.add(file.license) : unknownLicenses++
+      file.attributions ? addArrayToSet(file.attributions, attributions) : unknownParties++
+      if (facet !== 'core') {
+        // tag the file with the current facet if not core
+        file.facets = file.facets || []
+        file.facets.push(facet)
+      }
+    }
+    const result = {
+      attribution: {
+        unknown: unknownParties
+      },
+      discovered: {
+        unknown: unknownLicenses
+      },
+      files: facetFiles.length
+    }
+    setIfValue(result, 'attribution.parties', setToArray(attributions))
+    setIfValue(result, 'discovered.expressions', setToArray(licenseExpressions))
+    return result
   }
 
   _ensureCoordinates(coordinates, definition) {

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -129,10 +129,10 @@ class DefinitionService {
     const summarized = await this.summaryService.summarizeAll(coordinates, raw)
     const aggregated = await this.aggregationService.process(coordinates, summarized)
     const definition = await this.curationService.apply(coordinates, curation, aggregated)
-    this._ensureFacets(coordinates, definition)
+    this._ensureFacets(definition)
     this._ensureCurationInfo(definition, curation)
     this._ensureSourceLocation(coordinates, definition)
-    this._ensureCoordinates(definition)
+    this._ensureCoordinates(coordinates, definition)
     definition.score = this.computeScore(definition)
     return definition
   }

--- a/business/summarizer.js
+++ b/business/summarizer.js
@@ -10,38 +10,30 @@ class SummaryService {
 
   /**
    * Summarize the data for each of the supplied data points for different versions of an
-   * identified tool. Use the given filter function to determine if a particular file
-   * mentioned in the data should play a role in summarization.
+   * identified tool.
    *
    * @param {EntityCoordinates} coordinates the component being summarized
    * @param {string} tool the name of the tool whose output is being summarized
    * @param {*} data the data to summarize
-   * @param {function} filter filter function identifying analyzed files to NOT include in the summary
    */
-  _summarizeTool(coordinates, tool, data, filter = null) {
+  _summarizeTool(coordinates, tool, data) {
     if (!summarizers[tool]) return data
     const summarizer = summarizers[tool](this.options[tool] || {})
     return Object.getOwnPropertyNames(data).reduce((result, version) => {
-      result[version] = summarizer.summarize(coordinates, data[version], filter)
+      result[version] = summarizer.summarize(coordinates, data[version])
       return result
     }, {})
   }
 
-  summarizeFacets(coordinates, data) {
-    return this.summarizeAll(coordinates, data, null)
-  }
-
   /**
-   * Summarize all of the data for the identified component using the given filter function
-   * to determine if a particular file mentioned in the data should play a role in summarization.
+   * Summarize all of the data for the identified component.
    *
    * @param {} coordinates the component being summarized
    * @param {*} data the data to summarize
-   * @param {function} filter filter function identifying analyzed files to NOT include in the summary
    */
-  summarizeAll(coordinates, data, filter = {}) {
+  summarizeAll(coordinates, data) {
     const summary = Object.getOwnPropertyNames(data).reduce((result, tool) => {
-      result[tool] = this._summarizeTool(coordinates, tool, data[tool], filter)
+      result[tool] = this._summarizeTool(coordinates, tool, data[tool])
       return result
     }, {})
     summary.coordinates = coordinates

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,7 @@ const semver = require('semver')
 const EntityCoordinates = require('./entityCoordinates')
 const ResultCoordinates = require('./resultCoordinates')
 const moment = require('moment')
+const { set } = require('lodash')
 
 function toResultCoordinatesFromRequest(request) {
   return new ResultCoordinates(
@@ -44,9 +45,31 @@ function extractDate(dateAndTime) {
   return moment(dateAndTime).format('YYYY-MM-DD')
 }
 
+function setIfValue(target, path, value) {
+  if (!value) return
+  set(target, path, value)
+}
+
+function setToArray(values) {
+  const result = Array.from(values)
+    .filter(e => e)
+    .sort()
+  return result.length === 0 ? null : result
+}
+
+function addArrayToSet(array, set, valueExtractor) {
+  if (!array || !array.length) return set
+  valueExtractor = valueExtractor || (value => value)
+  for (let entry of array) set.add(valueExtractor(entry))
+  return set
+}
+
 module.exports = {
   toEntityCoordinatesFromRequest,
   toResultCoordinatesFromRequest,
   getLatestVersion,
-  extractDate
+  extractDate,
+  setIfValue,
+  setToArray,
+  addArrayToSet
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,6 +47,7 @@ function extractDate(dateAndTime) {
 
 function setIfValue(target, path, value) {
   if (!value) return
+  if (Array.isArray(value) && value.length === 0) return
   set(target, path, value)
 }
 

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const he = require('he')
 const { get, first } = require('lodash')
-const minimatch = require('minimatch')
 const { extractDate, setIfValue, addArrayToSet, setToArray } = require('../../lib/utils')
 
 class ScanCodeSummarizer {
@@ -70,10 +68,9 @@ class ScanCodeSummarizer {
       const fileLicense = asserted || file.licenses
       const licenses = addArrayToSet(fileLicense, new Set(), license => license.license || license.spdx_license_key)
       const licenseExpression = this._toExpression(licenses)
-      const attributions = this._collectAttributions(file.copyrights)
       const result = { path: file.path }
       setIfValue(result, 'license', licenseExpression)
-      setIfValue(result, 'attributions', attributions)
+      setIfValue(result, 'attributions', get(file, 'copyrights.statements'))
       return result
     })
   }
@@ -82,23 +79,6 @@ class ScanCodeSummarizer {
     if (!licenses) return null
     const list = setToArray(licenses)
     return list ? list.join(' and ') : null
-  }
-
-  _collectAttributions(copyrights) {
-    if (!copyrights || !copyrights.length) return null
-    const set = new Set()
-    for (let copyright of copyrights) {
-      if (!copyright.statements) continue
-      const statements = copyright.statements.map(statement =>
-        he
-          .decode(statement)
-          .replace(/(\\[nr]|[\n\r])/g, ' ')
-          .replace(/ +/g, ' ')
-          .trim()
-      )
-      addArrayToSet(statements, set)
-    }
-    return setToArray(set)
   }
 }
 

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 const he = require('he')
-const { get, remove, set, first, pullAllWith, isEqual } = require('lodash')
+const { get, first } = require('lodash')
 const minimatch = require('minimatch')
-const { extractDate } = require('../../lib/utils')
+const { extractDate, setIfValue, addArrayToSet, setToArray } = require('../../lib/utils')
 
 class ScanCodeSummarizer {
   constructor(options) {
@@ -12,85 +12,26 @@ class ScanCodeSummarizer {
   }
 
   /**
-   * Summarize the raw information related to the given coordinates using the supplied facet info to
-   * bucketize results. If `facets` is falsy, only return the extracted `facets` portion of the raw
-   * data, if any.
+   * Summarize the raw information related to the given coordinates.
    * @param {EntitySpec} coordinates - The entity for which we are summarizing
    * @param {*} harvested - the set of raw tool ouptuts related to the idenified entity
-   * @param {Facets} facets - an object detailing the facets to group by.
    * @returns {Definition} - a summary of the given raw information
    */
-  summarize(coordinates, harvested, facets = {}) {
+  summarize(coordinates, harvested) {
     if (!harvested || !harvested.content || !harvested.content.scancode_version)
       throw new Error('Not valid ScanCode data')
-
-    if (!facets)
-      // ScanCode output never has facet info in it
-      return {}
     const result = {}
     this.addDescribedInfo(result, coordinates, harvested)
     const declaredLicense =
       this._summarizeDeclaredLicenseInfo(harvested.content.files) || this._summarizePackageInfo(harvested.content.files)
-    this._setIfValue(result, 'licensed.declared', declaredLicense)
+    setIfValue(result, 'licensed.declared', declaredLicense)
     result.files = this._summarizeFileInfo(harvested.content.files)
-    const buckets = this.computeFileBuckets([...result.files], facets)
-    for (const facet in buckets)
-      this._setIfValue(result, `licensed.facets.${facet}`, this._summarizeFacetInfo(facet, buckets[facet]))
-    return result
-  }
-
-  computeFileBuckets(files, facets) {
-    const facetList = Object.getOwnPropertyNames(facets)
-    remove(facetList, 'core')
-    if (facetList.length === 0) return { core: files }
-    const result = { core: [...files] }
-    for (const facet in facetList) {
-      const facetKey = facetList[facet]
-      const filters = facets[facetKey]
-      if (!filters || filters.length === 0) break
-      result[facetKey] = files.filter(file => filters.some(filter => minimatch(file.path, filter)))
-      pullAllWith(result.core, result[facetKey], isEqual)
-    }
     return result
   }
 
   addDescribedInfo(result, coordinates, harvested) {
     const releaseDate = harvested._metadata.releaseDate
     if (releaseDate) result.described = { releaseDate: extractDate(releaseDate.trim()) }
-  }
-
-  _summarizeFacetInfo(facet, facetFiles) {
-    if (!facetFiles || facetFiles.length === 0) return null
-    const attributions = new Set()
-    const licenseExpressions = new Set()
-    let unknownParties = 0
-    let unknownLicenses = 0
-    for (let file of facetFiles) {
-      file.license ? licenseExpressions.add(file.license) : unknownLicenses++
-      file.attributions ? this._addArrayToSet(file.attributions, attributions) : unknownParties++
-      if (facet !== 'core') {
-        // tag the file with the current facet if not core
-        file.facets = file.facets || []
-        file.facets.push(facet)
-      }
-    }
-    const result = {
-      attribution: {
-        unknown: unknownParties
-      },
-      discovered: {
-        unknown: unknownLicenses
-      },
-      files: facetFiles.length
-    }
-    this._setIfValue(result, 'attribution.parties', this._setToArray(attributions))
-    this._setIfValue(result, 'discovered.expressions', this._setToArray(licenseExpressions))
-    return result
-  }
-
-  _setIfValue(target, path, value) {
-    if (!value) return
-    set(target, path, value)
   }
 
   _summarizeDeclaredLicenseInfo(files) {
@@ -100,7 +41,7 @@ class ScanCodeSummarizer {
       const isLicense = ['license', 'license.txt', 'license.md', 'license.html'].includes(baseName.toLowerCase())
       if (isLicense && file.licenses) {
         // Find the first license file and treat it as the authority
-        const declaredLicenses = this._addArrayToSet(file.licenses, new Set(), license => license.spdx_license_key)
+        const declaredLicenses = addArrayToSet(file.licenses, new Set(), license => license.spdx_license_key)
         return this._toExpression(declaredLicenses)
       }
     }
@@ -112,7 +53,7 @@ class ScanCodeSummarizer {
       const asserted = get(file, 'packages[0].asserted_licenses')
       // Find the first package file and treat it as the authority
       if (asserted) {
-        const packageLicenses = this._addArrayToSet(
+        const packageLicenses = addArrayToSet(
           asserted,
           new Set(),
           license => license.license || license.spdx_license_key
@@ -127,31 +68,20 @@ class ScanCodeSummarizer {
     return files.map(file => {
       const asserted = get(file, 'packages[0].asserted_licenses')
       const fileLicense = asserted || file.licenses
-      const licenses = this._addArrayToSet(
-        fileLicense,
-        new Set(),
-        license => license.license || license.spdx_license_key
-      )
+      const licenses = addArrayToSet(fileLicense, new Set(), license => license.license || license.spdx_license_key)
       const licenseExpression = this._toExpression(licenses)
       const attributions = this._collectAttributions(file.copyrights)
       const result = { path: file.path }
-      this._setIfValue(result, 'license', licenseExpression)
-      this._setIfValue(result, 'attributions', attributions)
+      setIfValue(result, 'license', licenseExpression)
+      setIfValue(result, 'attributions', attributions)
       return result
     })
   }
 
   _toExpression(licenses) {
     if (!licenses) return null
-    const list = this._setToArray(licenses)
+    const list = setToArray(licenses)
     return list ? list.join(' and ') : null
-  }
-
-  _setToArray(licenses) {
-    const result = Array.from(licenses)
-      .filter(e => e)
-      .sort()
-    return result.length === 0 ? null : result
   }
 
   _collectAttributions(copyrights) {
@@ -159,21 +89,16 @@ class ScanCodeSummarizer {
     const set = new Set()
     for (let copyright of copyrights) {
       if (!copyright.statements) continue
-      const statements = copyright.statements.map(statement => he.decode(statement)
-        .replace(/(\\[nr]|[\n\r])/g, ' ')
-        .replace(/ +/g, ' ')
-        .trim())
-      this._addArrayToSet(statements, set)
+      const statements = copyright.statements.map(statement =>
+        he
+          .decode(statement)
+          .replace(/(\\[nr]|[\n\r])/g, ' ')
+          .replace(/ +/g, ' ')
+          .trim()
+      )
+      addArrayToSet(statements, set)
     }
-    return this._setToArray(set)
-  }
-
-  _addArrayToSet(array, set, valueExtractor) {
-    if (!array || !array.length) return set
-
-    valueExtractor = valueExtractor || (value => value)
-    for (let entry of array) set.add(valueExtractor(entry))
-    return set
+    return setToArray(set)
   }
 }
 

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -44,7 +44,7 @@ describe('Definition Service', () => {
 })
 
 describe('Definition Service Facet management', () => {
-  it('handle special characters', () => {
+  it('handle special characters', async () => {
     const files = [
       buildFile('foo.txt', 'MIT', [
         '&#60;Bob&gt;',
@@ -57,9 +57,8 @@ describe('Definition Service Facet management', () => {
         'Bob  Bobberson'
       ])
     ]
-    const definition = createDefinition(undefined, files)
-    const service = DefinitionService()
-    service._ensureFacets(definition)
+    const service = createService(createDefinition(undefined, files))
+    const definition = await service.compute('npm/npmjs/-/test/1.0')
     validate(definition)
     const core = definition.licensed.facets.core
     expect(core.files).to.eq(1)
@@ -71,11 +70,10 @@ describe('Definition Service Facet management', () => {
     ])
   })
 
-  it('handles files with no data', () => {
+  it('handles files with no data', async () => {
     const files = [buildFile('foo.txt', null, null), buildFile('bar.txt', null, null)]
-    const definition = createDefinition(undefined, files)
-    const service = DefinitionService()
-    service._ensureFacets(definition)
+    const service = createService(createDefinition(undefined, files))
+    const definition = await service.compute('npm/npmjs/-/test/1.0')
     validate(definition)
     expect(definition.files.length).to.eq(2)
     expect(definition.licensed.declared).to.be.undefined
@@ -87,21 +85,19 @@ describe('Definition Service Facet management', () => {
     expect(core.discovered.unknown).to.eq(2)
   })
 
-  it('handles no files', () => {
+  it('handles no files', async () => {
     const files = []
-    const definition = createDefinition(undefined, files)
-    const service = DefinitionService()
-    service._ensureFacets(definition)
+    const service = createService(createDefinition(undefined, files))
+    const definition = await service.compute('npm/npmjs/-/test/1.0')
     validate(definition)
     expect(definition.files.length).to.eq(0)
     expect(definition.licensed).to.be.undefined
   })
 
-  it('gets all the attribution parties', () => {
+  it('gets all the attribution parties', async () => {
     const files = [buildFile('foo.txt', 'MIT', ['Bob', 'Fred']), buildFile('bar.txt', 'MIT', ['Jane', 'Fred'])]
-    const definition = createDefinition(undefined, files)
-    const service = DefinitionService()
-    service._ensureFacets(definition)
+    const service = createService(createDefinition(undefined, files))
+    const definition = await service.compute('npm/npmjs/-/test/1.0')
     validate(definition)
     const core = definition.licensed.facets.core
     expect(core.files).to.eq(2)
@@ -110,7 +106,7 @@ describe('Definition Service Facet management', () => {
     expect(core.attribution.unknown).to.eq(0)
   })
 
-  it('handle special characters', () => {
+  it('handle special characters', async () => {
     const files = [
       buildFile('foo.txt', 'MIT', [
         '&#60;Bob&gt;',
@@ -123,9 +119,8 @@ describe('Definition Service Facet management', () => {
         'Bob  Bobberson'
       ])
     ]
-    const definition = createDefinition(undefined, files)
-    const service = DefinitionService()
-    service._ensureFacets(definition)
+    const service = createService(createDefinition(undefined, files))
+    const definition = await service.compute('npm/npmjs/-/test/1.0')
     validate(definition)
     const core = definition.licensed.facets.core
     expect(core.files).to.eq(1)
@@ -137,12 +132,11 @@ describe('Definition Service Facet management', () => {
     ])
   })
 
-  it('summarizes with basic facets', () => {
+  it('summarizes with basic facets', async () => {
     const files = [buildFile('package.json', 'MIT', []), buildFile('LICENSE.foo', 'GPL', [])]
     const facets = { tests: ['*.json'] }
-    const definition = createDefinition(facets, files)
-    const service = DefinitionService()
-    service._ensureFacets(definition)
+    const service = createService(createDefinition(facets, files))
+    const definition = await service.compute('npm/npmjs/-/test/1.0')
     validate(definition)
     expect(definition.files.length).to.eq(2)
     const core = definition.licensed.facets.core
@@ -155,12 +149,11 @@ describe('Definition Service Facet management', () => {
     expect(tests.discovered.unknown).to.eq(0)
   })
 
-  it('summarizes with no core filters', () => {
+  it('summarizes with no core filters', async () => {
     const files = [buildFile('package.json', 'MIT', []), buildFile('LICENSE.foo', 'GPL', [])]
     const facets = { tests: ['*.json'] }
-    const definition = createDefinition(facets, files)
-    const service = DefinitionService()
-    service._ensureFacets(definition)
+    const service = createService(createDefinition(facets, files))
+    const definition = await service.compute('npm/npmjs/-/test/1.0')
     validate(definition)
     expect(definition.files.length).to.eq(2)
     const core = definition.licensed.facets.core
@@ -173,12 +166,11 @@ describe('Definition Service Facet management', () => {
     expect(tests.discovered.unknown).to.eq(0)
   })
 
-  it('summarizes with everything grouped into non-core facet', () => {
+  it('summarizes with everything grouped into non-core facet', async () => {
     const files = [buildFile('package.json', 'MIT', []), buildFile('LICENSE.foo', 'GPL', [])]
     const facets = { tests: ['*.json'], dev: ['*.foo'] }
-    const definition = createDefinition(facets, files)
-    const service = DefinitionService()
-    service._ensureFacets(definition)
+    const service = createService(createDefinition(facets, files))
+    const definition = await service.compute('npm/npmjs/-/test/1.0')
     validate(definition)
     expect(definition.files.length).to.eq(2)
     expect(definition.licensed.facets.core).to.be.undefined
@@ -192,12 +184,11 @@ describe('Definition Service Facet management', () => {
     expect(tests.discovered.unknown).to.eq(0)
   })
 
-  it('summarizes files in multiple facets', () => {
+  it('summarizes files in multiple facets', async () => {
     const files = [buildFile('LICENSE.json', 'GPL', []), buildFile('Test.json', 'MIT', [])]
     const facets = { tests: ['*.json'], dev: ['*.json'] }
-    const definition = createDefinition(facets, files)
-    const service = DefinitionService()
-    service._ensureFacets(definition)
+    const service = createService(createDefinition(facets, files))
+    const definition = await service.compute('npm/npmjs/-/test/1.0')
     validate(definition)
     expect(definition.files.length).to.eq(2)
     expect(definition.files[0].facets).to.deep.equalInAnyOrder(['tests', 'dev'])
@@ -240,4 +231,17 @@ function buildFile(path, license, holders) {
   setIfValue(result, 'license', license)
   setIfValue(result, 'attributions', holders ? holders.map(entry => `Copyright ${entry}`) : null)
   return result
+}
+
+function createService(definition, curation) {
+  const store = { delete: sinon.stub() }
+  const search = { delete: sinon.stub() }
+  const curator = {
+    get: () => Promise.resolve(curation),
+    apply: () => Promise.resolve(definition)
+  }
+  const harvest = { getAll: () => Promise.resolve(null) }
+  const summary = { summarizeAll: () => Promise.resolve(null) }
+  const aggregator = { process: () => Promise.resolve(null) }
+  return DefinitionService(harvest, summary, aggregator, curator, store, search)
 }

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -3,8 +3,12 @@
 
 const { expect } = require('chai')
 const sinon = require('sinon')
+const definitionSchema = require('../../schemas/definition')
+const Ajv = require('ajv')
+const ajv = new Ajv({ allErrors: true })
 const DefinitionService = require('../../business/definitionService')
 const EntityCoordinates = require('../../lib/entityCoordinates')
+const { setIfValue } = require('../../lib/utils')
 
 describe('Definition Service', () => {
   it('invalidates single coordinate', async () => {
@@ -38,3 +42,202 @@ describe('Definition Service', () => {
     expect(search.delete.getCall(1).args[0].name).to.be.eq('test1')
   })
 })
+
+describe('Definition Service Facet management', () => {
+  it('handle special characters', () => {
+    const files = [
+      buildFile('foo.txt', 'MIT', [
+        '&#60;Bob&gt;',
+        'Bob\\n',
+        'Bob\\r',
+        'Bob\r',
+        'Bob\n',
+        'Bob\n',
+        'Bob ',
+        'Bob  Bobberson'
+      ])
+    ]
+    const definition = createDefinition(undefined, files)
+    const service = DefinitionService()
+    service._ensureFacets(definition)
+    validate(definition)
+    const core = definition.licensed.facets.core
+    expect(core.files).to.eq(1)
+    expect(core.attribution.parties.length).to.eq(3)
+    expect(core.attribution.parties).to.deep.equalInAnyOrder([
+      'Copyright <Bob>',
+      'Copyright Bob',
+      'Copyright Bob Bobberson'
+    ])
+  })
+
+  it('handles files with no data', () => {
+    const files = [buildFile('foo.txt', null, null), buildFile('bar.txt', null, null)]
+    const definition = createDefinition(undefined, files)
+    const service = DefinitionService()
+    service._ensureFacets(definition)
+    validate(definition)
+    expect(definition.files.length).to.eq(2)
+    expect(definition.licensed.declared).to.be.undefined
+    const core = definition.licensed.facets.core
+    expect(core.files).to.eq(2)
+    expect(core.attribution.parties).to.be.undefined
+    expect(core.attribution.unknown).to.eq(2)
+    expect(core.discovered.expressions).to.be.undefined
+    expect(core.discovered.unknown).to.eq(2)
+  })
+
+  it('handles no files', () => {
+    const files = []
+    const definition = createDefinition(undefined, files)
+    const service = DefinitionService()
+    service._ensureFacets(definition)
+    validate(definition)
+    expect(definition.files.length).to.eq(0)
+    expect(definition.licensed).to.be.undefined
+  })
+
+  it('gets all the attribution parties', () => {
+    const files = [buildFile('foo.txt', 'MIT', ['Bob', 'Fred']), buildFile('bar.txt', 'MIT', ['Jane', 'Fred'])]
+    const definition = createDefinition(undefined, files)
+    const service = DefinitionService()
+    service._ensureFacets(definition)
+    validate(definition)
+    const core = definition.licensed.facets.core
+    expect(core.files).to.eq(2)
+    expect(core.attribution.parties.length).to.eq(3)
+    expect(core.attribution.parties).to.deep.equalInAnyOrder(['Copyright Bob', 'Copyright Jane', 'Copyright Fred'])
+    expect(core.attribution.unknown).to.eq(0)
+  })
+
+  it('handle special characters', () => {
+    const files = [
+      buildFile('foo.txt', 'MIT', [
+        '&#60;Bob&gt;',
+        'Bob\\n',
+        'Bob\\r',
+        'Bob\r',
+        'Bob\n',
+        'Bob\n',
+        'Bob ',
+        'Bob  Bobberson'
+      ])
+    ]
+    const definition = createDefinition(undefined, files)
+    const service = DefinitionService()
+    service._ensureFacets(definition)
+    validate(definition)
+    const core = definition.licensed.facets.core
+    expect(core.files).to.eq(1)
+    expect(core.attribution.parties.length).to.eq(3)
+    expect(core.attribution.parties).to.deep.equalInAnyOrder([
+      'Copyright <Bob>',
+      'Copyright Bob',
+      'Copyright Bob Bobberson'
+    ])
+  })
+
+  it('summarizes with basic facets', () => {
+    const files = [buildFile('package.json', 'MIT', []), buildFile('LICENSE.foo', 'GPL', [])]
+    const facets = { tests: ['*.json'] }
+    const definition = createDefinition(facets, files)
+    const service = DefinitionService()
+    service._ensureFacets(definition)
+    validate(definition)
+    expect(definition.files.length).to.eq(2)
+    const core = definition.licensed.facets.core
+    expect(core.files).to.eq(1)
+    expect(core.discovered.expressions).to.deep.eq(['GPL'])
+    expect(core.discovered.unknown).to.eq(0)
+    const tests = definition.licensed.facets.tests
+    expect(tests.files).to.eq(1)
+    expect(tests.discovered.expressions).to.deep.eq(['MIT'])
+    expect(tests.discovered.unknown).to.eq(0)
+  })
+
+  it('summarizes with no core filters', () => {
+    const files = [buildFile('package.json', 'MIT', []), buildFile('LICENSE.foo', 'GPL', [])]
+    const facets = { tests: ['*.json'] }
+    const definition = createDefinition(facets, files)
+    const service = DefinitionService()
+    service._ensureFacets(definition)
+    validate(definition)
+    expect(definition.files.length).to.eq(2)
+    const core = definition.licensed.facets.core
+    expect(core.files).to.eq(1)
+    expect(core.discovered.expressions).to.deep.eq(['GPL'])
+    expect(core.discovered.unknown).to.eq(0)
+    const tests = definition.licensed.facets.tests
+    expect(tests.files).to.eq(1)
+    expect(tests.discovered.expressions).to.deep.eq(['MIT'])
+    expect(tests.discovered.unknown).to.eq(0)
+  })
+
+  it('summarizes with everything grouped into non-core facet', () => {
+    const files = [buildFile('package.json', 'MIT', []), buildFile('LICENSE.foo', 'GPL', [])]
+    const facets = { tests: ['*.json'], dev: ['*.foo'] }
+    const definition = createDefinition(facets, files)
+    const service = DefinitionService()
+    service._ensureFacets(definition)
+    validate(definition)
+    expect(definition.files.length).to.eq(2)
+    expect(definition.licensed.facets.core).to.be.undefined
+    const dev = definition.licensed.facets.dev
+    expect(dev.files).to.eq(1)
+    expect(dev.discovered.expressions).to.deep.eq(['GPL'])
+    expect(dev.discovered.unknown).to.eq(0)
+    const tests = definition.licensed.facets.tests
+    expect(tests.files).to.eq(1)
+    expect(tests.discovered.expressions).to.deep.eq(['MIT'])
+    expect(tests.discovered.unknown).to.eq(0)
+  })
+
+  it('summarizes files in multiple facets', () => {
+    const files = [buildFile('LICENSE.json', 'GPL', []), buildFile('Test.json', 'MIT', [])]
+    const facets = { tests: ['*.json'], dev: ['*.json'] }
+    const definition = createDefinition(facets, files)
+    const service = DefinitionService()
+    service._ensureFacets(definition)
+    validate(definition)
+    expect(definition.files.length).to.eq(2)
+    expect(definition.files[0].facets).to.deep.equalInAnyOrder(['tests', 'dev'])
+    expect(definition.files[1].facets).to.deep.equalInAnyOrder(['tests', 'dev'])
+    expect(definition.licensed.facets.core).to.be.undefined
+    const dev = definition.licensed.facets.dev
+    expect(dev.files).to.eq(2)
+    expect(dev.discovered.expressions).to.deep.equalInAnyOrder(['GPL', 'MIT'])
+    expect(dev.discovered.unknown).to.eq(0)
+    const tests = definition.licensed.facets.tests
+    expect(tests.files).to.eq(2)
+    expect(tests.discovered.expressions).to.deep.equalInAnyOrder(['MIT', 'GPL'])
+    expect(tests.discovered.unknown).to.eq(0)
+  })
+
+  it('handles no facet defs', async () => {
+    const files = [createFile('/foo.txt', ['bob', 'jane'], ['MIT']), createFile('/bar.js', ['jane'], ['GPL-v3'])]
+    const definition = createDefinition([], files)
+    const service = DefinitionService(null, null, null, null, null, null)
+    service._ensureFacets(definition)
+  })
+})
+
+function validate(definition) {
+  // Tack on a dummy coordinates to keep the schema happy. Tool summarizations do not have to include coordinates
+  definition.coordinates = { type: 'npm', provider: 'npmjs', namespace: null, name: 'foo', revision: '1.0' }
+  if (!ajv.validate(definitionSchema, definition)) throw new Error(ajv.errorsText())
+}
+
+function createDefinition(facets, files) {
+  return { described: { facets }, files }
+}
+
+function createFile(path, attributions = [], licenses = []) {
+  return { path, attributions, licenses }
+}
+
+function buildFile(path, license, holders) {
+  const result = { path }
+  setIfValue(result, 'license', license)
+  setIfValue(result, 'attributions', holders ? holders.map(entry => `Copyright ${entry}`) : null)
+  return result
+}

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -20,10 +20,10 @@ describe('ScanCode summarizer', () => {
     expect(summary.coordinates).to.be.undefined
   })
 
-  it('gets all the attribution parties', () => {
+  it('gets all the per file license info and attribution parties', () => {
     const harvested = buildOutput([
       buildFile('foo.txt', 'MIT', ['Bob', 'Fred']),
-      buildFile('bar.txt', 'MIT', ['Jane', 'Fred', 'John'])
+      buildFile('bar.txt', 'GPL', ['Jane', 'Fred', 'John'])
     ])
     const summarizer = Summarizer()
     const coordinates = 'npm/npmjs/-/test/1.0'
@@ -31,13 +31,17 @@ describe('ScanCode summarizer', () => {
     validate(summary)
     expect(summary.files.length).to.eq(2)
     expect(summary.files[0].attributions.length).to.eq(2)
+    expect(summary.files[0].path).to.equal('foo.txt')
     expect(summary.files[0].attributions).to.deep.equalInAnyOrder(['Copyright Bob', 'Copyright Fred'])
+    expect(summary.files[0].license).to.equal('MIT')
+    expect(summary.files[1].path).to.equal('bar.txt')
     expect(summary.files[1].attributions.length).to.eq(3)
     expect(summary.files[1].attributions).to.deep.equalInAnyOrder([
       'Copyright John',
       'Copyright Jane',
       'Copyright Fred'
     ])
+    expect(summary.files[1].license).to.equal('GPL')
   })
 
   it('handles scan LICENSE file', () => {
@@ -61,13 +65,16 @@ describe('ScanCode summarizer', () => {
   })
 
   it('skips license files in subdirectories', () => {
-    const harvested = buildOutput([buildFile('/foo/LICENSE.md', 'MIT', []), buildFile('LICENSE.foo', 'GPL', [])])
+    const harvested = buildOutput([buildFile('foo/LICENSE.md', 'MIT', []), buildFile('LICENSE.foo', 'GPL', [])])
     const summarizer = Summarizer()
     const coordinates = 'npm/npmjs/-/test/1.0'
     const summary = summarizer.summarize(coordinates, harvested)
     validate(summary)
     expect(summary.files.length).to.eq(2)
     expect(summary.licensed).to.be.undefined
+    expect(summary.files[0].attributions).to.be.undefined
+    expect(summary.files[0].path).to.equal('foo/LICENSE.md')
+    expect(summary.files[0].license).to.equal('MIT')
   })
 
   it('handles scan with asserted license file even in a subdirectory', () => {


### PR DESCRIPTION
The previous notion of facets and grouping data into facets was largely coded into the scancode summarizer. With a recent redesign that introduced per-file data  such as license and copyright, the summarizers can be simplified and the facet grouping moved up a level or two and thus shared. 

This refactoring moves all the file grouping code up to the definition service and rationalizes the related tests.

Note that this does not change the definition schema so should be mergable without any data migrations.