### PR TITLE
compute implicit and curated scores

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -3,11 +3,12 @@
 
 const Readable = require('stream').Readable
 const throat = require('throat')
-const { get, union, remove, pullAllWith, isEqual } = require('lodash')
+const { get, set, union, remove, pullAllWith, isEqual } = require('lodash')
 const EntityCoordinates = require('../lib/entityCoordinates')
 const { setIfValue, setToArray, addArrayToSet } = require('../lib/utils')
 const minimatch = require('minimatch')
 const he = require('he')
+const extend = require('extend')
 
 class DefinitionService {
   constructor(harvest, summary, aggregator, curation, store, search) {
@@ -135,29 +136,64 @@ class DefinitionService {
     const curation = await this.curationService.get(coordinates, curationSpec)
     const raw = await this.harvestService.getAll(coordinates)
     const summarized = await this.summaryService.summarizeAll(coordinates, raw)
-    const aggregated = await this.aggregationService.process(coordinates, summarized)
-    const definition = await this.curationService.apply(coordinates, curation, aggregated)
+    const tooledDefinition = (await this.aggregationService.process(coordinates, summarized)) || {}
+    this._ensureToolScores(coordinates, tooledDefinition)
+    const definition = await this.curationService.apply(coordinates, curation, tooledDefinition)
+    this._finalizeDefinition(coordinates, definition, curation)
+    this._ensureCuratedScores(definition)
+    return definition
+  }
+
+  // Compute and store the scored for the given definition but do it in a way that does not affect the
+  // definition so that further curations can be done.
+  _ensureToolScores(coordinates, definition) {
+    const rawDefinition = extend(true, {}, definition)
+    this._finalizeDefinition(coordinates, rawDefinition)
+    const { describedScore, licensedScore } = this._computeScores(rawDefinition)
+    set(definition, 'described.toolScore', describedScore)
+    set(definition, 'licensed.toolScore', licensedScore)
+  }
+
+  _ensureCuratedScores(definition) {
+    const { describedScore, licensedScore } = this._computeScores(definition)
+    set(definition, 'described.score', describedScore)
+    set(definition, 'licensed.score', licensedScore)
+  }
+
+  _finalizeDefinition(coordinates, definition, curation) {
     this._ensureFacets(definition)
     this._ensureCurationInfo(definition, curation)
     this._ensureSourceLocation(coordinates, definition)
     this._ensureCoordinates(coordinates, definition)
-    definition.score = this.computeScore(definition)
-    return definition
   }
 
-  /**
-   * Given a defintion, calculate a score for the definition
-   * @param {Defition} defintion
-   * @returns {number} The score for the definition
-   */
-  computeScore(definition) {
+  // Given a definition, calculate the scores for the definition and return an object with a score per dimension
+  _computeScores(definition) {
+    return {
+      licensedScore: this._computeLicensedScore(definition),
+      describedScore: this._computeDescribedScore(definition)
+    }
+  }
+
+  // Given a definition, calculate and return the score for the described dimension
+  _computeDescribedScore(definition) {
+    // @todo we need to flesh this out
+    // For now it just checks that a few props are present
+    let result = 0
+    result += !!get(definition, 'described.releaseDate')
+    result += !!get(definition, 'described.sourceLocation')
+    // TODO add in validated
+    return result
+  }
+
+  // Given a definition, calculate and return the score for the licensed dimension
+  _computeLicensedScore(definition) {
     // @todo we need to flesh this out
     // For now it just checks that a license and copyright holders are present
-    const hasLicense = get(definition, 'licensed.declared')
-    const hasAttributionParties = get(definition, 'licensed.attribution.parties[0]')
-    if (hasLicense && hasAttributionParties) return 2
-    if (hasLicense || hasAttributionParties) return 1
-    return 0
+    let result = 0
+    result += !!get(definition, 'licensed.declared')
+    result += !!get(definition, 'licensed.attribution.parties[0]')
+    return result
   }
 
   /**
@@ -190,7 +226,7 @@ class DefinitionService {
   // ensure all the right facet information has been computed and added to the given definition
   _ensureFacets(definition) {
     if (!definition.files) return
-    const facetFiles = this._computeFacetFiles([...definition.files], definition.described.facets)
+    const facetFiles = this._computeFacetFiles([...definition.files], get(definition, 'described.facets'))
     for (const facet in facetFiles)
       setIfValue(definition, `licensed.facets.${facet}`, this._summarizeFacetInfo(facet, facetFiles[facet]))
   }
@@ -270,14 +306,14 @@ class DefinitionService {
   _ensureCurationInfo(definition, curation) {
     if (!curation) return
     this._ensureDescribed(definition)
-    const tools = (definition.described.tools = definition.described.tools || [])
     if (Object.getOwnPropertyNames(curation).length === 0) return
     const origin = get(curation, '_origin.sha')
-    tools.push(`curation${origin ? '/' + origin : 'supplied'}`)
+    definition.described.tools = definition.described.tools || []
+    definition.described.tools.push(`curation${origin ? '/' + origin : 'supplied'}`)
   }
 
   _ensureSourceLocation(coordinates, definition) {
-    if (definition.described && definition.described.sourceLocation) return
+    if (get(definition, 'described.sourceLocation')) return
     // For source components there may not be an explicit harvested source location (it is self-evident)
     // Make it explicit in the definition
     switch (coordinates.provider) {

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -181,7 +181,7 @@ class DefinitionService {
     // For now it just checks that a few props are present
     let result = 0
     result += !!get(definition, 'described.releaseDate')
-    result += !!get(definition, 'described.sourceLocation')
+    result += !!get(definition, 'described.sourceLocation.url')
     // TODO add in validated
     return result
   }

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -192,7 +192,7 @@ class DefinitionService {
     // For now it just checks that a license and copyright holders are present
     let result = 0
     result += !!get(definition, 'licensed.declared')
-    result += !!get(definition, 'licensed.attribution.parties[0]')
+    result += !!get(definition, 'licensed.facets.core.attribution.parties[0]')
     return result
   }
 

--- a/lib/curation.js
+++ b/lib/curation.js
@@ -19,7 +19,7 @@ class Curation {
   }
 
   static apply(definition, curation) {
-    utils.merge(definition, curation)
+    utils.mergeDefinitions(definition, curation)
     return definition
   }
 

--- a/lib/curation.js
+++ b/lib/curation.js
@@ -7,6 +7,7 @@ const ajv = new Ajv({ allErrors: true })
 require('ajv-errors')(ajv)
 const curationSchema = require('../schemas/curation')
 const EntityCoordinates = require('./entityCoordinates')
+const utils = require('./utils')
 
 class Curation {
   constructor(content, path = '') {
@@ -15,6 +16,11 @@ class Curation {
     this.path = path
     this.data = typeof content === 'string' ? this.load(content) : content
     this.validate()
+  }
+
+  static apply(definition, curation) {
+    utils.merge(definition, curation)
+    return definition
   }
 
   load(content) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3818,17 +3818,6 @@
         "fill-keys": "1.0.2",
         "module-not-found-error": "1.0.1",
         "resolve": "1.5.0"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-          "dev": true,
-          "requires": {
-            "path-parse": "1.0.6"
-          }
-        }
       }
     },
     "ps-tree": {
@@ -4090,6 +4079,15 @@
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
+      }
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.6"
       }
     },
     "resolve-from": {

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -211,10 +211,9 @@ class GitHubCurationService {
     )
   }
 
-  async apply(coordinates, curationSpec, summarized) {
+  async apply(coordinates, curationSpec, definition) {
     const curation = await this.get(coordinates, curationSpec)
-    utils.mergeDefinitions(summarized, curation)
-    return summarized
+    return Curation.apply(definition, curation)
   }
 
   async getContent(ref, path) {

--- a/schemas/definition.json
+++ b/schemas/definition.json
@@ -7,21 +7,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "score": {
-      "type": "number"
-    },
-    "coordinates": {
-      "$ref": "#/definitions/coordinates"
-    },
-    "files": {
-      "$ref": "#/definitions/files"
-    },
-    "described": {
-      "$ref": "#/definitions/described"
-    },
-    "licensed": {
-      "$ref": "#/definitions/licensed"
-    }
+    "coordinates": { "$ref": "#/definitions/coordinates" },
+    "files": { "$ref": "#/definitions/files" },
+    "described": { "$ref": "#/definitions/described" },
+    "licensed": { "$ref": "#/definitions/licensed" }
   },
   "definitions": {
     "type": {
@@ -35,12 +24,8 @@
       "required": ["type", "provider", "name", "revision"],
       "additionalProperties": false,
       "properties": {
-        "type": {
-          "$ref": "#/definitions/type"
-        },
-        "provider": {
-          "$ref": "#/definitions/provider"
-        },
+        "type": { "$ref": "#/definitions/type" },
+        "provider": { "$ref": "#/definitions/provider" },
         "namespace": {
           "type": ["string", "null"]
         },
@@ -92,36 +77,22 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "score": { "$ref": "#/definitions/score" },
+        "toolScore": { "$ref": "#/definitions/toolScore" },
         "facets": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "data": {
-              "$ref": "#/definitions/globList"
-            },
-            "dev": {
-              "$ref": "#/definitions/globList"
-            },
-            "doc": {
-              "$ref": "#/definitions/globList"
-            },
-            "examples": {
-              "$ref": "#/definitions/globList"
-            },
-            "tests": {
-              "$ref": "#/definitions/globList"
-            }
+            "data": { "$ref": "#/definitions/globList" },
+            "dev": { "$ref": "#/definitions/globList" },
+            "doc": { "$ref": "#/definitions/globList" },
+            "examples": { "$ref": "#/definitions/globList" },
+            "tests": { "$ref": "#/definitions/globList" }
           }
         },
-        "sourceLocation": {
-          "$ref": "#/definitions/sourceLocation"
-        },
-        "projectWebsite": {
-          "type": "string"
-        },
-        "issueTracker": {
-          "type": "string"
-        },
+        "sourceLocation": { "$ref": "#/definitions/sourceLocation" },
+        "projectWebsite": { "type": "string" },
+        "issueTracker": { "type": "string" },
         "releaseDate": {
           "type": "string",
           "format": "date"
@@ -134,6 +105,14 @@
         }
       }
     },
+    "score": {
+      "type": "number",
+      "description": "The effective score (combining tool and curated data) for the parent aspect of the definintion"
+    },
+    "toolScore": {
+      "type": "number",
+      "description": "The tool-based score for the parent aspect of the definintion"
+    },
     "globList": {
       "type": "array",
       "items": {
@@ -145,12 +124,8 @@
       "additionalProperties": false,
       "required": ["type", "provider", "url", "revision"],
       "properties": {
-        "type": {
-          "$ref": "#/definitions/type"
-        },
-        "provider": {
-          "$ref": "#/definitions/provider"
-        },
+        "type": { "$ref": "#/definitions/type" },
+        "provider": { "$ref": "#/definitions/provider" },
         "url": {
           "type": "string",
           "format": "uri"
@@ -167,36 +142,22 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "declared": {
-          "$ref": "#/definitions/declared"
-        },
-        "facets": {
-          "$ref": "#/definitions/facets"
-        }
+        "score": { "$ref": "#/definitions/score" },
+        "toolScore": { "$ref": "#/definitions/toolScore" },
+        "declared": { "$ref": "#/definitions/declared" },
+        "facets": { "$ref": "#/definitions/facets" }
       }
     },
     "facets": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "core": {
-          "$ref": "#/definitions/facet"
-        },
-        "data": {
-          "$ref": "#/definitions/facet"
-        },
-        "dev": {
-          "$ref": "#/definitions/facet"
-        },
-        "doc": {
-          "$ref": "#/definitions/facet"
-        },
-        "examples": {
-          "$ref": "#/definitions/facet"
-        },
-        "tests": {
-          "$ref": "#/definitions/facet"
-        }
+        "core": { "$ref": "#/definitions/facet" },
+        "data": { "$ref": "#/definitions/facet" },
+        "dev": { "$ref": "#/definitions/facet" },
+        "doc": { "$ref": "#/definitions/facet" },
+        "examples": { "$ref": "#/definitions/facet" },
+        "tests": { "$ref": "#/definitions/facet" }
       }
     },
     "facet": {
@@ -206,12 +167,8 @@
         "files": {
           "type": "number"
         },
-        "attribution": {
-          "$ref": "#/definitions/attribution"
-        },
-        "discovered": {
-          "$ref": "#/definitions/discovered"
-        }
+        "attribution": { "$ref": "#/definitions/attribution" },
+        "discovered": { "$ref": "#/definitions/discovered" }
       }
     },
     "attribution": {

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -60,7 +60,7 @@ describe('Definition Service score computation', () => {
     const raw = createDefinition(undefined, files)
     set(raw, 'licensed.declared', 'MIT')
     set(raw, 'described.releaseDate', '2018-08-09')
-    set(raw, 'described.sourceLocation', {})
+    set(raw, 'described.sourceLocation', { url: 'http://foo' })
     const { service, coordinates } = setup(raw)
     const definition = await service.compute(coordinates)
     expect(definition.described.score).to.eq(2)

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -9,6 +9,8 @@ const ajv = new Ajv({ allErrors: true })
 const DefinitionService = require('../../business/definitionService')
 const EntityCoordinates = require('../../lib/entityCoordinates')
 const { setIfValue } = require('../../lib/utils')
+const Curation = require('../../lib/curation')
+const { set } = require('lodash')
 
 describe('Definition Service', () => {
   it('invalidates single coordinate', async () => {
@@ -100,7 +102,9 @@ describe('Definition Service Facet management', () => {
     const definition = await service.compute(coordinates)
     validate(definition)
     expect(definition.files.length).to.eq(0)
-    expect(definition.licensed).to.be.undefined
+    expect(definition.licensed.score).to.eq(0)
+    expect(definition.licensed.toolScore).to.eq(0)
+    expect(Object.keys(definition.licensed).length).to.eq(2)
   })
 
   it('gets all the attribution parties', async () => {
@@ -221,8 +225,10 @@ function validate(definition) {
 }
 
 function createDefinition(facets, files, tools) {
-  const result = { described: { facets }, files }
-  if (tools) result.described.tools = tools
+  const result = {}
+  if (facets) set(result, 'described.facets', facets)
+  if (files) result.files = files
+  if (tools) set(result, 'described.tools', tools)
   return result
 }
 
@@ -242,11 +248,11 @@ function setup(definition, coordinateSpec, curation) {
   const search = { delete: sinon.stub(), store: sinon.stub() }
   const curator = {
     get: () => Promise.resolve(curation),
-    apply: () => Promise.resolve(definition)
+    apply: (coordinates, curationSpec, definition) => Promise.resolve(Curation.apply(definition, curation))
   }
   const harvest = { getAll: () => Promise.resolve(null) }
   const summary = { summarizeAll: () => Promise.resolve(null) }
-  const aggregator = { process: () => Promise.resolve(null) }
+  const aggregator = { process: () => Promise.resolve(definition) }
   const service = DefinitionService(harvest, summary, aggregator, curator, store, search)
   const coordinates = EntityCoordinates.fromString(coordinateSpec || 'npm/npmjs/-/test/1.0')
   return { coordinates, service }


### PR DESCRIPTION
The current scoring tells users the score of the entire definition and includes any curations. However, 
* Tome users will only be interested in (or emphasize) particular dimensions of the definition (e.g., licensed). For example, they may not care that the source location is not known.
* Project teams should be interested in how inherently ClearlyDefined their project is. The community should be able to tell the difference between a project has no data whatsoever but has been lovingly curated by an attentive user community, and one which is loved and clarified by the project team.

To address these scenarios, this PR splits the score computation into two (using just the harvested data and using the final, curated definition) and then does this for each dimension (described and licensed) separately. The resultant scores are stored in their respective dimension as `toolScore` and `score`.

The top level score is removed in this model. UI's presenting definitions and users assessing definitions are free to interpret and reveal these scores however most makes sense to their user base.