### PR TITLE
set licensed.declared based on interesting files license

### DIFF
--- a/business/aggregator.js
+++ b/business/aggregator.js
@@ -35,7 +35,7 @@ const { flattenDeep, set } = require('lodash')
 class AggregationService {
   constructor(options) {
     this.options = options
-    // we take the configured precedence exoected to be highest first
+    // we take the configured precedence expected to be highest first
     this.workingPrecedence =
       options.precedence && flattenDeep(options.precedence.map(group => [...group].reverse()).reverse())
   }

--- a/business/aggregator.js
+++ b/business/aggregator.js
@@ -35,6 +35,7 @@ const { flattenDeep, set } = require('lodash')
 class AggregationService {
   constructor(options) {
     this.options = options
+    // we take the configured precedence exoected to be highest first
     this.workingPrecedence =
       options.precedence && flattenDeep(options.precedence.map(group => [...group].reverse()).reverse())
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -116,7 +116,7 @@ function buildSourceUrl(spec) {
       const fullName = `${spec.namespace}/${spec.name}`.replace(/\./g, '/')
       return `https://search.maven.org/remotecontent?filepath=${fullName}/${spec.revision}/${spec.name}-${
         spec.revision
-        }-sources.jar`
+      }-sources.jar`
     default:
       return null
   }
@@ -142,13 +142,13 @@ function updateSourceLocation(spec) {
 }
 
 /**
-   * Determine if a given filePath is a license file based on name
-   * Checks deeper than the root depending on coordinate type
-   *
-   * @param {string} filePath
-   * @param {EntityCoordinates} coordinates - optional to look deeper than the root based on coordinate type
-   * @returns {boolean}
-   */
+ * Determine if a given filePath is a license file based on name
+ * Checks deeper than the root depending on coordinate type
+ *
+ * @param {string} filePath
+ * @param {EntityCoordinates} coordinates - optional to look deeper than the root based on coordinate type
+ * @returns {boolean}
+ */
 function isLicenseFile(filePath, coordinates) {
   if (!filePath) return false
   filePath = filePath.toLowerCase()
@@ -167,7 +167,7 @@ function _normalizeVersion(version) {
 }
 
 const _licenseFileNames = ['license', 'license.txt', 'license.md', 'license.html']
-const _licenseLocations = { 'npm': ['package/'] }
+const _licenseLocations = { npm: ['package/'], maven: ['meta-inf/'] }
 
 const _licenseUrlOverrides = [
   {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -116,7 +116,7 @@ function buildSourceUrl(spec) {
       const fullName = `${spec.namespace}/${spec.name}`.replace(/\./g, '/')
       return `https://search.maven.org/remotecontent?filepath=${fullName}/${spec.revision}/${spec.name}-${
         spec.revision
-      }-sources.jar`
+        }-sources.jar`
     default:
       return null
   }
@@ -141,10 +141,33 @@ function updateSourceLocation(spec) {
   }
 }
 
+/**
+   * Determine if a given filePath is a license file based on name
+   * Checks deeper than the root depending on coordinate type
+   *
+   * @param {string} filePath
+   * @param {EntityCoordinates} coordinates - optional to look deeper than the root based on coordinate type
+   * @returns {boolean}
+   */
+function isLicenseFile(filePath, coordinates) {
+  if (!filePath) return false
+  filePath = filePath.toLowerCase()
+  const basePath = filePath.split('/')[0]
+  if (_licenseFileNames.includes(basePath)) return true
+  if (!coordinates) return false
+  for (const prefix of _licenseLocations[coordinates.type] || []) {
+    if (_licenseFileNames.includes(filePath.replace(prefix, ''))) return true
+  }
+  return false
+}
+
 function _normalizeVersion(version) {
   if (version == '1') return '1.0.0' // version '1' is not semver valid see https://github.com/clearlydefined/crawler/issues/124
   return semver.valid(version) ? version : null
 }
+
+const _licenseFileNames = ['license', 'license.txt', 'license.md', 'license.html']
+const _licenseLocations = { 'npm': ['package/'] }
 
 const _licenseUrlOverrides = [
   {
@@ -176,5 +199,6 @@ module.exports = {
   extractLicenseFromLicenseUrl,
   mergeDefinitions,
   buildSourceUrl,
-  updateSourceLocation
+  updateSourceLocation,
+  isLicenseFile
 }

--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -65,7 +65,7 @@ class ClearlyDescribedSummarizer {
   addLicenseFromFiles(result, data, coordinates) {
     if (!data.interestingFiles) return
     const licenses = data.interestingFiles
-      .map(file => file.license != 'NOASSERTION' && isLicenseFile(file.path, coordinates) ? file.license : null)
+      .map(file => (file.license !== 'NOASSERTION' && isLicenseFile(file.path, coordinates) ? file.license : null))
       .filter(x => x)
     setIfValue(result, 'licensed.declared', uniq(licenses).join(' AND '))
   }

--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -58,6 +58,7 @@ class ClearlyDescribedSummarizer {
 
   addInterestingFiles(result, data) {
     setIfValue(result, 'files', data.interestingFiles)
+    setIfValue(result, 'licensed.declared', this._extractLicenseFromFiles(data.interestingFiles))
   }
 
   addMavenData(result, data) {
@@ -99,6 +100,14 @@ class ClearlyDescribedSummarizer {
   addPyPiData(result, data) {
     setIfValue(result, 'described.releaseDate', extractDate(data.releaseDate))
     setIfValue(result, 'licensed.declared', data.declaredLicense)
+  }
+
+  _extractLicenseFromFiles(files) {
+    if (!files) return
+    for (const file of files) {
+      if (file.license && file.license != 'NOASSERTION')
+        return file.license
+    }
   }
 }
 

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -90,23 +90,14 @@ describe('Utils mergeDefinitions', () => {
 
 describe('Utils isLicenseFile', () => {
   it('should detect root level license files', () => {
-    const inputs = [
-      'LICENSE',
-      'license',
-      'License.txt',
-      'LICENSE.md',
-      'LICENSE.HTML',
-    ]
+    const inputs = ['LICENSE', 'license', 'License.txt', 'LICENSE.md', 'LICENSE.HTML']
     for (const input of inputs) {
       expect(utils.isLicenseFile(input), `input: ${input}`).to.be.true
     }
   })
 
   it('should not detect nested license files without coordinates', () => {
-    const inputs = [
-      'package/LICENSE',
-      'licenses/license',
-    ]
+    const inputs = ['package/LICENSE', 'licenses/license']
 
     for (const input of inputs) {
       expect(utils.isLicenseFile(input), `input: ${input}`).to.be.false
@@ -119,10 +110,23 @@ describe('Utils isLicenseFile', () => {
       'package/license',
       'package/License.txt',
       'package/LICENSE.md',
-      'package/LICENSE.HTML',
+      'package/LICENSE.HTML'
     ]
     for (const input of inputs) {
       expect(utils.isLicenseFile(input, { type: 'npm' }), `input: ${input}`).to.be.true
+    }
+  })
+
+  it('should detect package level license files for mavens', () => {
+    const inputs = [
+      'meta-inf/LICENSE',
+      'meta-inf/license',
+      'meta-inf/License.txt',
+      'meta-inf/LICENSE.md',
+      'meta-inf/LICENSE.HTML'
+    ]
+    for (const input of inputs) {
+      expect(utils.isLicenseFile(input, { type: 'maven' }), `input: ${input}`).to.be.true
     }
   })
 
@@ -132,7 +136,7 @@ describe('Utils isLicenseFile', () => {
       'package/license',
       'package/License.txt',
       'package/LICENSE.md',
-      'package/LICENSE.HTML',
+      'package/LICENSE.HTML'
     ]
     for (const input of inputs) {
       expect(utils.isLicenseFile(input, { type: 'nuget' }), `input: ${input}`).to.be.false
@@ -145,10 +149,23 @@ describe('Utils isLicenseFile', () => {
       'package/deeper/license',
       'deeper/package/License.txt',
       '.package/LICENSE.md',
-      'package2/LICENSE.HTML',
+      'package2/LICENSE.HTML'
     ]
     for (const input of inputs) {
       expect(utils.isLicenseFile(input, { type: 'npm' }), `input: ${input}`).to.be.false
+    }
+  })
+
+  it('should not detect random folder license files for mavens', () => {
+    const inputs = [
+      'foobar/LICENSE',
+      'package/deeper/license',
+      'deeper/package/License.txt',
+      '.package/LICENSE.md',
+      'package2/LICENSE.HTML'
+    ]
+    for (const input of inputs) {
+      expect(utils.isLicenseFile(input, { type: 'maven' }), `input: ${input}`).to.be.false
     }
   })
 

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -87,3 +87,72 @@ describe('Utils mergeDefinitions', () => {
     expect(base.files[1].license).to.eq('GPL')
   })
 })
+
+describe('Utils isLicenseFile', () => {
+  it('should detect root level license files', () => {
+    const inputs = [
+      'LICENSE',
+      'license',
+      'License.txt',
+      'LICENSE.md',
+      'LICENSE.HTML',
+    ]
+    for (const input of inputs) {
+      expect(utils.isLicenseFile(input), `input: ${input}`).to.be.true
+    }
+  })
+
+  it('should not detect nested license files without coordinates', () => {
+    const inputs = [
+      'package/LICENSE',
+      'licenses/license',
+    ]
+
+    for (const input of inputs) {
+      expect(utils.isLicenseFile(input), `input: ${input}`).to.be.false
+    }
+  })
+
+  it('should detect package level license files for npms', () => {
+    const inputs = [
+      'package/LICENSE',
+      'package/license',
+      'package/License.txt',
+      'package/LICENSE.md',
+      'package/LICENSE.HTML',
+    ]
+    for (const input of inputs) {
+      expect(utils.isLicenseFile(input, { type: 'npm' }), `input: ${input}`).to.be.true
+    }
+  })
+
+  it('should not detect package level license files for NuGets', () => {
+    const inputs = [
+      'package/LICENSE',
+      'package/license',
+      'package/License.txt',
+      'package/LICENSE.md',
+      'package/LICENSE.HTML',
+    ]
+    for (const input of inputs) {
+      expect(utils.isLicenseFile(input, { type: 'nuget' }), `input: ${input}`).to.be.false
+    }
+  })
+
+  it('should not detect random folder license files for npms', () => {
+    const inputs = [
+      'foobar/LICENSE',
+      'package/deeper/license',
+      'deeper/package/License.txt',
+      '.package/LICENSE.md',
+      'package2/LICENSE.HTML',
+    ]
+    for (const input of inputs) {
+      expect(utils.isLicenseFile(input, { type: 'npm' }), `input: ${input}`).to.be.false
+    }
+  })
+
+  it('should handle falsy input', () => {
+    expect(utils.isLicenseFile()).to.be.false
+  })
+})

--- a/test/providers/summary/clearlydefined.js
+++ b/test/providers/summary/clearlydefined.js
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const assert = require('assert')
+const summarizer = require('../../../providers/summary/clearlydefined')()
+
+describe('ClearlyDescribedSummarizer extractLicenseFromFiles', () => {
+  it('extracts MIT license from files', () => {
+    const files = [{
+      path: 'LICENSE',
+      token: 'abcd',
+      license: 'MIT'
+    }]
+    const output = summarizer._extractLicenseFromFiles(files)
+    assert.equal(output, 'MIT')
+  })
+
+  it('extracts falsy from files with no license', () => {
+    const files = [{
+      path: 'LICENSE',
+      token: 'abcd'
+    }]
+    const output = summarizer._extractLicenseFromFiles(files)
+    assert.equal(false, !!output)
+  })
+
+  it('extracts falsy from files with NOASSERTION', () => {
+    const files = [{
+      path: 'LICENSE',
+      token: 'abcd',
+      license: 'NOASSERTION'
+    }]
+    const output = summarizer._extractLicenseFromFiles(files)
+    assert.equal(false, !!output)
+  })
+})

--- a/test/providers/summary/clearlydefined.js
+++ b/test/providers/summary/clearlydefined.js
@@ -4,33 +4,101 @@
 const assert = require('assert')
 const summarizer = require('../../../providers/summary/clearlydefined')()
 
-describe('ClearlyDescribedSummarizer extractLicenseFromFiles', () => {
-  it('extracts MIT license from files', () => {
-    const files = [{
+describe('ClearlyDescribedSummarizer addLicenseFromFiles', () => {
+  it('declares MIT license from license file', () => {
+    const result = {}
+    const interestingFiles = [{
       path: 'LICENSE',
       token: 'abcd',
       license: 'MIT'
     }]
-    const output = summarizer._extractLicenseFromFiles(files)
-    assert.equal(output, 'MIT')
+    summarizer.addLicenseFromFiles(result, { interestingFiles })
+    assert.strictEqual(result.licensed.declared, 'MIT')
   })
 
-  it('extracts falsy from files with no license', () => {
-    const files = [{
+  it('declares MIT license from license file in package folder for npm', () => {
+    const result = {}
+    const interestingFiles = [{
+      path: 'package/LICENSE',
+      token: 'abcd',
+      license: 'MIT'
+    }]
+    summarizer.addLicenseFromFiles(result, { interestingFiles }, { type: 'npm' })
+    assert.strictEqual(result.licensed.declared, 'MIT')
+  })
+
+  it('declares nothing from license file in package folder for nuget', () => {
+    const result = {}
+    const interestingFiles = [{
+      path: 'package/LICENSE',
+      token: 'abcd',
+      license: 'MIT'
+    }]
+    summarizer.addLicenseFromFiles(result, { interestingFiles }, { type: 'nuget' })
+    assert.strictEqual(result.licensed, undefined)
+  })
+
+  it('declares spdx license expression from multiple license files', () => {
+    const result = {}
+    const interestingFiles = [{
+      path: 'LICENSE',
+      token: 'abcd',
+      license: 'MIT'
+    },
+    {
+      path: 'LICENSE.html',
+      token: 'abcd',
+      license: '0BSD'
+    }]
+    summarizer.addLicenseFromFiles(result, { interestingFiles })
+    assert.strictEqual(result.licensed.declared, 'MIT AND 0BSD')
+  })
+
+  it('declares single license for multiple similar license files', () => {
+    const result = {}
+    const interestingFiles = [{
+      path: 'LICENSE',
+      token: 'abcd',
+      license: 'MIT'
+    },
+    {
+      path: 'LICENSE.html',
+      token: 'abcd',
+      license: 'MIT'
+    }]
+    summarizer.addLicenseFromFiles(result, { interestingFiles })
+    assert.strictEqual(result.licensed.declared, 'MIT')
+  })
+
+  it('declares nothing from non-license files with valid license', () => {
+    const result = {}
+    const interestingFiles = [{
+      path: 'not-A-License',
+      token: 'abcd',
+      license: 'MIT'
+    }]
+    summarizer.addLicenseFromFiles(result, { interestingFiles })
+    assert.strictEqual(result.licensed, undefined)
+  })
+
+  it('declares nothing from license files with no license', () => {
+    const result = {}
+    const interestingFiles = [{
       path: 'LICENSE',
       token: 'abcd'
     }]
-    const output = summarizer._extractLicenseFromFiles(files)
-    assert.equal(false, !!output)
+    summarizer.addLicenseFromFiles(result, { interestingFiles })
+    assert.strictEqual(result.licensed, undefined)
   })
 
-  it('extracts falsy from files with NOASSERTION', () => {
-    const files = [{
+  it('declares nothing from license files with NOASSERTION', () => {
+    const result = {}
+    const interestingFiles = [{
       path: 'LICENSE',
       token: 'abcd',
       license: 'NOASSERTION'
     }]
-    const output = summarizer._extractLicenseFromFiles(files)
-    assert.equal(false, !!output)
+    summarizer.addLicenseFromFiles(result, { interestingFiles })
+    assert.strictEqual(result.licensed, undefined)
   })
 })

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -57,7 +57,7 @@ describe('ScanCode summarizer', () => {
     expect(summary.licensed.declared).to.eq('MIT')
   })
 
-  it('skips directory entries', () => {
+  it('skips foo directory entries', () => {
     const { coordinates, harvested } = setup([buildDirectory('foo'), buildFile('foo/LICENSE.md', 'GPL', [])])
     const summary = Summarizer().summarize(coordinates, harvested)
     validate(summary)
@@ -80,6 +80,28 @@ describe('ScanCode summarizer', () => {
     expect(summary.files[0].attributions).to.be.undefined
     expect(summary.files[0].path).to.equal('foo/LICENSE.md')
     expect(summary.files[0].license).to.equal('MIT')
+  })
+
+  it('detects npm license file in package folder', () => {
+    const { coordinates, harvested } = setup([buildDirectory('package'), buildFile('package/LICENSE.md', 'GPL', [])], 'npm/npmjs/-/test/1.0')
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.files.length).to.eq(1)
+    expect(summary.licensed.declared).to.be.equal('GPL')
+    expect(summary.files[0].attributions).to.be.undefined
+    expect(summary.files[0].path).to.equal('package/LICENSE.md')
+    expect(summary.files[0].license).to.equal('GPL')
+  })
+
+  it('skips nuget license file in package folder', () => {
+    const { coordinates, harvested } = setup([buildDirectory('package'), buildFile('package/LICENSE.md', 'GPL', [])], 'nuget/nuget/-/test/1.0')
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.files.length).to.eq(1)
+    expect(summary.licensed).to.be.undefined
+    expect(summary.files[0].attributions).to.be.undefined
+    expect(summary.files[0].path).to.equal('package/LICENSE.md')
+    expect(summary.files[0].license).to.equal('GPL')
   })
 
   it('handles scan with asserted license file even in a subdirectory', () => {


### PR DESCRIPTION
If we find a license on a harvested interesting file, set this to the `licensed.declared` property of the definition.

This runs early, so it can be overwritten by the package manager metadata.

@jeffmcaffer does this meet the bar for declaring a license?

The scenario I am thinking about is someone ships a `LICENSE` file with their package and doesn't register this license metadata anywhere else.