### PR TITLE
fetch fresh curations from GitHub for every def compute

### DIFF
--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -147,7 +147,7 @@ class GitHubCurationService {
     const branch = await this.getBranchAndSha(pr)
     const branchName = branch.sha || branch.ref
     const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branchName}/${path}`
-    const content = await requestPromise({ url, method: 'GET', resolveWithFullResponse: true, simple: false })
+    const content = await requestPromise({ url, method: 'HEAD', resolveWithFullResponse: true, simple: false })
     if (content.statusCode !== 200) return null
     // If there is content, go and get it. This is a little wasteful (two calls) but
     // a) the vast majority of coordinates will not have any curation


### PR DESCRIPTION
The current code has the server caching a full copy of the curation repo locally and uses that when computing definitions. This works fine in most scenarios but when the user merges a curation, the service gets a webhook that immediately turns around and tries to (re)compute the definition. Unfortunately, the local copy of the repo will generally not have the "just merged" content. (The repo refresh period is 10 min but even if it was super fast, it will not be that fast)

This PR changes to hit GitHub all the time. That is not as bad as it seems. 

1) most components don't have curations
2) we can hit the GitHub raw content store to test for content without using tokens
3) we only recompute defintions when something might have changed (new blob, new curation) 

We can get better at this but for now we this is relatively simple and enables this important user flow.