### PR TITLE
Don't store empty definitions

### DIFF
--- a/business/aggregator.js
+++ b/business/aggregator.js
@@ -36,12 +36,13 @@ const _ = require('lodash')
 class AggregationService {
   constructor(options) {
     this.options = options
-    this.workingPrecedence = _.flattenDeep(options.precedence.map(group => [...group].reverse()).reverse())
+    this.workingPrecedence =
+      options.precedence && _.flattenDeep(options.precedence.map(group => [...group].reverse()).reverse())
   }
 
   process(coordinates, summarized) {
     let result = {}
-    const order = this.workingPrecedence
+    const order = this.workingPrecedence || []
     const tools = []
     order.forEach(tool => {
       const data = this._findData(tool, summarized)

--- a/business/summarizer.js
+++ b/business/summarizer.js
@@ -32,7 +32,7 @@ class SummaryService {
    * @param {*} data the data to summarize
    */
   summarizeAll(coordinates, data) {
-    const summary = Object.getOwnPropertyNames(data).reduce((result, tool) => {
+    const summary = Object.getOwnPropertyNames(data || {}).reduce((result, tool) => {
       result[tool] = this._summarizeTool(coordinates, tool, data[tool])
       return result
     }, {})

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -43,6 +43,13 @@ describe('Definition Service', () => {
     expect(service.definitionStore.store.notCalled).to.be.true
     expect(service.search.store.notCalled).to.be.true
   })
+
+  it('stores new definitions', async () => {
+    const { service, coordinates } = setup(createDefinition(null, null, ['foo']))
+    await service.get(coordinates)
+    expect(service.definitionStore.store.calledOnce).to.be.true
+    expect(service.search.store.calledOnce).to.be.true
+  })
 })
 
 describe('Definition Service Facet management', () => {
@@ -213,8 +220,10 @@ function validate(definition) {
   if (!ajv.validate(definitionSchema, definition)) throw new Error(ajv.errorsText())
 }
 
-function createDefinition(facets, files) {
-  return { described: { facets }, files }
+function createDefinition(facets, files, tools) {
+  const result = { described: { facets }, files }
+  if (tools) result.described.tools = tools
+  return result
 }
 
 function createFile(path, attributions = [], licenses = []) {


### PR DESCRIPTION
When the service is asked for a definition about which it has no information, we'd compute the (basically empty) definititon and then store it. That just clutters up the store and opens the service to attack with people querying random stuff.

This PR changes to only store when the definition has `tools`. The summarizer tracks what tools (including `curation`) go into making up the definition. If there are none then that means we did not have any harvested data and no curations were found. That is, ClearlyDefined does not have anything in particular to say about the requested component. So, nothing to store.