### PR TITLE
update swagger spec and UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,9 +12,6 @@ const serializeError = require('serialize-error')
 const requestId = require('request-id/express')
 const passport = require('passport')
 const swaggerUi = require('swagger-ui-express')
-const fs = require('fs')
-const yaml = require('js-yaml')
-const swaggerDoc = yaml.safeLoad(fs.readFileSync('./routes/swagger.yaml'))
 const loggerFactory = require('./providers/logging/logger')
 
 function createApp(config) {
@@ -84,9 +81,12 @@ function createApp(config) {
   app.use(helmet())
   app.use(requestId())
   app.use(cachingMiddleware(caching()))
+  app.use('/schemas', express.static('./schemas'))
 
   app.use(morgan('dev'))
-  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDoc))
+
+  const swaggerOptions = { swaggerUrl: 'http://localhost:4000/schemas/swagger.yaml' }
+  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(null, swaggerOptions))
   app.use('/webhook', bodyParser.raw({ limit: '5mb', type: '*/*' }), webhookRoute)
 
   // OAuth app initialization; skip if not configured (middleware can cope)

--- a/app.js
+++ b/app.js
@@ -85,7 +85,7 @@ function createApp(config) {
 
   app.use(morgan('dev'))
 
-  const swaggerOptions = { swaggerUrl: 'http://localhost:4000/schemas/swagger.yaml' }
+  const swaggerOptions = { swaggerUrl: `${config.endpoints.service}/schemas/swagger.yaml` }
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(null, swaggerOptions))
   app.use('/webhook', bodyParser.raw({ limit: '5mb', type: '*/*' }), webhookRoute)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4830,10 +4830,18 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
+    "swagger-ui-dist": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.20.0.tgz",
+      "integrity": "sha512-OOQep/BozOzF5H6Pa1T3SZW/kJ4M1kRyaq0TKtXRAwiZVgTWDbE8We/bx4Yq+FT1Em748U9UZco7Lum0PrKjRw=="
+    },
     "swagger-ui-express": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-2.0.13.tgz",
-      "integrity": "sha1-IDQ1GPIxPHiVps3/ZHjg7xPLn2Q="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.0.1.tgz",
+      "integrity": "sha512-KCwnxnn27Me9dBjD5nMjhfrw6WaC/Ad/AaZw6YgIICLirFKCeG23s2Vf0VP/Y3TNt/xmJRvg6rMXN9T7CXClHQ==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
     },
     "table": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "semver": "^5.4.1",
     "serialize-error": "^2.1.0",
     "spdx-license-list": "^4.1.0",
-    "swagger-ui-express": "^2.0.13",
+    "swagger-ui-express": "^4.0.1",
     "throat": "^4.1.0",
     "tmp": "0.0.33",
     "vso-node-api": "^6.2.8-preview",

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -8,8 +8,10 @@ info:
 servers:
   - url: https://api.clearlydefined.io
     description: Production environment
-  - url: https://dev.clearlydefined.io
+  - url: https://dev-api.clearlydefined.io
     description: Development environment
+  - url: http://localhost:4000
+    description: localhost environment
 
 paths:
   /curations/{type}/{provider}/{namespace}/{name}:
@@ -54,31 +56,32 @@ paths:
       responses:
         200:
           description: Component revision curation.
+  /curations:
     patch:
-      summary: Patches the curation of a component revision.
+      summary: Patches the curation of a (set of) component revision.
       tags:
         - curations
-      parameters:
-        - $ref: '#/components/parameters/type'
-        - $ref: '#/components/parameters/provider'
-        - $ref: '#/components/parameters/namespace'
-        - $ref: '#/components/parameters/name'
-        - $ref: '#/components/parameters/revision'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: /schemas/curations-1.0.json
       responses:
         200:
-          description: Nothing. TODO - this should be 204 or return something.
+          description: A summary of the curation (PR) created
+          content:
+            application/json:
+              schema:
+                type: object
+
   /harvest:
     post:
       summary: Post the given components to be harvested
       tags:
         - harvest
       requestBody:
-        description: A single or array of requests
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/bodies/request'
+        $ref: '#/components/requestBodies/request'
       responses:
         201:
           description: Harvested file has been accepted.
@@ -186,19 +189,14 @@ paths:
       tags:
         - definitions
       requestBody:
-        description: List of components to report on.
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/bodies/componentList'
+        $ref: '#/components/requestBodies/componentList'
       responses:
         200:
           description: Status request has been accepted.
           content:
             application/json:
               schema:
-                $ref: '#components/bodies/definitionList'
+                $ref: '#/components/requestBodies/definitionList'
     get:
       summary: Gets the coordinates for all definitions that match the given pattern in the specified part of the definition.
       tags:
@@ -293,69 +291,102 @@ tags:
     description: Definition attachments - Raw content of attachments for harvested component data
 
 components:
-  bodies:
-    componentList:
-      name: componentList
-      description: A list of components to operate on. Each entry is a path describing a component, potentially with a version.
-      type: array
-      items: string
-      example:
-        - git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca
-        - npm/npmjs/-/redie/0.3.0
-    request:
-      name: request
-      description: A request to harvest a component. One of harvest.json#definitions/requests or harvest.json#definitions/request
+  schemas:
+    harvestRequest:
       type: object
+      properties:
+        tool:
+          type: string
+        path:
+          type: string
       example:
         - tool: package
           path: npm/npmjs/-/redie/0.3.0
         - tool: source
           path: git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca
 
+  requestBodies:
+    componentList:
+      description: A list of components to operate on. Each entry is a path describing a component, potentially with a version.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              - git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca
+              - npm/npmjs/-/redie/0.3.0
+    request:
+      description: A request to harvest a component. One of harvest.json#definitions/requests or harvest.json#definitions/request
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              tool:
+                type: string
+              path:
+                type: string
+            example:
+              - tool: package
+                path: npm/npmjs/-/redie/0.3.0
+              - tool: source
+                path: git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca
     definitionList:
-      type: object
       description: A list of component definitions that are available (see definition.json#definitions/componentDefinitionList)
-      example:
-        'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca':
-          coordinates:
-            type: git
-            provider: github
-            namespace: microsoft
-            name: redie
-            revision: 194269b5b7010ad6f8dc4ef608c88128615031ca
-          described:
-            sourceLocation:
-              type: git
-              provider: github
-              namespace: microsoft
-              name: redie
-              revision: 194269b5b7010ad6f8dc4ef608c88128615031ca
-            releaseDate: '2018-01-29'
-          licensed:
-            declared: MIT
-            facets:
-              core:
-                attribution:
-                  parties:
-                    - Microsoft Corporation
-                discovered:
-                  - MIT
-                  - GPL
-
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca':
+                coordinates:
+                  type: git
+                  provider: github
+                  namespace: microsoft
+                  name: redie
+                  revision: 194269b5b7010ad6f8dc4ef608c88128615031ca
+                described:
+                  sourceLocation:
+                    type: git
+                    provider: github
+                    namespace: microsoft
+                    name: redie
+                    revision: 194269b5b7010ad6f8dc4ef608c88128615031ca
+                  releaseDate: '2018-01-29'
+                licensed:
+                  declared: MIT
+                  facets:
+                    core:
+                      attribution:
+                        parties:
+                          - Microsoft Corporation
+                      discovered:
+                        - MIT
+                        - GPL
     outputSummaryList:
-      type: object
       description: A list of tool outputs that are available (see harvest.json#definitions/definitionSummaryList)
-      example:
-        'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca':
-          clearlydefined:
-            - 1
-          scancode:
-            - 2.2.1
-        'npm/npmjs/-/redie/0.3.0':
-          clearlydefined:
-            - 1
-          scancode:
-            - 2.2.1
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca':
+                clearlydefined:
+                  - 1
+                scancode:
+                  - 2.2.1
+              'npm/npmjs/-/redie/0.3.0':
+                clearlydefined:
+                  - 1
+                scancode:
+                  - 2.2.1
 
   parameters:
     type:


### PR DESCRIPTION
fixes #238 

turns out there were multiple issues. 
* old version of swagger-ui 
* swagger.yaml that was invalid (halfway between 2.0 and 3.0 format)
* not supplying a swagger url so swagger could not figure out base urls for referenced docs
* no route serving up the referenced files

This PR addresses all of these and gets the structure in the right format. There are still issues with the actual swagger being out of date and likely some incompatibilities with JSON schema and swagger (e.g., pattern properties). Those can be worked out in a subsequent PR.