### PR TITLE
normalize fossology license summary to spdx only

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,12 +75,13 @@ function extractLicenseFromLicenseUrl(licenseUrl) {
     if (licenseUrlMatch) {
       if (licenseUrlOverride.license) return licenseUrlOverride.license
       if (licenseUrlOverride.licenseMatchGroup)
-        return _normalizeSpdx(licenseUrlMatch[licenseUrlOverride.licenseMatchGroup])
+        return normalizeSpdx(licenseUrlMatch[licenseUrlOverride.licenseMatchGroup])
     }
   }
 }
 
-function _normalizeSpdx(input) {
+// returns a properly cased spdx identifier or undefined if invalid
+function normalizeSpdx(input) {
   if (!input) return
   const loweredInput = input.toLowerCase()
   for (const spdx of spdxLicenseList) {
@@ -198,5 +199,6 @@ module.exports = {
   mergeDefinitions,
   buildSourceUrl,
   updateSourceLocation,
-  isLicenseFile
+  isLicenseFile,
+  normalizeSpdx
 }

--- a/providers/summary/fossology.js
+++ b/providers/summary/fossology.js
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const { setIfValue } = require('../../lib/utils')
+const { setIfValue, normalizeSpdx } = require('../../lib/utils')
+const { get } = require('lodash')
 
 class FOSSologySummarizer {
   constructor(options) {
@@ -26,9 +27,10 @@ class FOSSologySummarizer {
     const files = content.split('\n')
     return files
       .map(file => {
-        const path = /^File (.*?) contains/.exec(file)
-        const license = /license\(s\) (.*?)$/.exec(file)
-        if (path && path[1] && license && license[1]) return { path: path[1], license: license[1] }
+        const path = get(/^File (.*?) contains/.exec(file), '[1]')
+        const license = normalizeSpdx(get(/license\(s\) (.*?)$/.exec(file), '[1]'))
+        if (path && license) return { path, license }
+        if (path) return { path }
       })
       .filter(e => e)
   }

--- a/test/summary/fossology.js
+++ b/test/summary/fossology.js
@@ -22,7 +22,7 @@ describe('Fossology summarizer', () => {
   it('gets all the per file license info and attribution parties', () => {
     const { coordinates, harvested } = setup([
       buildFile('foo.txt', 'MIT', ['Bob', 'Fred', 'Bob', 'bob']),
-      buildFile('bar.txt', 'GPL', ['Jane', 'Fred', 'John'])
+      buildFile('bar.txt', 'GPL-3.0', ['Jane', 'Fred', 'John'])
     ])
     const summary = Summarizer().summarize(coordinates, harvested)
     validate(summary)
@@ -30,7 +30,22 @@ describe('Fossology summarizer', () => {
     expect(summary.files[0].path).to.equal('foo.txt')
     expect(summary.files[0].license).to.equal('MIT')
     expect(summary.files[1].path).to.equal('bar.txt')
-    expect(summary.files[1].license).to.equal('GPL')
+    expect(summary.files[1].license).to.equal('GPL-3.0')
+  })
+
+  it('does not apply non-spdx licenses', () => {
+    const { coordinates, harvested } = setup([buildFile('foo.txt', 'No_license_found'), buildFile('bar.txt', ' ')])
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.files).to.deep.eq([{ path: 'foo.txt' }, { path: 'bar.txt' }])
+  })
+
+  it('mixes spdx and non-spdx licenses correctly', () => {
+    // summary should come out
+    const { coordinates, harvested } = setup([buildFile('foo.txt', 'No_license_found'), buildFile('bar.txt', 'MIT')])
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.files).to.deep.eq([{ path: 'foo.txt' }, { path: 'bar.txt', license: 'MIT' }])
   })
 })
 


### PR DESCRIPTION
hitting the defintion route for `"git/github/reactiveui/reactiveui/8ed94f5d40248f409177e2cdd82e2029e9f7c601"`

before:
![image](https://user-images.githubusercontent.com/5168796/47389150-e3e46700-d6c8-11e8-98f8-2b1567a272f0.png)

after:
![image](https://user-images.githubusercontent.com/5168796/47389180-f2328300-d6c8-11e8-93aa-768293407cde.png)
