### PR TITLE
update rubygem summarizer to read licenses from registryData

### DIFF
--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -146,7 +146,13 @@ class ClearlyDescribedSummarizer {
 
   addGemData(result, data) {
     setIfValue(result, 'described.releaseDate', extractDate(data.releaseDate))
-    setIfValue(result, 'licensed.declared', data.licenses)
+    if (!setIfValue(result, 'licensed.declared', normalizeSpdx(get(data, 'registryData.license')))) {
+      const licenses = (get(data, 'registryData.licenses') || [])
+        .map(normalizeSpdx)
+        .filter(x => x)
+        .join(' OR ')
+      setIfValue(result, 'licensed.declared', licenses)
+    }
   }
 
   addPyPiData(result, data) {

--- a/test/summary/clearlyDefined.js
+++ b/test/summary/clearlyDefined.js
@@ -7,6 +7,7 @@ const { expect } = chai
 const Summarizer = require('../../providers/summary/clearlydefined')
 const { setIfValue } = require('../../lib/utils')
 const EntityCoordinates = require('../../lib/entityCoordinates')
+const { set } = require('lodash')
 
 describe('ClearlyDefined Maven summarizer', () => {
   it('handles with all the data', () => {
@@ -241,11 +242,26 @@ function setupNpm(releaseDate, license, homepage, bugs, sourceInfo) {
 
 describe('ClearlyDefined Gem summarizer', () => {
   it('handles with all the data', () => {
-    const { coordinates, harvested } = setupGem('2018-03-06T11:38:10.284Z', 'MIT')
+    const { coordinates, harvested } = setupGem('2018-03-06T11:38:10.284Z', ['MIT'])
     const summary = Summarizer().summarize(coordinates, harvested)
     validate(summary)
     expect(summary.licensed.declared).to.eq('MIT')
     expect(summary.described.releaseDate).to.eq('2018-03-06')
+  })
+
+  it('handles multiple licenses', () => {
+    const { coordinates, harvested } = setupGem('2018-03-06T11:38:10.284Z', ['MIT', 'BSD-2-Clause'])
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.licensed.declared).to.eq('MIT OR BSD-2-Clause')
+  })
+
+  it('handles singular license', () => {
+    const { coordinates, harvested } = setupGem('2018-03-06T11:38:10.284Z')
+    set(harvested, 'registryData.license', 'MIT')
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.licensed.declared).to.eq('MIT')
   })
 
   it('handles data with source location', () => {
@@ -266,11 +282,11 @@ describe('ClearlyDefined Gem summarizer', () => {
   })
 })
 
-function setupGem(releaseDate, license, sourceInfo) {
+function setupGem(releaseDate, licenses, sourceInfo) {
   const coordinates = EntityCoordinates.fromString('gem/rubygems/-/test/1.0')
   const harvested = {}
   setIfValue(harvested, 'releaseDate', releaseDate)
-  setIfValue(harvested, 'licenses', license)
+  setIfValue(harvested, 'registryData.licenses', licenses)
   if (sourceInfo) harvested.sourceInfo = createSourceLocation(sourceInfo)
   return { coordinates, harvested }
 }

--- a/test/summary/clearlyDefined.js
+++ b/test/summary/clearlyDefined.js
@@ -7,7 +7,6 @@ const { expect } = chai
 const Summarizer = require('../../providers/summary/clearlydefined')
 const { setIfValue } = require('../../lib/utils')
 const EntityCoordinates = require('../../lib/entityCoordinates')
-const { set } = require('lodash')
 
 describe('ClearlyDefined Maven summarizer', () => {
   it('handles with all the data', () => {
@@ -257,8 +256,7 @@ describe('ClearlyDefined Gem summarizer', () => {
   })
 
   it('handles singular license', () => {
-    const { coordinates, harvested } = setupGem('2018-03-06T11:38:10.284Z')
-    set(harvested, 'registryData.license', 'MIT')
+    const { coordinates, harvested } = setupGem('2018-03-06T11:38:10.284Z', 'MIT')
     const summary = Summarizer().summarize(coordinates, harvested)
     validate(summary)
     expect(summary.licensed.declared).to.eq('MIT')
@@ -286,7 +284,8 @@ function setupGem(releaseDate, licenses, sourceInfo) {
   const coordinates = EntityCoordinates.fromString('gem/rubygems/-/test/1.0')
   const harvested = {}
   setIfValue(harvested, 'releaseDate', releaseDate)
-  setIfValue(harvested, 'registryData.licenses', licenses)
+  if (typeof licenses === 'string') setIfValue(harvested, 'registryData.license', licenses)
+  else setIfValue(harvested, 'registryData.licenses', licenses)
   if (sourceInfo) harvested.sourceInfo = createSourceLocation(sourceInfo)
   return { coordinates, harvested }
 }


### PR DESCRIPTION
see spec https://guides.rubygems.org/specification-reference/#license=

There is `license (string)` and `licenses (array)`

Example of a dual licensed: https://rubygems.org/api/v1/gems/mocha.json

Interpreting to join with `OR`

![image](https://user-images.githubusercontent.com/5168796/49900454-74127300-fe13-11e8-90aa-031009ad87cd.png)
