### PR TITLE
refactor source location management

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -13,6 +13,8 @@ const definitionSchema = require('../schemas/definition')
 const Ajv = require('ajv')
 const ajv = new Ajv({ allErrors: true })
 
+const currentSchema = '1.0.0'
+
 class DefinitionService {
   constructor(harvest, summary, aggregator, curation, store, search) {
     this.harvestService = harvest
@@ -40,7 +42,8 @@ class DefinitionService {
     }
     const definitionCoordinates = this._getDefinitionCoordinates(coordinates)
     const existing = force ? null : await this.definitionStore.get(definitionCoordinates)
-    return this._cast(existing || (await this.computeAndStore(coordinates)))
+    const result = get(existing, 'schema') === currentSchema ? existing : await this.computeAndStore(coordinates)
+    return this._cast(result)
   }
 
   // ensure the defintion is a properly classed object
@@ -194,6 +197,7 @@ class DefinitionService {
     this._ensureCurationInfo(definition, curation)
     this._ensureSourceLocation(coordinates, definition)
     this._ensureCoordinates(coordinates, definition)
+    definition.schema = currentSchema
   }
 
   // Given a definition, calculate the scores for the definition and return an object with a score per dimension

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,6 +6,11 @@ const harvestFile = {
   location: config.get('FILE_STORE_LOCATION') || (process.platform === 'win32' ? 'c:/temp/cd' : '/tmp/cd')
 }
 
+const harvestStoreProvider = config.get('HARVEST_STORE_PROVIDER') || 'file'
+const harvestConnectionString =
+  config.get('HARVEST_AZBLOB_CONNECTION_STRING') || config.get('CRAWLER_AZBLOB_CONNECTION_STRING')
+const harvestContainerName = config.get('HARVEST_AZBLOB_CONTAINER_NAME') || config.get('CRAWLER_AZBLOB_CONTAINER_NAME')
+
 module.exports = {
   summary: {},
   curation: {
@@ -30,10 +35,10 @@ module.exports = {
       }
     },
     store: {
-      provider: config.get('HARVEST_STORE_PROVIDER') || 'file',
+      provider: harvestStoreProvider,
       azblob: {
-        connectionString: config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
-        containerName: config.get('HARVEST_AZBLOB_CONTAINER_NAME') || `harvest-${process.env.NODE_ENV}`
+        connectionString: harvestConnectionString,
+        containerName: harvestContainerName
       },
       file: harvestFile
     }
@@ -43,13 +48,12 @@ module.exports = {
   },
   definition: {
     store: {
-      provider: config.get('COMPONENT_STORE_PROVIDER') || config.get('HARVEST_STORE_PROVIDER') || 'file',
+      provider: config.get('DEFINITION_STORE_PROVIDER') || harvestStoreProvider,
       azblob: {
-        connectionString:
-          config.get('COMPONENT_AZBLOB_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
+        connectionString: config.get('DEFINITION_AZBLOB_CONNECTION_STRING') || harvestConnectionString,
         containerName:
-          config.get('COMPONENT_AZBLOB_CONTAINER_NAME') ||
-          config.get('HARVEST_AZBLOB_CONTAINER_NAME') + '-definition' ||
+          config.get('DEFINITION_AZBLOB_CONTAINER_NAME') ||
+          harvestContainerName + '-definition' ||
           `definition-${process.env.NODE_ENV}`
       },
       file: {

--- a/providers/stores/file.js
+++ b/providers/stores/file.js
@@ -41,7 +41,8 @@ class FileStore extends AbstractStore {
               const link = get(object, '_metadata.links.self.href')
               if (link) return resolve(coordinateClass.fromUrn(link).toString())
               // assume its a definition and look for a coordinates object
-              resolve(coordinateClass.fromObject(object.coordinates).toString())
+              const definitionCoordinates = coordinateClass.fromObject(object.coordinates)
+              resolve(definitionCoordinates ? definitionCoordinates.toString() : null)
             })
           )
         })

--- a/schemas/curation.json
+++ b/schemas/curation.json
@@ -166,7 +166,7 @@
     },
     "sourceLocation": {
       "type": "object",
-      "required": ["type", "provider", "revision", "url"],
+      "required": ["type", "provider", "name", "revision"],
       "additionalProperties": false,
       "properties": {
         "type": {
@@ -174,6 +174,18 @@
         },
         "provider": {
           "$ref": "#/definitions/provider"
+        },
+        "namespace": {
+          "type": "string",
+          "errorMessage": {
+            "type": "Namespace must be a string"
+          }
+        },
+        "name": {
+          "type": "string",
+          "errorMessage": {
+            "type": "Name must be a string"
+          }
         },
         "url": {
           "type": "string",

--- a/schemas/definition.json
+++ b/schemas/definition.json
@@ -10,7 +10,10 @@
     "coordinates": { "$ref": "#/definitions/coordinates" },
     "files": { "$ref": "#/definitions/files" },
     "described": { "$ref": "#/definitions/described" },
-    "licensed": { "$ref": "#/definitions/licensed" }
+    "licensed": { "$ref": "#/definitions/licensed" },
+    "schema": {
+      "type": "string"
+    }
   },
   "definitions": {
     "type": {
@@ -122,10 +125,16 @@
     "sourceLocation": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "provider", "url", "revision"],
+      "required": ["type", "provider", "name", "revision"],
       "properties": {
         "type": { "$ref": "#/definitions/type" },
         "provider": { "$ref": "#/definitions/provider" },
+        "namespace": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
         "url": {
           "type": "string",
           "format": "uri"

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -55,7 +55,14 @@ describe('Definition Service score computation', () => {
     const raw = createDefinition(undefined, files)
     set(raw, 'licensed.declared', 'MIT')
     set(raw, 'described.releaseDate', '2018-08-09')
-    set(raw, 'described.sourceLocation', { type: 'git', provider: 'github', url: 'http://foo', revision: '324325' })
+    set(raw, 'described.sourceLocation', {
+      type: 'git',
+      provider: 'github',
+      namespace: 'testns',
+      name: 'testname',
+      revision: '324325',
+      url: 'http://foo'
+    })
     const { service, coordinates } = setup(raw)
     const definition = await service.compute(coordinates)
     expect(definition.described.score).to.eq(2)

--- a/test/fixtures/curation-valid.1.yaml
+++ b/test/fixtures/curation-valid.1.yaml
@@ -2,38 +2,40 @@ coordinates:
   name: lodash
   provider: npmjs
   type: npm
-  namespace: "-"
+  namespace: '-'
 revisions:
   4.17.4:
     files:
-      - path: "/foo"
-        license: "MIT"
+      - path: '/foo'
+        license: 'MIT'
         attributions:
-          - "attribution1"
-          - "attribution2"
-      - path: "/bar"
-        license: "GPL"
+          - 'attribution1'
+          - 'attribution2'
+      - path: '/bar'
+        license: 'GPL'
         attributions:
-          - "attribution3"
-          - "attribution4"
-      - path: "/foo/bar"
-        license: "Apache-2.0"
+          - 'attribution3'
+          - 'attribution4'
+      - path: '/foo/bar'
+        license: 'Apache-2.0'
         attributions:
-          - "attribution3"
+          - 'attribution3'
     described:
       sourceLocation:
-        provider: "github"
-        revision: "ba6ed320e350f8b2eae4eb9683302ddac0ddf66f"
-        type: "git"
-        url: "https://github.com/caolan/async"
-      projectWebsite: "www.foo.bar.com"
-      issueTracker: "www.issueTracker.org"
-      releaseDate: "2018-01-18"
+        type: 'git'
+        provider: 'github'
+        namespace: 'clearlydefined'
+        name: 'testrepo'
+        revision: 'ba6ed320e350f8b2eae4eb9683302ddac0ddf66f'
+        url: 'https://github.com/clearlydefined/testrepo'
+      projectWebsite: 'www.foo.bar.com'
+      issueTracker: 'www.issueTracker.org'
+      releaseDate: '2018-01-18'
       facets:
         tests:
-          - "foo"
-          - "bar"
+          - 'foo'
+          - 'bar'
         doc:
-          - "foo"
+          - 'foo'
     licensed:
-      declared: "MIT"
+      declared: 'MIT'


### PR DESCRIPTION
Significant refactoring of how source locations are managed.

* source location now has a `namespace` and `name` just like other coordinates. The URL is computed. 
* Curation source locations still have a `url` but that will be migrated away
* add schema version for definitions and auto recompute if the cached def's schema is old
* make the service config settings independent of the crawlers. There was as a conflict on the store provider settings (crawler wanted `cd(file)` and service wanted `file`). Makes it cleaner anyway