### PR TITLE
Add a suggestions API

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,6 +61,9 @@ function createApp(config) {
   curationService.definitionService = definitionService
   const definitionsRoute = require('./routes/definitions')(definitionService)
 
+  const suggestionService = require('./business/suggestionService')(definitionService, definitionStore)
+  const suggestionsRoute = require('./routes/suggestions')(suggestionService)
+
   const attachmentsRoute = require('./routes/attachments')(attachmentStore)
 
   const githubSecret = config.webhook.githubSecret
@@ -121,6 +124,7 @@ function createApp(config) {
   app.use('/curations', curationsRoute)
   app.use('/definitions', definitionsRoute)
   app.use('/attachments', attachmentsRoute)
+  app.use('/suggestions', suggestionsRoute)
 
   // catch 404 and forward to error handler
   const requestHandler = (req, res, next) => {

--- a/business/suggestionService.js
+++ b/business/suggestionService.js
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { find, findLast, get, set } = require('lodash')
+const EntityCoordinates = require('../lib/entityCoordinates')
+
+class SuggestionService {
+  constructor(definitionService, definitionStore) {
+    this.definitionService = definitionService
+    this.definitionStore = definitionStore
+  }
+
+  /**
+   * Get suggestions for the given coordinates.
+   *
+   * @param {EntityCoordinates} coordinates - The entity for which we are looking for suggestions
+   * @returns {Suggestion} A set of suggested fixes for the definition at the given coordinates.
+   * `null` is returned if no such coordinates are found.
+   */
+  async get(coordinates) {
+    const related = await this._getRelatedDefinitions(coordinates)
+    if (!related) return null
+    const result = this._createBaseSuggestion(coordinates)
+    await this._collectLicenseSuggestions(related, result)
+    return result
+  }
+
+  async _getRelatedDefinitions(coordinates) {
+    const related = await this.definitionStore.list(coordinates.asRevisionless(), 'definitions')
+    const sorted = related.sort((one, two) => (one.described.releaseDate > two.described.releaseDate ? 1 : -1))
+    const index = sorted.findIndex(entry => entry.coordinates.revision === coordinates.revision)
+    if (index === -1) return null
+    const before = sorted.slice(Math.max(index - 3, 0), index).reverse()
+    const after = sorted.slice(index + 1, index + 3)
+    return { sorted, index, before, after }
+  }
+
+  _createBaseSuggestion(coordinates) {
+    return {
+      coordinates: coordinates
+    }
+  }
+
+  _collectLicenseSuggestions(related, suggestions) {
+    // for now only do suggestions if there is something missing
+    const definition = related.sorted[related.index]
+    if (get(definition, 'licensed.declared') || !(related.before.length + related.after.length)) return
+    const before = findLast(related.before, entry => get(entry, 'licensed.declared'))
+    const after = find(related.after, entry => get(entry, 'licensed.declared'))
+    const suggestionDefinitions = [before, after].filter(x => x)
+    const suggestionObjects = suggestionDefinitions.map(suggestion => suggestion.licensed.declared)
+    set(suggestions, 'licensed.declared', suggestionObjects)
+  }
+}
+
+module.exports = (definitionService, definitionStore) => new SuggestionService(definitionService, definitionStore)

--- a/providers/stores/mongo.js
+++ b/providers/stores/mongo.js
@@ -32,13 +32,15 @@ class MongoStore {
    * @param {EntityCoordinates} coordinates
    * @returns A list of matching coordinates i.e. [ 'npm/npmjs/-/JSONStream/1.3.3' ]
    */
-  async list(coordinates) {
+  async list(coordinates, expand = null) {
     // TODO protect this regex from DoS attacks
     const list = await this.collection.find(
       { _id: new RegExp('^' + this._getId(coordinates)) },
-      { projection: { _id: 1 } }
+      { projection: { _id: expand === 'definitions' ? 0 : 1 } }
     )
-    return (await list.toArray()).map(entry => entry._id)
+    const result = await list.toArray()
+    if (expand === 'definitions') return result
+    return result.map(entry => entry._id)
   }
 
   /**

--- a/routes/suggestions.js
+++ b/routes/suggestions.js
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const asyncMiddleware = require('../middleware/asyncMiddleware')
+const express = require('express')
+const router = express.Router()
+const utils = require('../lib/utils')
+
+// Get some suggestions for a specific revision of a component
+router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(getSuggestions))
+async function getSuggestions(request, response) {
+  const coordinates = utils.toEntityCoordinatesFromRequest(request)
+  const result = await suggestionService.get(coordinates)
+  if (result) return response.status(200).send(result)
+  response.sendStatus(404)
+}
+
+let suggestionService
+
+function setup(service) {
+  suggestionService = service
+  return router
+}
+
+module.exports = setup

--- a/test/business/suggestionServiceTest.js
+++ b/test/business/suggestionServiceTest.js
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const sinon = require('sinon')
+const SuggestionService = require('../../business/suggestionService')
+const EntityCoordinates = require('../../lib/entityCoordinates')
+const { setIfValue } = require('../../lib/utils')
+const moment = require('moment')
+const { get } = require('lodash')
+
+const testCoordinates = EntityCoordinates.fromString('npm/npmjs/-/test/10.0')
+
+describe('Suggestion Service', () => {
+  it('gets suggestion for missing declared license', async () => {
+    const now = moment()
+    const definition = createDefinition(testCoordinates, now)
+    const before1 = createModifiedDefinition(testCoordinates, now, -3, 'MIT')
+    const before2 = createModifiedDefinition(testCoordinates, now, -5, 'MIT')
+    const after = createModifiedDefinition(testCoordinates, now, 2, 'GPL')
+    const others = [before1, before2, after]
+    const service = setup(definition, others)
+    const suggestions = await service.get(testCoordinates)
+    expect(suggestions).to.not.be.null
+    const declared = get(suggestions, 'licensed.declared')
+    expect(declared).to.equalInAnyOrder(['MIT', 'GPL'])
+  })
+})
+
+function createModifiedDefinition(coordinates, now, amount, license, files) {
+  const newCoordinates = { ...coordinates, revision: `${coordinates.revision.split('.')[0] + amount}.0` }
+  const newDate = moment(now).add(amount, 'days')
+  return createDefinition(newCoordinates, newDate, license, files)
+}
+
+function createDefinition(coordinates, releaseDate, license, files) {
+  const result = { coordinates }
+  setIfValue(result, 'licensed.declared', license)
+  setIfValue(result, 'described.releaseDate', releaseDate.toDate())
+  setIfValue(result, 'files', files)
+  return result
+}
+
+function buildFile(path, license, holders) {
+  const result = { path }
+  setIfValue(result, 'license', license)
+  setIfValue(result, 'attributions', holders ? holders.map(entry => `Copyright ${entry}`) : null)
+  return result
+}
+
+function setup(definition, others) {
+  const definitionService = { get: sinon.stub().callsFake(() => Promise.resolve(definition)) }
+  const definitionStore = { list: () => Promise.resolve([...others, definition]) }
+  return SuggestionService(definitionService, definitionStore)
+}


### PR DESCRIPTION
To enable new workflows that suggest curations to users, we need an API that finds/creates suggestions. This is the first of what is sure to be a long line of suggestion algorithms. The point of this PR is to plumb in an API and some basic suggestions to demonstrate the function.

* Only suggesting values for missing things
* Only consults other versions of the same component (i.e., it does not follow other types of relations like source location)
* Pretty rudimentary context info for the origin of each suggestion