### PR TITLE
fix mongo tests and azure definition coordinates

### DIFF
--- a/providers/stores/abstractAzblobStore.js
+++ b/providers/stores/abstractAzblobStore.js
@@ -60,8 +60,7 @@ class AbstractAzBlobStore {
   }
 
   _toStoragePathFromCoordinates(coordinates) {
-    const storageCoordinates = Object.assign({}, coordinates, { tool: 'definition', toolVersion: 1 })
-    return AbstractFileStore.toStoragePathFromCoordinates(storageCoordinates)
+    return AbstractFileStore.toStoragePathFromCoordinates(coordinates)
   }
 
   _toResultCoordinatesFromStoragePath(path) {

--- a/providers/stores/mongo.js
+++ b/providers/stores/mongo.js
@@ -34,10 +34,11 @@ class MongoStore {
    */
   async list(coordinates) {
     // TODO protect this regex from DoS attacks
-    const list = await this.collection
-      .find({ _id: new RegExp('^' + this._getId(coordinates)) }, { projection: { _id: 1 } })
-      .toArray()
-    return list.map(entry => entry._id)
+    const list = await this.collection.find(
+      { _id: new RegExp('^' + this._getId(coordinates)) },
+      { projection: { _id: 1 } }
+    )
+    return (await list.toArray()).map(entry => entry._id)
   }
 
   /**

--- a/test/providers/store/azblobDefinition.js
+++ b/test/providers/store/azblobDefinition.js
@@ -66,16 +66,14 @@ describe('azblob Definition store', () => {
     const store = createStore()
     await store.store(definition)
     expect(store.blobService.createBlockBlobFromText.callCount).to.eq(1)
-    expect(store.blobService.createBlockBlobFromText.args[0][1]).to.eq(
-      'npm/npmjs/-/foo/revision/1.0/tool/definition/1.json'
-    )
+    expect(store.blobService.createBlockBlobFromText.args[0][1]).to.eq('npm/npmjs/-/foo/revision/1.0.json')
   })
 
   it('deletes a definition', async () => {
     const store = createStore()
     await store.delete(EntityCoordinates.fromString('npm/npmjs/-/foo/1.0'))
     expect(store.blobService.deleteBlob.callCount).to.eq(1)
-    expect(store.blobService.deleteBlob.args[0][1]).to.eq('npm/npmjs/-/foo/revision/1.0/tool/definition/1.json')
+    expect(store.blobService.deleteBlob.args[0][1]).to.eq('npm/npmjs/-/foo/revision/1.0.json')
   })
 
   it('gets a definition', async () => {


### PR DESCRIPTION
obsoletes #247 

* Azure blob definitions have moved to be in their own collection but we were still appending on a /tool/definition/1 to the coordinates. Not needed. Remove and fix up tests
* The Mongo definition store tests were left in a broken state. Fix them up.

