### PR TITLE
fix pr check url

### DIFF
--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -234,8 +234,8 @@ class GitHubCurationService {
     return this.definitionService.invalidate(coordinateList)
   }
 
-  async validateCurations(number, componentPath, sha, ref) {
-    await this.postCommitStatus(sha, number, componentPath, 'pending', 'Validation in progress')
+  async validateCurations(number, sha, ref) {
+    await this.postCommitStatus(sha, number, 'pending', 'Validation in progress')
     const curations = await this.getCurations(number, ref)
     const invalidCurations = curations.filter(x => !x.isValid)
     let state = 'success'
@@ -244,13 +244,13 @@ class GitHubCurationService {
       state = 'error'
       description = `Invalid curations: ${invalidCurations.map(x => x.path).join(', ')}`
     }
-    return this.postCommitStatus(sha, number, componentPath, state, description)
+    return this.postCommitStatus(sha, number, state, description)
   }
 
-  async postCommitStatus(sha, number, componentPath, state, description) {
+  async postCommitStatus(sha, number, state, description) {
     const { owner, repo } = this.options
     const github = Github.getClient(this.options)
-    const target_url = `${this.endpoints.website}/curate/${componentPath}/pr/${number}`
+    const target_url = `${this.endpoints.website}/curations/${number}`
     try {
       return github.repos.createStatus({
         owner,

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -26,12 +26,8 @@ async function handleGitHubCall(request, response) {
   if (!body) return
   const pr = body.pull_request
   if (body.action === 'closed') pr.merged ? await curationService.handleMerge(pr.number, pr.head.ref) : null
-  else {
-    // TODO hack alert! use the title of the PR to find the definition in clearlydefined.io
-    // In the future we need a more concrete/robust way to capture this in the PR in the face of
-    // people not using our tools etc. Ideally read it out of the PR files themselves.
-    await curationService.validateCurations(pr.number, pr.title, pr.head.sha, pr.head.ref)
-  }
+  else await curationService.validateCurations(pr.number, pr.head.sha, pr.head.ref)
+
   response.status(200).end()
 }
 

--- a/test/providers/github.js
+++ b/test/providers/github.js
@@ -37,10 +37,10 @@ describe('Github Curation Service', () => {
     sinon.stub(service, 'getCurations').callsFake(() => {
       return [createCuration()]
     })
-    await service.validateCurations(1, 'npm/npmjs/-/test', '42', 'testBranch')
+    await service.validateCurations(1, '42', 'testBranch')
     expect(service.postCommitStatus.calledTwice).to.be.true
-    expect(service.postCommitStatus.getCall(0).args[3]).to.be.eq('pending')
-    expect(service.postCommitStatus.getCall(1).args[3]).to.be.eq('success')
+    expect(service.postCommitStatus.getCall(0).args[2]).to.be.eq('pending')
+    expect(service.postCommitStatus.getCall(1).args[2]).to.be.eq('success')
   })
 
   it('validates invalid PR change', async () => {
@@ -49,10 +49,10 @@ describe('Github Curation Service', () => {
     sinon.stub(service, 'getCurations').callsFake(() => {
       return [createInvalidCuration()]
     })
-    await service.validateCurations(1, 'npm/npmjs/-/test', '42', 'testBranch')
+    await service.validateCurations(1, '42', 'testBranch')
     expect(service.postCommitStatus.calledTwice).to.be.true
-    expect(service.postCommitStatus.getCall(0).args[3]).to.be.eq('pending')
-    expect(service.postCommitStatus.getCall(1).args[3]).to.be.eq('error')
+    expect(service.postCommitStatus.getCall(0).args[2]).to.be.eq('pending')
+    expect(service.postCommitStatus.getCall(1).args[2]).to.be.eq('error')
   })
 
   it('merges simple changes', async () => {

--- a/test/routes/webhookGitHubTests.js
+++ b/test/routes/webhookGitHubTests.js
@@ -82,9 +82,8 @@ describe('Webhook Route for GitHub calls', () => {
     expect(service.handleMerge.calledOnce).to.be.false
     expect(service.validateCurations.calledOnce).to.be.true
     expect(service.validateCurations.getCall(0).args[0]).to.be.eq(1)
-    expect(service.validateCurations.getCall(0).args[1]).to.be.eq('test pr')
-    expect(service.validateCurations.getCall(0).args[2]).to.be.eq('24')
-    expect(service.validateCurations.getCall(0).args[3]).to.be.eq('changes')
+    expect(service.validateCurations.getCall(0).args[1]).to.be.eq('24')
+    expect(service.validateCurations.getCall(0).args[2]).to.be.eq('changes')
   })
 })
 


### PR DESCRIPTION
Fix the URL used in PR check to guide people to clearlydefined.io/curations/##

Note: still have to fix that route in the site. that will come in a future PR