### PR TITLE
change commit -> tree for github sourceUrls

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -108,7 +108,7 @@ function buildSourceUrl(spec) {
   // We only support two source providers so anything else is likely bogus.
   switch (spec.provider) {
     case 'github':
-      return `https://github.com/${spec.namespace}/${spec.name}/commit/${spec.revision}`
+      return `https://github.com/${spec.namespace}/${spec.name}/tree/${spec.revision}`
     case 'mavencentral': {
       const fullName = `${spec.namespace}/${spec.name}`.replace(/\./g, '/')
       return `https://search.maven.org/remotecontent?filepath=${fullName}/${spec.revision}/${spec.name}-${

--- a/test/summary/clearlyDefined.js
+++ b/test/summary/clearlyDefined.js
@@ -323,5 +323,5 @@ function createSourceLocation() {
 }
 
 function getSourceUrl() {
-  return 'https://github.com/clearlydefined/test/commit/42'
+  return 'https://github.com/clearlydefined/test/tree/42'
 }


### PR DESCRIPTION
This way it will work for tags too

The revisions for git components can be commit or tag

Tag:

- https://api.clearlydefined.io/definitions/git/github/expressjs/body-parser/1.5.2
   - https://github.com/expressjs/body-parser/commit/1.5.2
   - https://github.com/expressjs/body-parser/tree/1.5.2

Commit:

- https://api.clearlydefined.io/definitions/git/github/expressjs/body-parser/bd386d3a7d540bac90bbdaff88f653414f6647fc
    - https://github.com/expressjs/body-parser/commit/bd386d3a7d540bac90bbdaff88f653414f6647fc
    - https://github.com/expressjs/body-parser/tree/bd386d3a7d540bac90bbdaff88f653414f6647fc