### PR TITLE
Handle and expose interesting file content

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,9 +46,6 @@ const curationService = require(`./providers/curation/${curationProvider}`)(
 )
 const curations = require('./routes/curations')(curationService)
 
-const contentStoreProvider = config.content.store.provider
-const contentStore = require(`./providers/stores/${contentStoreProvider}`)(config.content.store[contentStoreProvider])
-
 const definitionStoreProvider = config.definition.store.provider
 const definitionStore = require(`./providers/stores/${definitionStoreProvider}`)(
   config.definition.store[definitionStoreProvider]
@@ -71,7 +68,7 @@ const definitionService = require('./business/definitionService')(
 // Circular dependency. Reach in and set the curationService's definitionService. Sigh.
 curationService.definitionService = definitionService
 
-const content = require('./routes/content')(contentStore)
+const attachments = require('./routes/attachments')(harvestStore)
 const definitions = require('./routes/definitions')(harvestStore, curationService, definitionService)
 
 const appLogger = console // @todo add real logger
@@ -125,7 +122,7 @@ app.use('/harvest', harvest)
 app.use(bodyParser.json())
 app.use('/curations', curations)
 app.use('/definitions', definitions)
-app.use('/content', content)
+app.use('/attachments', attachments)
 
 // catch 404 and forward to error handler
 const requestHandler = (req, res, next) => {

--- a/app.js
+++ b/app.js
@@ -1,5 +1,11 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
+
+// TODO consider putting this in for real
+// process.on('unhandledRejection', (reason, p) => {
+//   throw reason
+// })
+
 const express = require('express')
 const logger = require('morgan')
 const bodyParser = require('body-parser')
@@ -40,6 +46,9 @@ const curationService = require(`./providers/curation/${curationProvider}`)(
 )
 const curations = require('./routes/curations')(curationService)
 
+const contentStoreProvider = config.content.store.provider
+const contentStore = require(`./providers/stores/${contentStoreProvider}`)(config.content.store[contentStoreProvider])
+
 const definitionStoreProvider = config.definition.store.provider
 const definitionStore = require(`./providers/stores/${definitionStoreProvider}`)(
   config.definition.store[definitionStoreProvider]
@@ -62,6 +71,7 @@ const definitionService = require('./business/definitionService')(
 // Circular dependency. Reach in and set the curationService's definitionService. Sigh.
 curationService.definitionService = definitionService
 
+const content = require('./routes/content')(contentStore)
 const definitions = require('./routes/definitions')(harvestStore, curationService, definitionService)
 
 const appLogger = console // @todo add real logger
@@ -115,6 +125,7 @@ app.use('/harvest', harvest)
 app.use(bodyParser.json())
 app.use('/curations', curations)
 app.use('/definitions', definitions)
+app.use('/content', content)
 
 // catch 404 and forward to error handler
 const requestHandler = (req, res, next) => {

--- a/app.js
+++ b/app.js
@@ -67,9 +67,9 @@ const definitionService = require('./business/definitionService')(
 )
 // Circular dependency. Reach in and set the curationService's definitionService. Sigh.
 curationService.definitionService = definitionService
+const definitions = require('./routes/definitions')(definitionService)
 
 const attachments = require('./routes/attachments')(harvestStore)
-const definitions = require('./routes/definitions')(harvestStore, curationService, definitionService)
 
 const appLogger = console // @todo add real logger
 const githubSecret = config.webhook.githubSecret

--- a/business/aggregator.js
+++ b/business/aggregator.js
@@ -29,7 +29,7 @@
 // The function should return a summary schema.
 //
 
-const { getLatestVersion, merge } = require('../lib/utils')
+const { getLatestVersion, mergeDefinitions } = require('../lib/utils')
 const { flattenDeep, set } = require('lodash')
 
 class AggregationService {
@@ -47,7 +47,7 @@ class AggregationService {
       const data = this._findData(tool, summarized)
       if (data) {
         tools.push(data.toolSpec)
-        merge(result, data.summary)
+        mergeDefinitions(result, data.summary)
       }
     })
     set(result, 'described.tools', tools.reverse())

--- a/business/aggregator.js
+++ b/business/aggregator.js
@@ -29,30 +29,28 @@
 // The function should return a summary schema.
 //
 
-const extend = require('extend')
-const utils = require('../lib/utils')
-const _ = require('lodash')
+const { getLatestVersion, merge } = require('../lib/utils')
+const { flattenDeep, set } = require('lodash')
 
 class AggregationService {
   constructor(options) {
     this.options = options
     this.workingPrecedence =
-      options.precedence && _.flattenDeep(options.precedence.map(group => [...group].reverse()).reverse())
+      options.precedence && flattenDeep(options.precedence.map(group => [...group].reverse()).reverse())
   }
 
   process(coordinates, summarized) {
-    let result = {}
+    const result = {}
     const order = this.workingPrecedence || []
     const tools = []
     order.forEach(tool => {
       const data = this._findData(tool, summarized)
       if (data) {
         tools.push(data.toolSpec)
-        extend(true, result, data.summary)
+        merge(result, data.summary)
       }
     })
-    result.described = result.described || {}
-    result.described.tools = tools.reverse()
+    set(result, 'described.tools', tools.reverse())
     return result
   }
 
@@ -63,7 +61,7 @@ class AggregationService {
     if (toolVersion) return { toolSpec, summary: summarized[tool][toolVersion] }
 
     const versions = Object.getOwnPropertyNames(summarized[tool])
-    const latest = utils.getLatestVersion(versions)
+    const latest = getLatestVersion(versions)
     return latest ? { toolSpec: `${tool}/${latest}`, summary: summarized[tool][latest] } : null
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: MIT
 const config = require('painless-config')
 
+const file = {
+  location: config.get('FILE_STORE_LOCATION') || (process.platform === 'win32' ? 'c:/temp/cd' : '/tmp/cd')
+}
+
 module.exports = {
   summary: {},
   curation: {
@@ -31,13 +35,25 @@ module.exports = {
         connectionString: config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
         containerName: config.get('HARVEST_AZBLOB_CONTAINER_NAME') || `harvest-${process.env.NODE_ENV}`
       },
-      file: {
-        location: config.get('FILE_STORE_LOCATION') || (process.platform === 'win32' ? 'c:/temp/cd' : '/tmp/cd')
-      }
+      file
     }
   },
   aggregator: {
     precedence: [['scancode', 'clearlydefined', 'cdsource']]
+  },
+  content: {
+    store: {
+      provider: config.get('CONTENT_STORE_PROVIDER') || config.get('HARVEST_STORE_PROVIDER') || 'file',
+      azblob: {
+        connectionString:
+          config.get('CONTENT_AZBLOB_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
+        containerName:
+          config.get('CONTENT_AZBLOB_CONTAINER_NAME') ||
+          config.get('HARVEST_AZBLOB_CONTAINER_NAME') + '-content' ||
+          `content-${process.env.NODE_ENV}`
+      },
+      file
+    }
   },
   definition: {
     store: {
@@ -50,9 +66,7 @@ module.exports = {
           config.get('HARVEST_AZBLOB_CONTAINER_NAME') + '-definition' ||
           `definition-${process.env.NODE_ENV}`
       },
-      file: {
-        location: config.get('FILE_STORE_LOCATION') || (process.platform === 'win32' ? 'c:/temp/cd' : '/tmp/cd')
-      }
+      file
     }
   },
   auth: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -41,20 +41,6 @@ module.exports = {
   aggregator: {
     precedence: [['scancode', 'clearlydefined', 'cdsource']]
   },
-  content: {
-    store: {
-      provider: config.get('CONTENT_STORE_PROVIDER') || config.get('HARVEST_STORE_PROVIDER') || 'file',
-      azblob: {
-        connectionString:
-          config.get('CONTENT_AZBLOB_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
-        containerName:
-          config.get('CONTENT_AZBLOB_CONTAINER_NAME') ||
-          config.get('HARVEST_AZBLOB_CONTAINER_NAME') + '-content' ||
-          `content-${process.env.NODE_ENV}`
-      },
-      file
-    }
-  },
   definition: {
     store: {
       provider: config.get('COMPONENT_STORE_PROVIDER') || config.get('HARVEST_STORE_PROVIDER') || 'file',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,7 +70,7 @@ function addArrayToSet(array, set, valueExtractor) {
 
 // merge the given definition onto the base definition. Be careful to handle various arrays
 // correctly by finding matching entried and merging them as appropriate.
-function merge(base, newDefinition) {
+function mergeDefinitions(base, newDefinition) {
   if (!newDefinition) return
   const overlay = { ...newDefinition }
   delete overlay.files
@@ -96,5 +96,5 @@ module.exports = {
   setIfValue,
   setToArray,
   addArrayToSet,
-  merge
+  mergeDefinitions
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,8 @@ const semver = require('semver')
 const EntityCoordinates = require('./entityCoordinates')
 const ResultCoordinates = require('./resultCoordinates')
 const moment = require('moment')
-const { set } = require('lodash')
+const { set, find } = require('lodash')
+const extend = require('extend')
 
 function toResultCoordinatesFromRequest(request) {
   return new ResultCoordinates(
@@ -67,6 +68,21 @@ function addArrayToSet(array, set, valueExtractor) {
   return set
 }
 
+// merge the given definition onto the base definition. Be careful to handle various arrays
+// correctly by finding matching entried and merging them as appropriate.
+function merge(base, newDefinition) {
+  if (!newDefinition) return
+  const overlay = { ...newDefinition }
+  delete overlay.files
+  extend(true, base, overlay)
+  if (!newDefinition.files) return
+  if (!base.files) return (base.files = newDefinition.files)
+  newDefinition.files.forEach(file => {
+    const entry = find(base.files, current => current.path === file.path)
+    if (entry) extend(true, entry, file)
+  })
+}
+
 function _normalizeVersion(version) {
   if (version == '1') return '1.0.0' // version '1' is not semver valid see https://github.com/clearlydefined/crawler/issues/124
   return semver.valid(version) ? version : null
@@ -79,5 +95,6 @@ module.exports = {
   extractDate,
   setIfValue,
   setToArray,
-  addArrayToSet
+  addArrayToSet,
+  merge
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1718,8 +1718,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.4",
@@ -2293,7 +2292,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2609,7 +2607,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -3567,7 +3564,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -3680,8 +3676,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -5056,8 +5051,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1594,6 +1594,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
       "requires": {
         "is-object": "1.0.1",
         "merge-descriptors": "1.0.1"
@@ -1718,7 +1719,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.4",
@@ -2292,6 +2294,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2607,6 +2610,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -2805,7 +2809,8 @@
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -3259,7 +3264,8 @@
     "module-not-found-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
     },
     "moment": {
       "version": "2.19.4",
@@ -3564,6 +3570,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -3676,7 +3683,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -3688,6 +3696,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -3796,13 +3810,25 @@
       "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "proxyquire": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
-      "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.0.1.tgz",
+      "integrity": "sha512-fQr3VQrbdzHrdaDn3XuisVoJlJNDJizHAvUXw9IuXRR8BpV2x0N7LsCxrpJkeKfPbNjiNU/V5vc008cI0TmzzQ==",
+      "dev": true,
       "requires": {
         "fill-keys": "1.0.2",
         "module-not-found-error": "1.0.1",
-        "resolve": "1.1.7"
+        "resolve": "1.5.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.6"
+          }
+        }
       }
     },
     "ps-tree": {
@@ -4065,11 +4091,6 @@
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
       }
-    },
-    "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -5051,7 +5072,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "express-init": "^1.1.0",
     "express-rate-limit": "^2.11.0",
     "extend": "^3.0.1",
-    "glob": "^7.1.2",
     "he": "^1.1.1",
     "helmet": "^3.9.0",
     "js-yaml": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "express-init": "^1.1.0",
     "express-rate-limit": "^2.11.0",
     "extend": "^3.0.1",
+    "glob": "^7.1.2",
     "he": "^1.1.1",
     "helmet": "^3.9.0",
     "js-yaml": "^3.10.0",
@@ -41,7 +42,6 @@
     "painless-config": "^0.1.0",
     "passport": "^0.4.0",
     "passport-github": "^1.1.0",
-    "proxyquire": "^1.8.0",
     "readdirp": "^2.1.0",
     "recursive-readdir": "^2.2.1",
     "redis": "^2.8.0",
@@ -61,6 +61,7 @@
     "mocha": "^4.0.1",
     "node-mocks-http": "^1.6.7",
     "nodemon": "^1.18.2",
+    "proxyquire": "^2.0.1",
     "sinon": "^4.2.2"
   }
 }

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -13,6 +13,7 @@ const throat = require('throat')
 const Github = require('../../lib/github')
 const Curation = require('../../lib/curation')
 const EntityCoordinates = require('../../lib/entityCoordinates')
+const utils = require('../../lib/utils')
 const tmp = require('tmp')
 const path = require('path')
 tmp.setGracefulCleanup()
@@ -152,7 +153,7 @@ class GitHubCurationService {
   async _getAllLocal(coordinates) {
     await this.ensureCurations()
     const filePath = `${this.tempLocation.name}/${this.options.repo}/${this._getSearchRoot(coordinates)}.yaml`
-    var result
+    let result
     try {
       result = yaml.safeLoad(fs.readFileSync(filePath))
     } catch (error) {
@@ -212,7 +213,8 @@ class GitHubCurationService {
 
   async apply(coordinates, curationSpec, summarized) {
     const curation = await this.get(coordinates, curationSpec)
-    return curation ? extend(true, {}, summarized, curation) : summarized
+    utils.merge(summarized, curation)
+    return summarized
   }
 
   async getContent(ref, path) {

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -213,7 +213,7 @@ class GitHubCurationService {
 
   async apply(coordinates, curationSpec, summarized) {
     const curation = await this.get(coordinates, curationSpec)
-    utils.merge(summarized, curation)
+    utils.mergeDefinitions(summarized, curation)
     return summarized
   }
 

--- a/providers/stores/abstractStore.js
+++ b/providers/stores/abstractStore.js
@@ -36,7 +36,7 @@ class AbstractStore {
   }
 
   _getEntry(entry, type) {
-    if (entry.startsWith('deadletter/')) return null
+    if (entry.startsWith('deadletter/') || entry.startsWith('attachments/')) return null
     if (type === 'entity') return this._toEntityCoordinatesFromStoragePath(entry)
     if (type === 'result') return this._toResultCoordinatesFromStoragePath(entry)
     throw new Error(`Invalid list type: ${type}`)

--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -13,6 +13,7 @@ class ClearlyDescribedSummarizer {
     const result = {}
     this.addFacetInfo(result, data)
     this.addSourceLocation(result, data)
+    this.addInterestingFiles(result, data)
     switch (coordinates.type) {
       case 'npm':
         this.addNpmData(result, data)
@@ -48,6 +49,10 @@ class ClearlyDescribedSummarizer {
       'described.sourceLocation',
       pick(data.sourceInfo, ['type', 'provider', 'url', 'revision', 'path'])
     )
+  }
+
+  addInterestingFiles(result, data) {
+    setIfValue(result, 'files', data.interestingFiles)
   }
 
   addMavenData(result, data) {

--- a/routes/attachments.js
+++ b/routes/attachments.js
@@ -7,22 +7,22 @@ const router = express.Router()
 const ResultCoordinates = require('../lib/resultCoordinates')
 
 // Get a proposed patch for a specific revision of a component
-router.get('/:contentToken', asyncMiddleware(getContent))
+router.get('/:token', asyncMiddleware(getAttachment))
 
-async function getContent(request, response) {
+async function getAttachment(request, response) {
   // TODO this is a hack. The coordinates are not intended to be sparse. Here make sure the
   // token is the "namespace" to avoid the '-' showing up. Fix is likely to have an explicit
-  // ContentCoordinates class that has the right shape and generalize the stores to just take
+  // AttachmentCoordinates class that has the right shape and generalize the stores to just take
   // "coordinates" and not worry about how they are structured.
-  const coordinates = new ResultCoordinates('content', null, request.params.contentToken)
-  const result = await contentStore.get(coordinates)
-  if (result) return response.status(200).send(result.content)
+  const coordinates = new ResultCoordinates('attachment', null, request.params.token)
+  const result = await harvestStore.get(coordinates)
+  if (result) return response.status(200).send(result.attachment)
   response.sendStatus(404)
 }
 
-let contentStore
-function setup(content) {
-  contentStore = content
+let harvestStore
+function setup(harvest) {
+  harvestStore = harvest
   return router
 }
 module.exports = setup

--- a/routes/attachments.js
+++ b/routes/attachments.js
@@ -16,8 +16,8 @@ async function getAttachment(request, response) {
   // "coordinates" and not worry about how they are structured.
   const coordinates = new ResultCoordinates('attachment', null, request.params.token)
   const result = await harvestStore.get(coordinates)
-  if (result) return response.status(200).send(result.attachment)
-  response.sendStatus(404)
+  if (!result) return response.sendStatus(404)
+  response.status(200).send(result.attachment)
 }
 
 let harvestStore

--- a/routes/content.js
+++ b/routes/content.js
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const asyncMiddleware = require('../middleware/asyncMiddleware')
+const express = require('express')
+const router = express.Router()
+const ResultCoordinates = require('../lib/resultCoordinates')
+
+// Get a proposed patch for a specific revision of a component
+router.get('/:contentToken', asyncMiddleware(getContent))
+
+async function getContent(request, response) {
+  // TODO this is a hack. The coordinates are not intended to be sparse. Here make sure the
+  // token is the "namespace" to avoid the '-' showing up. Fix is likely to have an explicit
+  // ContentCoordinates class that has the right shape and generalize the stores to just take
+  // "coordinates" and not worry about how they are structured.
+  const coordinates = new ResultCoordinates('content', null, request.params.contentToken)
+  const result = await contentStore.get(coordinates)
+  if (result) return response.status(200).send(result.content)
+  response.sendStatus(404)
+}
+
+let contentStore
+function setup(content) {
+  contentStore = content
+  return router
+}
+module.exports = setup

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -70,13 +70,9 @@ router.post(
   })
 )
 
-let harvestService
-let curationService
 let definitionService
 
-function setup(harvest, curation, definition) {
-  harvestService = harvest
-  curationService = curation
+function setup(definition) {
   definitionService = definition
   return router
 }

--- a/routes/swagger.yaml
+++ b/routes/swagger.yaml
@@ -285,21 +285,21 @@ paths:
       responses:
         200:
           description: Component definition.
-  /content/{token}:
+  /attachments/{token}:
     get:
-      summary: Gets the content for the file with the given content token.
+      summary: Gets the attachment with the given content token.
       tags:
-        - content
+        - attachments
       parameters:
         - in: path
           name: token
           schema:
             type: string
           required: true
-          description: The token identifying the content to access
+          description: The token identifying the attachment to access
       responses:
         200:
-          description: The raw content corresponding to the given token.
+          description: The raw contne of the attachment corresponding to the given token.
 
 tags:
   - name: definitions
@@ -308,8 +308,8 @@ tags:
     description: Curate component metadata - ClearlyDefined developers will be interested in these
   - name: harvest
     description: Harvest component metadata - ClearlyDefined developers will be intereted in these
-  - name: content
-    description: Definition content - Raw content of interesting files found in components while harvesting
+  - name: attachments
+    description: Definition attachments - Raw content of attachments for harvested component data
 
 components:
   bodies:

--- a/routes/swagger.yaml
+++ b/routes/swagger.yaml
@@ -299,7 +299,7 @@ paths:
           description: The token identifying the attachment to access
       responses:
         200:
-          description: The raw contne of the attachment corresponding to the given token.
+          description: The raw content of the attachment corresponding to the given token.
 
 tags:
   - name: definitions

--- a/routes/swagger.yaml
+++ b/routes/swagger.yaml
@@ -1,15 +1,15 @@
-openapi: "3.0.0"
+openapi: '3.0.0'
 
 info:
-  version: "0.1.0"
+  version: '0.1.0'
   title: ClearlyDefined API
   description: The REST API for clearlydefined.io
 
 servers:
-- url: https://api.clearlydefined.io
-  description: Production environment
-- url: https://dev.clearlydefined.io
-  description: Development environment
+  - url: https://api.clearlydefined.io
+    description: Production environment
+  - url: https://dev.clearlydefined.io
+    description: Development environment
 
 paths:
   /curations/{type}/{provider}/{namespace}/{name}:
@@ -18,10 +18,10 @@ paths:
       tags:
         - curations
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
       responses:
         200:
           description: List of curations for the identified components.
@@ -31,12 +31,12 @@ paths:
       tags:
         - curations
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
-        - $ref: "#/components/parameters/revision"
-        - $ref: "#/components/parameters/pr"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/revision'
+        - $ref: '#/components/parameters/pr'
       responses:
         200:
           description: Proposed curation for the component revision.
@@ -46,11 +46,11 @@ paths:
       tags:
         - curations
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
-        - $ref: "#/components/parameters/revision"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/revision'
       responses:
         200:
           description: Component revision curation.
@@ -59,11 +59,11 @@ paths:
       tags:
         - curations
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
-        - $ref: "#/components/parameters/revision"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/revision'
       responses:
         200:
           description: Nothing. TODO - this should be 204 or return something.
@@ -108,11 +108,11 @@ paths:
       tags:
         - harvest
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
-        - $ref: "#/components/parameters/revision"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/revision'
         - name: form
           in: query
           schema:
@@ -136,12 +136,12 @@ paths:
       tags:
         - harvest
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
-        - $ref: "#/components/parameters/revision"
-        - $ref: "#/components/parameters/tool"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/revision'
+        - $ref: '#/components/parameters/tool'
         - name: form
           in: query
           schema:
@@ -160,13 +160,13 @@ paths:
       tags:
         - harvest
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
-        - $ref: "#/components/parameters/revision"
-        - $ref: "#/components/parameters/tool"
-        - $ref: "#/components/parameters/toolVersion"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/revision'
+        - $ref: '#/components/parameters/tool'
+        - $ref: '#/components/parameters/toolVersion'
         - name: form
           in: query
           schema:
@@ -189,13 +189,13 @@ paths:
       tags:
         - harvest
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
-        - $ref: "#/components/parameters/revision"
-        - $ref: "#/components/parameters/tool"
-        - $ref: "#/components/parameters/toolVersion"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/revision'
+        - $ref: '#/components/parameters/tool'
+        - $ref: '#/components/parameters/toolVersion'
       responses:
         201:
           description: Harvested file has been accepted.
@@ -236,18 +236,18 @@ paths:
           description: The part of the definition to search for the given pattern. Valid values are 'coordinates' (default) and 'copyrights'.
       responses:
         200:
-      description: List of definitions that have definitions.
+          description: List of definitions that have definitions.
   /definitions/{type}/{provider}/{namespace}/{name}/{revision}:
     get:
       summary: Gets the definition for a component revision.
       tags:
         - definitions
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
-        - $ref: "#/components/parameters/revision"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/revision'
       responses:
         200:
           description: Component definition.
@@ -256,11 +256,11 @@ paths:
       tags:
         - definitions
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
-        - $ref: "#/components/parameters/revision"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/revision'
         - name: preview
           in: query
           schema:
@@ -276,15 +276,31 @@ paths:
       tags:
         - definitions
       parameters:
-        - $ref: "#/components/parameters/type"
-        - $ref: "#/components/parameters/provider"
-        - $ref: "#/components/parameters/namespace"
-        - $ref: "#/components/parameters/name"
-        - $ref: "#/components/parameters/revision"
-        - $ref: "#/components/parameters/pr"
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/namespace'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/revision'
+        - $ref: '#/components/parameters/pr'
       responses:
         200:
           description: Component definition.
+  /content/{token}:
+    get:
+      summary: Gets the content for the file with the given content token.
+      tags:
+        - content
+      parameters:
+        - in: path
+          name: token
+          schema:
+            type: string
+          required: true
+          description: The token identifying the content to access
+      responses:
+        200:
+          description: The raw content corresponding to the given token.
+
 tags:
   - name: definitions
     description: Component definitions - most API consumers will be interested in these
@@ -292,7 +308,8 @@ tags:
     description: Curate component metadata - ClearlyDefined developers will be interested in these
   - name: harvest
     description: Harvest component metadata - ClearlyDefined developers will be intereted in these
-
+  - name: content
+    description: Definition content - Raw content of interesting files found in components while harvesting
 
 components:
   bodies:
@@ -317,7 +334,7 @@ components:
     definitionList:
       type: object
       description: A list of component definitions that are available (see definition.json#definitions/componentDefinitionList)
-      example: 
+      example:
         'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca':
           coordinates:
             type: git
@@ -325,7 +342,7 @@ components:
             namespace: microsoft
             name: redie
             revision: 194269b5b7010ad6f8dc4ef608c88128615031ca
-          described: 
+          described:
             sourceLocation:
               type: git
               provider: github
@@ -336,22 +353,22 @@ components:
           licensed:
             declared: MIT
             facets:
-              core: 
+              core:
                 attribution:
                   parties:
                     - Microsoft Corporation
                 discovered:
-                    - MIT
-                    - GPL
+                  - MIT
+                  - GPL
 
     outputSummaryList:
       type: object
       description: A list of tool outputs that are available (see harvest.json#definitions/definitionSummaryList)
-      example: 
+      example:
         'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca':
-          clearlydefined: 
+          clearlydefined:
             - 1
-          scancode: 
+          scancode:
             - 2.2.1
         'npm/npmjs/-/redie/0.3.0':
           clearlydefined:
@@ -368,8 +385,8 @@ components:
       schema:
         type: string
         enum:
-        - npm
-        - git
+          - npm
+          - git
     provider:
       name: provider
       in: path
@@ -378,8 +395,8 @@ components:
       schema:
         type: string
         enum:
-        - npmjs
-        - github
+          - npmjs
+          - github
     namespace:
       name: namespace
       in: path

--- a/schemas/definition.json
+++ b/schemas/definition.json
@@ -2,6 +2,7 @@
   "$id": "https://api.clearlydefined.io/schemas/definition.json#",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "definition",
+  "version": "0.0.2",
   "required": ["coordinates"],
   "type": "object",
   "additionalProperties": false,
@@ -75,16 +76,14 @@
           },
           "facets": {
             "type": "array",
-            "description":
-              "The facets in which this file exists, if any. Note that the absence of facets implies the 'core' facet.",
+            "description": "The facets in which this file exists, if any. Note that the absence of facets implies the 'core' facet.",
             "items": {
               "type": "string"
             }
           },
-          "content": {
+          "token": {
             "type": "string",
-            "description":
-              "An opaque token representing the content of this file. This value can be presented to the system's API to get the content if stored by the system"
+            "description": "An opaque token representing the content of this file. This value can be presented to the system's API to get the content if stored by the system"
           }
         }
       }

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai')
 const utils = require('../../lib/utils')
 
-describe('Utils', () => {
+describe('Utils latest version', () => {
   it('should get the latest version', () => {
     const inputs = {
       '1': ['1'], // https://github.com/clearlydefined/crawler/issues/124
@@ -20,8 +20,45 @@ describe('Utils', () => {
 
     for (const expected of Object.getOwnPropertyNames(inputs)) {
       const result = '' + utils.getLatestVersion(inputs[expected])
-
       expect(result).to.equal(expected)
     }
+  })
+})
+
+describe('Utils merge', () => {
+  it('should add new entries as needed', () => {
+    const base = { described: { releaseDate: '2018-6-3' } }
+    const newDefinition = { described: { issueTracker: 'http://bugs' }, files: [{ path: '1.txt', token: '13' }] }
+    utils.merge(base, newDefinition)
+    expect(base.described.releaseDate).to.eq('2018-6-3')
+    expect(base.files.length).to.eq(1)
+    expect(base.files[0].path).to.eq('1.txt')
+    expect(base.files[0].token).to.eq('13')
+  })
+
+  it('should merge entries as needed', () => {
+    const base = { described: { releaseDate: '2018-6-3' }, files: [{ path: '1.txt', license: 'MIT' }] }
+    const newDefinition = { described: { issueTracker: 'http://bugs' }, files: [{ path: '1.txt', token: '13' }] }
+    utils.merge(base, newDefinition)
+    expect(base.described.releaseDate).to.eq('2018-6-3')
+    expect(base.files.length).to.eq(1)
+    expect(base.files[0].path).to.eq('1.txt')
+    expect(base.files[0].token).to.eq('13')
+    expect(base.files[0].license).to.eq('MIT')
+  })
+
+  it('does not mess with existing entries', () => {
+    const base = {
+      described: { releaseDate: '2018-6-3' },
+      files: [{ path: '1.txt', license: 'MIT' }, { path: '2.txt', license: 'GPL' }]
+    }
+    const newDefinition = { described: { issueTracker: 'http://bugs' }, files: [{ path: '1.txt', token: '13' }] }
+    utils.merge(base, newDefinition)
+    expect(base.described.releaseDate).to.eq('2018-6-3')
+    expect(base.files.length).to.eq(2)
+    expect(base.files[0].path).to.eq('1.txt')
+    expect(base.files[0].token).to.eq('13')
+    expect(base.files[1].path).to.eq('2.txt')
+    expect(base.files[1].license).to.eq('GPL')
   })
 })

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -25,11 +25,11 @@ describe('Utils latest version', () => {
   })
 })
 
-describe('Utils merge', () => {
+describe('Utils mergeDefinitions', () => {
   it('should add new entries as needed', () => {
     const base = { described: { releaseDate: '2018-6-3' } }
     const newDefinition = { described: { issueTracker: 'http://bugs' }, files: [{ path: '1.txt', token: '13' }] }
-    utils.merge(base, newDefinition)
+    utils.mergeDefinitions(base, newDefinition)
     expect(base.described.releaseDate).to.eq('2018-6-3')
     expect(base.files.length).to.eq(1)
     expect(base.files[0].path).to.eq('1.txt')
@@ -39,7 +39,7 @@ describe('Utils merge', () => {
   it('should merge entries as needed', () => {
     const base = { described: { releaseDate: '2018-6-3' }, files: [{ path: '1.txt', license: 'MIT' }] }
     const newDefinition = { described: { issueTracker: 'http://bugs' }, files: [{ path: '1.txt', token: '13' }] }
-    utils.merge(base, newDefinition)
+    utils.mergeDefinitions(base, newDefinition)
     expect(base.described.releaseDate).to.eq('2018-6-3')
     expect(base.files.length).to.eq(1)
     expect(base.files[0].path).to.eq('1.txt')
@@ -53,7 +53,7 @@ describe('Utils merge', () => {
       files: [{ path: '1.txt', license: 'MIT' }, { path: '2.txt', license: 'GPL' }]
     }
     const newDefinition = { described: { issueTracker: 'http://bugs' }, files: [{ path: '1.txt', token: '13' }] }
-    utils.merge(base, newDefinition)
+    utils.mergeDefinitions(base, newDefinition)
     expect(base.described.releaseDate).to.eq('2018-6-3')
     expect(base.files.length).to.eq(2)
     expect(base.files[0].path).to.eq('1.txt')

--- a/test/providers/github.js
+++ b/test/providers/github.js
@@ -2,6 +2,8 @@ const { expect } = require('chai')
 const GitHubCurationService = require('../../providers/curation/github')
 const Curation = require('../../lib/curation')
 const sinon = require('sinon')
+const extend = require('extend')
+const { find } = require('lodash')
 
 function createService(definitionService = null, endpoints = { website: 'http://localhost:3000' }) {
   return GitHubCurationService(
@@ -52,24 +54,96 @@ describe('Github Curation Service', () => {
     expect(service.postCommitStatus.getCall(0).args[3]).to.be.eq('pending')
     expect(service.postCommitStatus.getCall(1).args[3]).to.be.eq('error')
   })
+
+  it('merges simple changes', async () => {
+    const service = createService()
+    sinon.stub(service, 'get').callsFake(() => simpleCuration.revisions['1.0'])
+    const base = { coordinates: definitionCoordinates }
+    await service.apply(null, null, base)
+    expect(base.described.projectWebsite).to.eq('http://foo.com')
+  })
+
+  it('merges complex curation on simple base', async () => {
+    const service = createService()
+    sinon.stub(service, 'get').callsFake(() => complexCuration.revisions['1.0'])
+    const base = extend(true, {}, simpleHarvested)
+    await service.apply(null, null, base)
+    expect(base.described.releaseDate).to.eq('2018-10-19')
+    expect(base.described.projectWebsite).to.eq('http://foo.com')
+    const file1 = find(base.files, file => file.path === '1.txt')
+    expect(!!file1).to.be.true
+    expect(file1.license).to.eq('MIT')
+    const file2 = find(base.files, file => file.path === '2.txt')
+    expect(!!file2).to.be.true
+    expect(file2.license).to.eq('GPL')
+  })
+
+  it('merges simple curation on complex base', async () => {
+    const service = createService()
+    sinon.stub(service, 'get').callsFake(() => simpleCuration.revisions['1.0'])
+    const base = extend(true, {}, complexHarvested)
+    await service.apply(null, null, base)
+    expect(base.described.releaseDate).to.eq('2018-08-09')
+    expect(base.described.projectWebsite).to.eq('http://foo.com')
+    const file1 = find(base.files, file => file.path === '1.txt')
+    expect(!!file1).to.be.true
+    expect(file1.token).to.eq('1 token')
+    const file2 = find(base.files, file => file.path === '2.txt')
+    expect(!!file2).to.be.true
+    expect(file2.token).to.eq('2 token')
+  })
+
+  it('merges complex structures', async () => {
+    const service = createService()
+    sinon.stub(service, 'get').callsFake(() => complexCuration.revisions['1.0'])
+    const base = extend(true, {}, complexHarvested)
+    await service.apply(null, null, base)
+    expect(base.described.projectWebsite).to.eq('http://foo.com')
+    const file1 = find(base.files, file => file.path === '1.txt')
+    expect(!!file1).to.be.true
+    expect(file1.license).to.eq('MIT')
+    expect(file1.token).to.eq('1 token')
+    const file2 = find(base.files, file => file.path === '2.txt')
+    expect(!!file2).to.be.true
+    expect(file2.license).to.eq('GPL')
+    expect(file2.token).to.eq('2 token')
+  })
 })
 
-function createCuration() {
-  return new Curation({
-    coordinates: {
-      type: 'npm',
-      provider: 'npmjs',
-      namespace: null,
-      name: 'test'
-    },
-    revisions: {
-      '1.0': {
-        described: {
-          projectWebsite: 'http://foo.com'
-        }
-      }
+const curationCoordinates = { type: 'npm', provider: 'npmjs', namespace: null, name: 'test' }
+const definitionCoordinates = { ...curationCoordinates, revision: '1.0' }
+
+const simpleCuration = {
+  coordinates: curationCoordinates,
+  revisions: {
+    '1.0': {
+      described: { projectWebsite: 'http://foo.com' }
     }
-  })
+  }
+}
+
+const complexCuration = {
+  coordinates: curationCoordinates,
+  revisions: {
+    '1.0': {
+      described: { releaseDate: '2018-10-19', projectWebsite: 'http://foo.com' },
+      files: [{ path: '1.txt', license: 'MIT' }, { path: '2.txt', license: 'GPL' }]
+    }
+  }
+}
+
+const simpleHarvested = {
+  coordinates: definitionCoordinates
+}
+
+const complexHarvested = {
+  coordinates: definitionCoordinates,
+  described: { releaseDate: '2018-08-09' },
+  files: [{ path: '2.txt', token: '2 token' }, { path: '1.txt', token: '1 token' }]
+}
+
+function createCuration() {
+  return new Curation(simpleCuration)
 }
 
 function createInvalidCuration() {

--- a/test/providers/store/fileScan.js
+++ b/test/providers/store/fileScan.js
@@ -10,7 +10,7 @@ const assert = require('assert')
 const ResultCoordinates = require('../../../lib/resultCoordinates')
 const EntityCoordinates = require('../../../lib/entityCoordinates')
 
-var FileStore
+let FileStore
 
 describe('list a tool result ', () => {
   beforeEach(function() {


### PR DESCRIPTION
The crawler now captures interesting files (e.g., LICENSE.md, ...) and stores it with an opaque token (sha256 hash of the raw content). This PR adds the following to support this new data.

* API for getting the content given a token
* extraction of the relevant harvested data during summarization 
* proper merging of the file tokens during aggregation and curation
* More tests

Note that the store access technique is replicated from how we are handling the definition and harvest stores. That is, we directly access the underlying storage shared with the crawler. This may prove to be an issue in the future as we are sharing implementation details. As it is, the storage structure is pretty stable. 

Note as well that this includes a subtle change in a little used part of the schema. The `files[n].content` property changed to be called `files[n].token`. The term content was misleading as the value is a pointer to the content not the content itself.