### PR TITLE
fix merge bug and adapt to nomos output change

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@ const searchProvider = config.search.provider
 const search = require(`./providers/search/${searchProvider}`)(config.search[searchProvider])
 initializers.push(() => {
   search.initialize()
-  if (searchProvider === 'memory') definitionService.reload('definitions')
+  // if (searchProvider === 'memory') definitionService.reload('definitions')
 })
 
 const definitionService = require('./business/definitionService')(

--- a/business/aggregator.js
+++ b/business/aggregator.js
@@ -50,6 +50,7 @@ class AggregationService {
         mergeDefinitions(result, data.summary)
       }
     })
+    if (!tools.length) return null
     set(result, 'described.tools', tools.reverse())
     return result
   }

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -143,10 +143,10 @@ class DefinitionService {
     const curation = await this.curationService.get(coordinates, curationSpec)
     const raw = await this.harvestService.getAll(coordinates)
     coordinates = this._getCasedCoordinates(raw, coordinates)
-    const summarized = await this.summaryService.summarizeAll(coordinates, raw)
-    const tooledDefinition = (await this.aggregationService.process(coordinates, summarized)) || {}
-    this._ensureToolScores(coordinates, tooledDefinition)
-    const definition = await this.curationService.apply(coordinates, curation, tooledDefinition)
+    const summaries = await this.summaryService.summarizeAll(coordinates, raw)
+    const aggregatedDefinition = (await this.aggregationService.process(coordinates, summaries)) || {}
+    this._ensureToolScores(coordinates, aggregatedDefinition)
+    const definition = await this.curationService.apply(coordinates, curation, aggregatedDefinition)
     this._finalizeDefinition(coordinates, definition, curation)
     this._ensureCuratedScores(definition)
     // protect against any element of the compute producing an invalid defintion

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,9 +38,10 @@ function getLatestVersion(versions) {
   if (versions.length === 0) return null
   if (versions.length === 1) return versions[0]
   return versions.reduce((max, current) => {
-    const normalized = _normalizeVersion(current)
-    if (!normalized || semver.prerelease(normalized) !== null) return max
-    return semver.gt(normalized, _normalizeVersion(max)) ? current : max
+    const normalizedCurrent = _normalizeVersion(current)
+    if (!normalizedCurrent || semver.prerelease(normalizedCurrent) !== null) return max
+    const normalizedMax = _normalizeVersion(max)
+    return semver.gt(normalizedCurrent, normalizedMax) ? current : max
   }, versions[0])
 }
 
@@ -74,8 +75,7 @@ function extractLicenseFromLicenseUrl(licenseUrl) {
   for (const licenseUrlOverride of _licenseUrlOverrides) {
     const licenseUrlMatch = licenseUrlOverride.test.exec(licenseUrl)
     if (licenseUrlMatch) {
-      if (licenseUrlOverride.license)
-        return licenseUrlOverride.license
+      if (licenseUrlOverride.license) return licenseUrlOverride.license
       if (licenseUrlOverride.licenseMatchGroup)
         return _normalizeSpdx(licenseUrlMatch[licenseUrlOverride.licenseMatchGroup])
     }
@@ -83,7 +83,7 @@ function extractLicenseFromLicenseUrl(licenseUrl) {
 }
 
 function _normalizeSpdx(input) {
-  if (!input) return 
+  if (!input) return
   const loweredInput = input.toLowerCase()
   for (const spdx of spdxLicenseList) {
     if (loweredInput === spdx.toLowerCase()) return spdx
@@ -102,6 +102,7 @@ function mergeDefinitions(base, newDefinition) {
   newDefinition.files.forEach(file => {
     const entry = find(base.files, current => current.path === file.path)
     if (entry) extend(true, entry, file)
+    else base.files.push(file)
   })
 }
 

--- a/providers/summary/fossology.js
+++ b/providers/summary/fossology.js
@@ -3,7 +3,6 @@
 
 const { set } = require('lodash')
 const { setIfValue } = require('../../lib/utils')
-const base64 = require('base-64')
 
 class FOSSologySummarizer {
   constructor(options) {
@@ -25,8 +24,7 @@ class FOSSologySummarizer {
   }
 
   _summarizeNomosLicenseInfo(content) {
-    const nomosOutput = base64.decode(content)
-    const files = nomosOutput.split('\n')
+    const files = content.split('\n')
     return files
       .map(file => {
         const path = /^File (.*?) contains/.exec(file)

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -7,6 +7,7 @@ const definitionSchema = require('../../schemas/definition')
 const Ajv = require('ajv')
 const ajv = new Ajv({ allErrors: true })
 const DefinitionService = require('../../business/definitionService')
+const AggregatorService = require('../../business/aggregator')
 const EntityCoordinates = require('../../lib/entityCoordinates')
 const { setIfValue } = require('../../lib/utils')
 const Curation = require('../../lib/curation')
@@ -267,6 +268,74 @@ describe('Definition Service Facet management', () => {
   })
 })
 
+describe('Aggregation service', () => {
+  it('handles no tool data', async () => {
+    const { service, coordinates } = setupAggregator()
+    const aggregated = service.process(coordinates, {})
+    expect(aggregated).to.be.null
+  })
+
+  it('handles one tool one version data', async () => {
+    const summaries = { tool2: { '1.0.0': { files: [buildFile('foo.txt', 'MIT')] } } }
+    const { service, coordinates } = setupAggregator()
+    const aggregated = service.process(coordinates, summaries)
+    expect(aggregated.files.length).to.eq(1)
+  })
+
+  it('handles one tool multiple version data', async () => {
+    const summaries = {
+      tool2: {
+        '1.0.0': { files: [buildFile('foo.txt', 'MIT'), buildFile('bar.txt', 'MIT')] },
+        '2.0.0': { files: [buildFile('foo.txt', 'GPL')] }
+      }
+    }
+    const { service, coordinates } = setupAggregator()
+    const aggregated = service.process(coordinates, summaries)
+    expect(aggregated.files.length).to.eq(1)
+    expect(aggregated.files[0].path).to.eq('foo.txt')
+    expect(aggregated.files[0].license).to.eq('GPL')
+  })
+
+  it('handles multiple tools and one file data', async () => {
+    const summaries = {
+      tool2: { '1.0.0': { files: [buildFile('foo.txt', 'MIT')] }, '2.0.0': { files: [buildFile('foo.txt', 'GPL')] } },
+      tool1: { '3.0.0': { files: [buildFile('foo.txt', 'BSD')] } }
+    }
+    const { service, coordinates } = setupAggregator()
+    const aggregated = service.process(coordinates, summaries)
+    expect(aggregated.files.length).to.eq(1)
+    expect(aggregated.files[0].license).to.eq('BSD')
+  })
+
+  it('handles multiple tools and multiple file data with extras ignored', async () => {
+    const summaries = {
+      tool2: { '1.0.0': { files: [buildFile('foo.txt', 'MIT')] }, '2.0.0': { files: [buildFile('foo.txt', 'GPL')] } },
+      tool1: { '3.0.0': { files: [buildFile('foo.txt', 'BSD')] }, '2.0.0': { files: [buildFile('bar.txt', 'GPL')] } }
+    }
+    const { service, coordinates } = setupAggregator()
+    const aggregated = service.process(coordinates, summaries)
+    expect(aggregated.files.length).to.eq(1)
+    expect(aggregated.files[0].license).to.eq('BSD')
+  })
+
+  it('handles multiple tools and multiple file data with extras included', async () => {
+    const summaries = {
+      tool2: { '1.0.0': { files: [buildFile('foo.txt', 'MIT')] }, '2.0.0': { files: [buildFile('foo.txt', 'GPL')] } },
+      tool1: {
+        '3.0.0': { files: [buildFile('foo.txt', 'BSD'), buildFile('bar.txt', 'GPL')] },
+        '2.0.0': { files: [buildFile('bar.txt', 'GPL')] }
+      }
+    }
+    const { service, coordinates } = setupAggregator()
+    const aggregated = service.process(coordinates, summaries)
+    expect(aggregated.files.length).to.eq(2)
+    expect(aggregated.files[0].path).to.eq('foo.txt')
+    expect(aggregated.files[0].license).to.eq('BSD')
+    expect(aggregated.files[1].path).to.eq('bar.txt')
+    expect(aggregated.files[1].license).to.eq('GPL')
+  })
+})
+
 function validate(definition) {
   // Tack on a dummy coordinates to keep the schema happy. Tool summarizations do not have to include coordinates
   definition.coordinates = { type: 'npm', provider: 'npmjs', namespace: null, name: 'foo', revision: '1.0' }
@@ -301,4 +370,11 @@ function setup(definition, coordinateSpec, curation) {
   const service = DefinitionService(harvest, summary, aggregator, curator, store, search)
   const coordinates = EntityCoordinates.fromString(coordinateSpec || 'npm/npmjs/-/test/1.0')
   return { coordinates, service }
+}
+
+function setupAggregator() {
+  const coordinates = EntityCoordinates.fromString('npm/npmjs/-/test/1.0')
+  const config = { precedence: [['tool1', 'tool2', 'tool3']] }
+  const service = AggregatorService(config)
+  return { service, coordinates }
 }

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -82,6 +82,7 @@ describe('Utils mergeDefinitions', () => {
     expect(base.files.length).to.eq(2)
     expect(base.files[0].path).to.eq('1.txt')
     expect(base.files[0].token).to.eq('13')
+    expect(base.files[0].license).to.eq('MIT')
     expect(base.files[1].path).to.eq('2.txt')
     expect(base.files[1].license).to.eq('GPL')
   })

--- a/test/summary/fossology.js
+++ b/test/summary/fossology.js
@@ -48,7 +48,7 @@ function setup(files, coordinateSpec) {
       version: '3.3.0',
       output: {
         contentType: 'application/base64',
-        content: new Buffer(files.map(file => file.licenses).join('\n')).toString('base64')
+        content: files.map(file => file.licenses).join('\n')
       }
     }
   }


### PR DESCRIPTION
There was a bug in `mergeDefinition` such that new files in the supplied newDefinition were not added to the base. Fixed and added a mess of tests

Also adapted to nomos' changed to NOT base64 encode
