### PR TITLE
add missing copyright deduplication

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -259,6 +259,7 @@ class DefinitionService {
     for (let file of facetFiles) {
       file.license ? licenseExpressions.add(file.license) : unknownLicenses++
       const statements = this._simplifyAttributions(file.attributions)
+      setIfValue(file, 'attributions', statements)
       statements ? addArrayToSet(statements, attributions) : unknownParties++
       if (facet !== 'core') {
         // tag the file with the current facet if not core

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const { get, first, flatten } = require('lodash')
+const { get, first, flatten, uniq } = require('lodash')
 const { extractDate, setIfValue, addArrayToSet, setToArray } = require('../../lib/utils')
 
 class ScanCodeSummarizer {
@@ -70,7 +70,7 @@ class ScanCodeSummarizer {
       const licenseExpression = this._toExpression(licenses)
       const result = { path: file.path }
       setIfValue(result, 'license', licenseExpression)
-      setIfValue(result, 'attributions', file.copyrights ? flatten(file.copyrights.map(c => c.statements)) : null)
+      setIfValue(result, 'attributions', file.copyrights ? uniq(flatten(file.copyrights.map(c => c.statements))) : null)
       return result
     })
   }

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -122,6 +122,12 @@ describe('Definition Service Facet management', () => {
       'Copyright Bob',
       'Copyright Bob Bobberson'
     ])
+    expect(definition.files.length).to.eq(1)
+    expect(definition.files[0].attributions).to.deep.equalInAnyOrder([
+      'Copyright <Bob>',
+      'Copyright Bob',
+      'Copyright Bob Bobberson'
+    ])
   })
 
   it('handles files with no data', async () => {

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -21,15 +21,15 @@ describe('ScanCode summarizer', () => {
 
   it('gets all the per file license info and attribution parties', () => {
     const { coordinates, harvested } = setup([
-      buildFile('foo.txt', 'MIT', ['Bob', 'Fred']),
+      buildFile('foo.txt', 'MIT', ['Bob', 'Fred', 'Bob', 'bob']),
       buildFile('bar.txt', 'GPL', ['Jane', 'Fred', 'John'])
     ])
     const summary = Summarizer().summarize(coordinates, harvested)
     validate(summary)
     expect(summary.files.length).to.eq(2)
-    expect(summary.files[0].attributions.length).to.eq(2)
+    expect(summary.files[0].attributions.length).to.eq(3)
     expect(summary.files[0].path).to.equal('foo.txt')
-    expect(summary.files[0].attributions).to.deep.equalInAnyOrder(['Copyright Bob', 'Copyright Fred'])
+    expect(summary.files[0].attributions).to.deep.equalInAnyOrder(['Copyright Bob', 'Copyright Fred', 'Copyright bob'])
     expect(summary.files[0].license).to.equal('MIT')
     expect(summary.files[1].path).to.equal('bar.txt')
     expect(summary.files[1].attributions.length).to.eq(3)


### PR DESCRIPTION
This fixes #203. There was a missing `setIfValue` in the code that computed the definition. We cleaned up all the attributions and used those values to compute the cumulative attributions for each facet but neglected to store the cleaned up attributions on the corresponding file. 

I also took the opportunity to add some simple deduping (though not full cleanup) to the scancode summarizer and add a few tests for these cases.