### PR TITLE
add curations/sync route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,30 @@
   "requires": true,
   "dependencies": {
     "@octokit/rest": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-14.0.3.tgz",
-      "integrity": "sha512-r0AbDS6aVYGQEyW5w4NIV1+ikTUq53gDXVutFo9bW88wC/ce/pGoNI5+2tmKJ5s2tPmQh/iqUpdfua2ssFVwqQ==",
+      "version": "14.0.9",
+      "resolved": "http://registry.npmjs.org/@octokit/rest/-/rest-14.0.9.tgz",
+      "integrity": "sha512-irP9phKfTXEZIcW2R+VNCtGHZJrXMWmSYp6RRfFn4BtAqtDRXF5z9JxCEQlAhNBf6X1koNi5k49tIAAAEJNlVQ==",
       "requires": {
         "before-after-hook": "^1.1.0",
         "debug": "^3.1.0",
-        "dotenv": "^4.0.0",
-        "https-proxy-agent": "^2.1.0",
+        "is-array-buffer": "^1.0.0",
         "is-stream": "^1.1.0",
         "lodash": "^4.17.4",
-        "proxy-from-env": "^1.0.0",
         "url-template": "^2.0.8"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -65,14 +68,6 @@
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
-      }
-    },
-    "agent-base": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
@@ -403,9 +398,9 @@
       }
     },
     "before-after-hook": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
-      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.2.0.tgz",
+      "integrity": "sha512-wI3QtdLppHNkmM1VgRVLCrlWCKk/YexlPicYbXPs4eYdd1InrUCTFsx5bX1iUQzzMsoRXXPpM1r+p7JEJJydag=="
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -1126,11 +1121,6 @@
         "is-obj": "^1.0.0"
       }
     },
-    "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
-    },
     "double-ended-queue": {
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
@@ -1171,19 +1161,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
-    },
-    "es6-promise": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2578,25 +2555,6 @@
         "sshpk": "^1.7.0"
       }
     },
-    "https-proxy-agent": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
-      "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
-      "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -2698,6 +2656,11 @@
           }
         }
       }
+    },
+    "is-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-lj035IqdAwsodoRGs9/8+Kn3HPoz9CTuZbcw63afugWonxigvUVeHY5d6Ve1O+s1N3RCk7txo2TIWQLbU0SuNA=="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -3963,11 +3926,6 @@
         "forwarded": "~0.1.0",
         "ipaddr.js": "1.4.0"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "proxyquire": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/clearlydefined/service.git"
   },
   "dependencies": {
-    "@octokit/rest": "^14.0.0",
+    "@octokit/rest": "^14.0.9",
     "ajv": "^6.5.2",
     "ajv-errors": "^1.0.0",
     "applicationinsights": "^1.0.6",

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -11,6 +11,7 @@ const Github = require('../../lib/github')
 const Curation = require('../../lib/curation')
 const EntityCoordinates = require('../../lib/entityCoordinates')
 const tmp = require('tmp')
+const loggerFactory = require('../logging/logger')
 tmp.setGracefulCleanup()
 
 // Responsible for managing curation patches in a store
@@ -26,7 +27,7 @@ class GitHubCurationService {
     this.curationUpdateTime = null
     this.tempLocation = null
     this.github = Github.getClient(options)
-    this.logger = require('../logging/logger')()
+    this.logger = loggerFactory()
   }
 
   get tmpOptions() {
@@ -40,8 +41,8 @@ class GitHubCurationService {
    * Enumerate all contributions in GitHub and in the store and updates any out of sync
    * @returns Promise indicating the operation is complete. The value of the resolved promise is undefined.
    */
-  async syncAllContributions() {
-    let response = await this.github.pullRequests.getAll({
+  async syncAllContributions(client) {
+    let response = await client.pullRequests.getAll({
       owner: this.options.owner,
       repo: this.options.repo,
       per_page: 100,

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -48,11 +48,14 @@ class GitHubCurationService {
       per_page: 100,
       state: 'all'
     })
-    let prs = response.data
+    this._processContributions(response.data)
     while (this.github.hasNextPage(response)) {
       response = await this.github.getNextPage(response)
-      prs = prs.concat(response.data)
+      this._processContributions(response.data)
     }
+  }
+
+  async _processContributions(prs) {
     for (let pr of prs) {
       const storedContribution = await this.store.getContribution(pr.number)
       if (new Date(get(storedContribution, 'pr.updated_at')).getTime() >= new Date(pr.updated_at).getTime()) continue

--- a/providers/curation/memoryStore.js
+++ b/providers/curation/memoryStore.js
@@ -19,6 +19,10 @@ class MemoryStore {
     })
   }
 
+  getContribution(prNumber) {
+    return this.curations[prNumber]
+  }
+
   updateContribution(pr, curations = null) {
     if (curations) {
       const files = {}

--- a/providers/curation/memoryStore.js
+++ b/providers/curation/memoryStore.js
@@ -20,7 +20,7 @@ class MemoryStore {
   }
 
   getContribution(prNumber) {
-    return this.curations[prNumber]
+    return this.contributions[prNumber]
   }
 
   updateContribution(pr, curations = null) {

--- a/providers/curation/mongoCurationStore.js
+++ b/providers/curation/mongoCurationStore.js
@@ -47,6 +47,15 @@ class MongoCurationStore {
   }
 
   /**
+   * Retrieve the contribution by number
+   * @param {Number} prNumber - the PR number as provided by GitHub
+   * @returns the Curations found if any
+   */
+  getContribution(prNumber) {
+    return this.collection.findOne({ _id: prNumber })
+  }
+
+  /**
    * Update the contribution entry for the given PR and record the associated curations -- the
    * actual file content in the PR. If the curations are not provided, just the PR data is updated,
    * any existing curation data is preserved.

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -6,6 +6,7 @@ const express = require('express')
 const router = express.Router()
 const utils = require('../lib/utils')
 const Curation = require('../lib/curation')
+const { permissionsCheck } = require('../middleware/permissions')
 
 // Get a proposed patch for a specific revision of a component
 router.get('/:type/:provider/:namespace/:name/:revision/pr/:pr', asyncMiddleware(getChangesForCoordinatesInPr))
@@ -69,10 +70,10 @@ async function updateCurations(request, response) {
   })
 }
 
-router.post('/sync', asyncMiddleware(syncAllContributions))
+router.post('/sync', permissionsCheck('curate'), asyncMiddleware(syncAllContributions))
 
 async function syncAllContributions(request, response) {
-  await curationService.syncAllContributions()
+  await curationService.syncAllContributions(request.app.locals.user.github.client)
   response.send({ status: 'OK' })
 }
 

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -69,6 +69,13 @@ async function updateCurations(request, response) {
   })
 }
 
+router.post('/sync', asyncMiddleware(syncAllContributions))
+
+async function syncAllContributions(request, response) {
+  await curationService.syncAllContributions()
+  response.send({ status: 'OK' })
+}
+
 let curationService
 
 function setup(service) {

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -30,8 +30,9 @@ async function handleGitHubCall(request, response) {
     switch (body.action) {
       case 'opened':
       case 'synchronize': {
-        curationService.validateContributions(pr.number, pr.head.sha)
-        await curationService.updateContribution(pr)
+        const curations = curationService.getContributedCurations(pr.number, pr.head.sha)
+        curationService.validateContributions(pr.number, pr.head.sha, curations)
+        await curationService.updateContribution(pr, curations)
         break
       }
       case 'closed': {

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -28,16 +28,14 @@ async function handleGitHubCall(request, response) {
   const pr = body.pull_request
   try {
     switch (body.action) {
-      case 'opened': {
-        await curationService.prOpened(pr)
+      case 'opened':
+      case 'synchronize': {
+        curationService.validateContributions(pr.number, pr.head.sha)
+        await curationService.updateContribution(pr)
         break
       }
       case 'closed': {
-        await (pr.merged ? curationService.prMerged(pr) : curationService.prClosed(pr))
-        break
-      }
-      case 'synchronize': {
-        await curationService.prUpdated(pr)
+        await curationService.updateContribution(pr)
         break
       }
     }

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -28,7 +28,7 @@ describe('Github Curation Service', () => {
     sinon.stub(service, '_getContributedCurations').callsFake(() => {
       return [createCuration()]
     })
-    await service._validateContributions(1, '42', 'testBranch')
+    await service.validateContributions('42', 'testBranch')
     expect(service._postCommitStatus.calledTwice).to.be.true
     expect(service._postCommitStatus.getCall(0).args[2]).to.be.eq('pending')
     expect(service._postCommitStatus.getCall(1).args[2]).to.be.eq('success')
@@ -40,7 +40,7 @@ describe('Github Curation Service', () => {
     sinon.stub(service, '_getContributedCurations').callsFake(() => {
       return [createInvalidCuration()]
     })
-    await service._validateContributions(1, '42', 'testBranch')
+    await service.validateContributions('42', 'testBranch')
     expect(service._postCommitStatus.calledTwice).to.be.true
     expect(service._postCommitStatus.getCall(0).args[2]).to.be.eq('pending')
     expect(service._postCommitStatus.getCall(1).args[2]).to.be.eq('error')

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -12,10 +12,10 @@ const { find } = require('lodash')
 describe('Github Curation Service', () => {
   it('invalidates coordinates when handling merge', async () => {
     const service = createService()
-    sinon.stub(service, '_getContributedCurations').callsFake(() => {
+    sinon.stub(service, 'getContributedCurations').callsFake(() => {
       return [createCuration(simpleCuration)]
     })
-    const result = await service._getContributedCurations(1, 42)
+    const result = await service.getContributedCurations(1, 42)
     const coords = { ...simpleCuration.coordinates }
     const resultCoords = result.map(change => change.data.coordinates)
     expect(resultCoords).to.be.deep.equalInAnyOrder([coords])
@@ -25,10 +25,11 @@ describe('Github Curation Service', () => {
   it('validates valid PR change', async () => {
     const service = createService()
     sinon.stub(service, '_postCommitStatus').returns(Promise.resolve())
-    sinon.stub(service, '_getContributedCurations').callsFake(() => {
+    sinon.stub(service, 'getContributedCurations').callsFake(() => {
       return [createCuration()]
     })
-    await service.validateContributions('42', 'testBranch')
+    const curations = await service.getContributedCurations(42, 'testBranch')
+    await service.validateContributions('42', 'testBranch', curations)
     expect(service._postCommitStatus.calledTwice).to.be.true
     expect(service._postCommitStatus.getCall(0).args[2]).to.be.eq('pending')
     expect(service._postCommitStatus.getCall(1).args[2]).to.be.eq('success')
@@ -37,10 +38,11 @@ describe('Github Curation Service', () => {
   it('validates invalid PR change', async () => {
     const service = createService()
     sinon.stub(service, '_postCommitStatus').returns(Promise.resolve())
-    sinon.stub(service, '_getContributedCurations').callsFake(() => {
+    sinon.stub(service, 'getContributedCurations').callsFake(() => {
       return [createInvalidCuration()]
     })
-    await service.validateContributions('42', 'testBranch')
+    const curations = await service.getContributedCurations(42, 'testBranch')
+    await service.validateContributions('42', 'testBranch', curations)
     expect(service._postCommitStatus.calledTwice).to.be.true
     expect(service._postCommitStatus.getCall(0).args[2]).to.be.eq('pending')
     expect(service._postCommitStatus.getCall(1).args[2]).to.be.eq('error')

--- a/test/providers/curation/githubPRs.js
+++ b/test/providers/curation/githubPRs.js
@@ -30,11 +30,22 @@ const files = {
 }
 
 const prs = {
-  12: { number: 12, head: { ref: 'master', sha: '32' }, files: [{ filename: 'curations/npm/npmjs/-/foo.yaml' }] },
+  11: {
+    number: 12,
+    head: { ref: 'master', sha: '32' },
+    files: [{ filename: 'curations/npm/npmjs/-/foo.yaml' }]
+  },
+  12: {
+    number: 12,
+    head: { ref: 'master', sha: '32' },
+    files: [{ filename: 'curations/npm/npmjs/-/foo.yaml' }],
+    merged_at: '2018-11-13T02:44:34Z'
+  },
   13: {
     number: 13,
     head: { ref: 'master', sha: '72' },
-    files: [{ filename: 'curations/npm/npmjs/-/foo.yaml' }, { filename: 'curations/npm/npmjs/-/bar.yaml' }]
+    files: [{ filename: 'curations/npm/npmjs/-/foo.yaml' }, { filename: 'curations/npm/npmjs/-/bar.yaml' }],
+    merged_at: '2018-11-13T02:44:34Z'
   }
 }
 
@@ -57,7 +68,7 @@ describe('Curation service pr events', () => {
 
   it('handles open', async () => {
     const service = createService()
-    await service.prOpened(prs[12])
+    await service.updateContribution(prs[11])
     const updateSpy = service.store.updateContribution
     expect(updateSpy.calledOnce).to.be.true
     expect(updateSpy.args[0][0].number).to.be.equal(12)
@@ -67,7 +78,7 @@ describe('Curation service pr events', () => {
 
   it('handles update', async () => {
     const service = createService()
-    await service.prUpdated(prs[12])
+    await service.updateContribution(prs[11])
     const updateSpy = service.store.updateContribution
     expect(updateSpy.calledOnce).to.be.true
     expect(updateSpy.args[0][0].number).to.be.equal(12)
@@ -77,12 +88,13 @@ describe('Curation service pr events', () => {
 
   it('handles merge', async () => {
     const service = createService()
-    await service.prMerged(prs[12])
+    await service.updateContribution(prs[12])
 
     const updateSpy = service.store.updateContribution
     expect(updateSpy.calledOnce).to.be.true
     expect(updateSpy.args[0][0].number).to.be.equal(12)
-    expect(updateSpy.args[0][1]).to.be.undefined
+    const data = updateSpy.args[0][1].map(curation => curation.data)
+    expect(data).to.be.deep.equalInAnyOrder([complexCuration()])
 
     const curationSpy = service.store.updateCurations
     expect(curationSpy.calledOnce).to.be.true
@@ -100,7 +112,7 @@ describe('Curation service pr events', () => {
 
   it('handles close', async () => {
     const service = createService()
-    await service.prClosed(prs[12])
+    await service.updateContribution(prs[12])
     const updateSpy = service.store.updateContribution
     expect(updateSpy.calledOnce).to.be.true
     expect(updateSpy.args[0][0].number).to.be.equal(12)
@@ -117,12 +129,13 @@ describe('Curation service pr events', () => {
 
   it('handles failure to compute one definition of multiple', async () => {
     const service = createService()
-    await service.prMerged(prs[13])
+    await service.updateContribution(prs[13])
 
     const updateSpy = service.store.updateContribution
     expect(updateSpy.calledOnce).to.be.true
     expect(updateSpy.args[0][0].number).to.be.equal(13)
-    expect(updateSpy.args[0][1]).to.be.undefined
+    const data = updateSpy.args[0][1].map(curation => curation.data)
+    expect(data).to.be.deep.equalInAnyOrder([complexCuration('foo'), complexCuration('bar')])
 
     const curationSpy = service.store.updateCurations
     expect(curationSpy.calledOnce).to.be.true

--- a/test/routes/webhookGitHubTests.js
+++ b/test/routes/webhookGitHubTests.js
@@ -113,6 +113,7 @@ function createLogger() {
 
 function createCurationService() {
   return {
+    getContributedCurations: sinon.stub(),
     updateContribution: sinon.stub(),
     validateContributions: sinon.stub()
   }

--- a/test/routes/webhookGitHubTests.js
+++ b/test/routes/webhookGitHubTests.js
@@ -15,10 +15,7 @@ describe('Webhook Route for GitHub calls', () => {
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
     await router._handlePost(request, response)
     expect(response.statusCode).to.be.eq(200)
-    expect(service.prOpened.calledOnce).to.be.false
-    expect(service.prClosed.calledOnce).to.be.false
-    expect(service.prMerged.calledOnce).to.be.false
-    expect(service.prUpdated.calledOnce).to.be.false
+    expect(service.updateContribution.calledOnce).to.be.false
     expect(response._getData()).to.be.eq('')
     expect(logger.error.notCalled).to.be.true
     expect(logger.info.notCalled).to.be.true
@@ -33,10 +30,7 @@ describe('Webhook Route for GitHub calls', () => {
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
     await router._handlePost(request, response)
     expect(response.statusCode).to.be.eq(400)
-    expect(service.prOpened.calledOnce).to.be.false
-    expect(service.prClosed.calledOnce).to.be.false
-    expect(service.prMerged.calledOnce).to.be.false
-    expect(service.prUpdated.calledOnce).to.be.false
+    expect(service.updateContribution.calledOnce).to.be.false
     expect(response._getData().startsWith('Missing')).to.be.true
   })
 
@@ -49,10 +43,7 @@ describe('Webhook Route for GitHub calls', () => {
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
     await router._handlePost(request, response)
     expect(response.statusCode).to.be.eq(400)
-    expect(service.prOpened.calledOnce).to.be.false
-    expect(service.prClosed.calledOnce).to.be.false
-    expect(service.prMerged.calledOnce).to.be.false
-    expect(service.prUpdated.calledOnce).to.be.false
+    expect(service.updateContribution.calledOnce).to.be.false
     expect(response._getData().startsWith('Missing')).to.be.true
   })
 
@@ -81,7 +72,8 @@ describe('Webhook Route for GitHub calls', () => {
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
     await router._handlePost(request, response)
     expect(response.statusCode).to.be.eq(200)
-    expect(service.prClosed.calledOnce).to.be.true
+    expect(service.validateContributions.calledOnce).to.be.false
+    expect(service.updateContribution.calledOnce).to.be.true
     expect(logger.info.calledOnce).to.be.true
     expect(logger.error.notCalled).to.be.true
   })
@@ -94,7 +86,8 @@ describe('Webhook Route for GitHub calls', () => {
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
     await router._handlePost(request, response)
     expect(response.statusCode).to.be.eq(200)
-    expect(service.prOpened.calledOnce).to.be.true
+    expect(service.validateContributions.calledOnce).to.be.true
+    expect(service.updateContribution.calledOnce).to.be.true
     expect(logger.info.calledOnce).to.be.true
     expect(logger.error.notCalled).to.be.true
   })
@@ -103,11 +96,12 @@ describe('Webhook Route for GitHub calls', () => {
     const request = createRequest('opened')
     const response = httpMocks.createResponse()
     const logger = createLogger()
-    const service = createCurationService(true)
+    const service = createCurationService()
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
     await router._handlePost(request, response)
     expect(response.statusCode).to.be.eq(200)
-    expect(service.prOpened.calledOnce).to.be.true
+    expect(service.validateContributions.calledOnce).to.be.true
+    expect(service.updateContribution.calledOnce).to.be.true
     expect(logger.info.calledOnce).to.be.true
     expect(logger.error.notCalled).to.be.true
   })
@@ -117,12 +111,10 @@ function createLogger() {
   return { info: sinon.stub(), error: sinon.stub() }
 }
 
-function createCurationService(failsMissing = false) {
+function createCurationService() {
   return {
-    prOpened: sinon.stub().callsFake(() => (failsMissing ? Promise.reject({ code: 404 }) : Promise.resolve(null))),
-    prClosed: sinon.stub(),
-    prUpdated: sinon.stub(),
-    prMerged: sinon.stub()
+    updateContribution: sinon.stub(),
+    validateContributions: sinon.stub()
   }
 }
 


### PR DESCRIPTION
new route `/curations/sync` to synchronize all the curation PRs and recompute definitions for merged ones.

This route is locked down to the curation github team `curation-dev|curation-prod` 
Authenticate with bearer auth github token