### PR TITLE
Integrate chive to generate notice files

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,8 +56,9 @@ function createApp(config) {
   )
   // Circular dependency. Reach in and set the curationService's definitionService. Sigh.
   curationService.definitionService = definitionService
+  const noticeService = require('./business/noticeService')(definitionService)
   const definitionsRoute = require('./routes/definitions')(definitionService)
-
+  const noticesRoute = require('./routes/notices')(noticeService)
   const attachmentsRoute = require('./routes/attachments')(attachmentStore)
 
   const githubSecret = config.webhook.githubSecret
@@ -121,6 +122,7 @@ function createApp(config) {
   app.use(bodyParser.json())
   app.use('/curations', curationsRoute)
   app.use('/definitions', definitionsRoute)
+  app.use('/notices', noticesRoute)
   app.use('/attachments', attachmentsRoute)
 
   // catch 404 and forward to error handler

--- a/app.js
+++ b/app.js
@@ -56,7 +56,7 @@ function createApp(config) {
   )
   // Circular dependency. Reach in and set the curationService's definitionService. Sigh.
   curationService.definitionService = definitionService
-  const noticeService = require('./business/noticeService')(definitionService)
+  const noticeService = require('./business/noticeService')(definitionService, attachmentStore)
   const definitionsRoute = require('./routes/definitions')(definitionService)
   const noticesRoute = require('./routes/notices')(noticeService)
   const attachmentsRoute = require('./routes/attachments')(attachmentStore)

--- a/business/noticeService.js
+++ b/business/noticeService.js
@@ -20,28 +20,26 @@ class NoticeService {
     const renderer = template ? new TemplateRenderer(template) : new TextRenderer()
     const docbuilder = new DocBuilder(renderer)
     const result = await this.definitionService.getAll(coordinates)
-    const source = new JsonSource(
-      JSON.stringify({
-        packages: await Promise.all(
-          Object.keys(result).map(async id => {
-            const definition = result[id]
-            return {
-              name: [definition.coordinates.namespace, definition.coordinates.name].filter(x => x).join('/'),
-              version: get(definition, 'coordinates.revision'),
-              license: get(definition, 'licensed.declared'),
-              copyrights: get(definition, 'licensed.facets.core.attribution.parties'),
-              website: get(definition, 'described.projectWebsite') || '',
-              text: await this._getPackageText(definition)
-            }
-          })
-        )
+    const packages = await Promise.all(
+      Object.keys(result).map(async id => {
+        const definition = result[id]
+        return {
+          name: [definition.coordinates.namespace, definition.coordinates.name].filter(x => x).join('/'),
+          version: get(definition, 'coordinates.revision'),
+          license: get(definition, 'licensed.declared'),
+          copyrights: get(definition, 'licensed.facets.core.attribution.parties'),
+          website: get(definition, 'described.projectWebsite') || '',
+          text: await this._getPackageText(definition)
+        }
       })
     )
+    const source = new JsonSource(JSON.stringify({ packages: packages.filter(x => x.license) }))
     await docbuilder.read(source)
     return docbuilder.build()
   }
 
   async _getPackageText(definition) {
+    if (!definition.files) return ''
     const texts = await Promise.all(
       definition.files
         .filter(file => file.token && file.natures && file.natures.includes('license'))

--- a/business/noticeService.js
+++ b/business/noticeService.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 const { get } = require('lodash')
-const validator = require('../schemas/validator')
 const DocBuilder = require('tiny-attribution-generator/lib/docbuilder').default
 const TextRenderer = require('tiny-attribution-generator/lib/outputs/text').default
 const TemplateRenderer = require('tiny-attribution-generator/lib/outputs/template').default

--- a/business/noticeService.js
+++ b/business/noticeService.js
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { get } = require('lodash')
+const validator = require('../schemas/validator')
+const DocBuilder = require('tiny-attribution-generator/lib/docbuilder').default
+const TextRenderer = require('tiny-attribution-generator/lib/outputs/text').default
+const JsonSource = require('tiny-attribution-generator/lib/inputs/json').default
+
+const logger = require('../providers/logging/logger')
+
+class NoticeService {
+  constructor(definitionService) {
+    this.definitionService = definitionService
+    this.logger = logger()
+  }
+
+  async generate(coordinates) {
+    const textRenderer = new TextRenderer()
+    const docbuilder = new DocBuilder(textRenderer)
+    const result = await this.definitionService.getAll(coordinates)
+    const source = new JsonSource(
+      JSON.stringify({
+        packages: Object.keys(result).map(id => {
+          const definition = result[id]
+          return {
+            name: this._getName(definition),
+            version: get(definition, 'coordinates.revision'),
+            license: get(definition, 'licensed.declared'),
+            copyrights: get(definition, 'licensed.facets.core.attribution.parties'),
+            website: get(definition, 'described.projectWebsite') || ''
+          }
+        })
+      })
+    )
+    await docbuilder.read(source)
+    return docbuilder.build()
+  }
+
+  _getName(definition) {
+    if (!definition.coordinates) return null
+    return [(definition.coordinates.namespace, definition.coordinates.name)].filter(x => x).join('/')
+  }
+}
+
+module.exports = definitionService => new NoticeService(definitionService)

--- a/business/noticeService.js
+++ b/business/noticeService.js
@@ -5,6 +5,7 @@ const { get } = require('lodash')
 const validator = require('../schemas/validator')
 const DocBuilder = require('tiny-attribution-generator/lib/docbuilder').default
 const TextRenderer = require('tiny-attribution-generator/lib/outputs/text').default
+const TemplateRenderer = require('tiny-attribution-generator/lib/outputs/template').default
 const JsonSource = require('tiny-attribution-generator/lib/inputs/json').default
 
 const logger = require('../providers/logging/logger')
@@ -16,11 +17,10 @@ class NoticeService {
     this.logger = logger()
   }
 
-  async generate(coordinates) {
-    const textRenderer = new TextRenderer()
-    const docbuilder = new DocBuilder(textRenderer)
+  async generate(coordinates, template = '') {
+    const renderer = template ? new TemplateRenderer(template) : new TextRenderer()
+    const docbuilder = new DocBuilder(renderer)
     const result = await this.definitionService.getAll(coordinates)
-
     const source = new JsonSource(
       JSON.stringify({
         packages: await Promise.all(

--- a/package-lock.json
+++ b/package-lock.json
@@ -556,6 +556,11 @@
         "type-is": "~1.6.15"
       }
     },
+    "bottleneck": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.15.3.tgz",
+      "integrity": "sha512-2sHF/gMwTshF//gQninQBEHDNBXuvDLfSczPHpDc2U/9SC+P/97Zt01hy7UTEV0atSZ9BQBIHsdju/6wn7m4+w=="
+    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -662,6 +662,15 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -806,6 +815,21 @@
         }
       }
     },
+    "clean-css": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "requires": {
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -879,8 +903,7 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -937,6 +960,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -1881,6 +1909,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -2558,6 +2591,32 @@
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "requires": {
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2692,6 +2751,32 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.1.0.tgz",
       "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
+    },
+    "html-minifier": {
+      "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+      "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+      "requires": {
+        "camel-case": "3.0.x",
+        "clean-css": "4.2.x",
+        "commander": "2.17.x",
+        "he": "1.2.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.4.x"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+        },
+        "he": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+          "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+        }
+      }
     },
     "http-errors": {
       "version": "1.6.2",
@@ -3219,6 +3304,11 @@
       "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
       "dev": true
     },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -3683,6 +3773,14 @@
             "isarray": "0.0.1"
           }
         }
+      }
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "^1.1.1"
       }
     },
     "nocache": {
@@ -5024,6 +5122,22 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
+    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -5068,6 +5182,14 @@
       "requires": {
         "object-path": "^0.9.2",
         "walk-back": "^1.1.0"
+      }
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "requires": {
+        "no-case": "^2.2.0"
       }
     },
     "parseurl": {
@@ -5424,6 +5546,11 @@
       "requires": {
         "rc": "^1.0.1"
       }
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -6201,6 +6328,65 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "superagent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-4.1.0.tgz",
+      "integrity": "sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==",
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.0",
+        "form-data": "^2.3.3",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^2.4.0",
+        "qs": "^6.6.0",
+        "readable-stream": "^3.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "mime": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+          "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "qs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+          "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
+        },
+        "readable-stream": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "swagger-ui-dist": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.20.0.tgz",
@@ -6283,6 +6469,31 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
+    },
+    "tiny-attribution-generator": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/tiny-attribution-generator/-/tiny-attribution-generator-0.0.5.tgz",
+      "integrity": "sha512-jjQwrux9+0DRHo57Kjb6mYQesGqXRWtPIpmbL7WJ7q3/6oqsM99tfQBL7Yp4p39t8JQqaGOvvRE23XBnDl1O2A==",
+      "requires": {
+        "handlebars": "^4.0.12",
+        "html-minifier": "^3.5.20",
+        "lodash": "^4.17.11",
+        "spdx-license-list": "^4.1.0",
+        "superagent": "^4.0.0-beta.5",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "spdx-license-list": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-4.1.0.tgz",
+          "integrity": "sha512-nlyjgQUe1PgBGU0RdXIwo+N1VHI0XV/hxCBms8fhRDV7qottuPdX3gcTB4dpNnnQ/fIC3ymb/oWB6S8T6nQEnw=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
     },
     "tmp": {
       "version": "0.0.33",
@@ -6418,6 +6629,27 @@
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
+      }
+    },
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "uid2": {
@@ -6557,6 +6789,11 @@
         "semver-diff": "^2.0.0",
         "xdg-basedir": "^3.0.0"
       }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "azure-storage": "^2.10.2",
     "base-64": "^0.1.0",
     "body-parser": "~1.18.2",
+    "bottleneck": "^2.15.3",
     "colors": "^1.1.2",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "spdx-satisfies": "github:clearlydefined/spdx-satisfies.js#fork",
     "swagger-ui-express": "^4.0.1",
     "throat": "^4.1.0",
+    "tiny-attribution-generator": "0.0.5",
     "tmp": "0.0.33",
     "vso-node-api": "^6.2.8-preview",
     "winston": "^2.3.0",

--- a/routes/notices.js
+++ b/routes/notices.js
@@ -9,11 +9,19 @@ const validator = require('../schemas/validator')
 
 router.post('/', asyncMiddleware(generateNotices))
 
+/**
+ *
+ * {
+ *   coordinates: [""],
+ *   output: "text|html|template|json",
+ *   options: { "template": ""}
+ * }
+ */
 async function generateNotices(request, response) {
   if (!validator.validate('notice-request', request.body)) return response.status(400).send(validator.errorsText())
-  const coordinatesList = request.body.coordinates.map(entry => EntityCoordinates.fromString(entry))
-  const output = await noticeService.generate(coordinatesList, request.body.template)
-  response.send(output)
+  const coordinates = request.body.coordinates.map(entry => EntityCoordinates.fromString(entry))
+  const result = await noticeService.generate(coordinates, request.body.output, request.body.options)
+  response.send(result)
 }
 
 let noticeService

--- a/routes/notices.js
+++ b/routes/notices.js
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const asyncMiddleware = require('../middleware/asyncMiddleware')
+const express = require('express')
+const router = express.Router()
+const EntityCoordinates = require('../lib/entityCoordinates')
+
+router.post(
+  '/',
+  asyncMiddleware(async (request, response) => {
+    const coordinatesList = request.body.coordinates.map(entry => EntityCoordinates.fromString(entry))
+    const output = await noticeService.generate(coordinatesList)
+    response.send(output)
+  })
+)
+
+let noticeService
+
+function setup(notice) {
+  noticeService = notice
+  return router
+}
+module.exports = setup

--- a/routes/notices.js
+++ b/routes/notices.js
@@ -5,10 +5,12 @@ const asyncMiddleware = require('../middleware/asyncMiddleware')
 const express = require('express')
 const router = express.Router()
 const EntityCoordinates = require('../lib/entityCoordinates')
+const validator = require('../schemas/validator')
 
 router.post(
   '/',
   asyncMiddleware(async (request, response) => {
+    if (!validator.validate('notice-request', request.body)) return response.status(400).send(validator.errorsText())
     const coordinatesList = request.body.coordinates.map(entry => EntityCoordinates.fromString(entry))
     const output = await noticeService.generate(coordinatesList, request.body.template)
     response.send(output)

--- a/routes/notices.js
+++ b/routes/notices.js
@@ -10,7 +10,7 @@ router.post(
   '/',
   asyncMiddleware(async (request, response) => {
     const coordinatesList = request.body.coordinates.map(entry => EntityCoordinates.fromString(entry))
-    const output = await noticeService.generate(coordinatesList)
+    const output = await noticeService.generate(coordinatesList, request.body.template)
     response.send(output)
   })
 )

--- a/routes/notices.js
+++ b/routes/notices.js
@@ -7,15 +7,14 @@ const router = express.Router()
 const EntityCoordinates = require('../lib/entityCoordinates')
 const validator = require('../schemas/validator')
 
-router.post(
-  '/',
-  asyncMiddleware(async (request, response) => {
-    if (!validator.validate('notice-request', request.body)) return response.status(400).send(validator.errorsText())
-    const coordinatesList = request.body.coordinates.map(entry => EntityCoordinates.fromString(entry))
-    const output = await noticeService.generate(coordinatesList, request.body.template)
-    response.send(output)
-  })
-)
+router.post('/', asyncMiddleware(generateNotices))
+
+async function generateNotices(request, response) {
+  if (!validator.validate('notice-request', request.body)) return response.status(400).send(validator.errorsText())
+  const coordinatesList = request.body.coordinates.map(entry => EntityCoordinates.fromString(entry))
+  const output = await noticeService.generate(coordinatesList, request.body.template)
+  response.send(output)
+}
 
 let noticeService
 

--- a/schemas/notice-request.json
+++ b/schemas/notice-request.json
@@ -8,6 +8,7 @@
   "properties": {
     "coordinates": {
       "type": "array",
+      "items": { "type": "string" },
       "errorMessage": {
         "type": "coordinates type must be an array"
       }

--- a/schemas/notice-request.json
+++ b/schemas/notice-request.json
@@ -1,0 +1,26 @@
+{
+  "$id": "https://api.clearlydefined.io/schemas/notice-request.json#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "noticeRequest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["coordinates"],
+  "properties": {
+    "coordinates": {
+      "type": "array",
+      "errorMessage": {
+        "type": "coordinates type must be an array"
+      }
+    },
+    "template": {
+      "type": "string",
+      "errorMessage": {
+        "type": "template type must be a string"
+      }
+    }
+  },
+  "errorMessage": {
+    "type": "A notice request must be an object",
+    "additionalProperties": "A notice request can only contain coordinates array and template string"
+  }
+}

--- a/schemas/notice-request.json
+++ b/schemas/notice-request.json
@@ -13,10 +13,16 @@
         "type": "coordinates type must be an array"
       }
     },
-    "template": {
+    "output": {
       "type": "string",
       "errorMessage": {
-        "type": "template type must be a string"
+        "type": "output must be a string"
+      }
+    },
+    "options": {
+      "type": "object",
+      "errorMessage": {
+        "type": "options must be an object"
       }
     }
   },

--- a/schemas/validator.js
+++ b/schemas/validator.js
@@ -8,5 +8,6 @@ ajv.addSchema(require('../schemas/curations-1.0'), 'curations')
 ajv.addSchema(require('../schemas/curation-1.0'), 'curation')
 ajv.addSchema(require('../schemas/definition-1.0'), 'definition')
 ajv.addSchema(require('../schemas/harvest-1.0'), 'harvest')
+ajv.addSchema(require('../schemas/notice-request'), 'notice-request')
 
 module.exports = ajv

--- a/test/business/noticeServiceTest.js
+++ b/test/business/noticeServiceTest.js
@@ -8,66 +8,132 @@ const spdxLicenseList = require('spdx-license-list/full')
 
 describe('Notice Service', () => {
   it('generates simple notice', async () => {
-    const { service } = setup({
+    const { service, coordinates } = setup({
       'npm/npmjs/-/test/1.0.0': {
         coordinates: { name: 'test', revision: '1.0.0' },
-        licensed: { declared: 'MIT' }
+        licensed: { declared: 'MIT', facets: { core: { attribution: { parties: ['copyright me'] } } } },
+        described: { tools: ['clearlydefined/1.0.0'] }
       }
     })
-    const notice = await service.generate()
-    expect(notice).to.eq('** test; version 1.0.0 -- \n\n' + spdxLicenseList.MIT.licenseText)
+    const notice = await service.generate(coordinates)
+    expect(notice.content).to.eq('** test; version 1.0.0 -- \ncopyright me\n\n' + spdxLicenseList.MIT.licenseText)
+    expect(notice.summary).to.deep.eq({
+      totalCoordinates: 1,
+      clearlyNoticedCoordinates: 1,
+      warnings: { noCopyrights: [], notHarvested: [], noLicenseDeclared: [] }
+    })
   })
 
   it('generates notices with namespace', async () => {
-    const { service } = setup({
+    const { service, coordinates } = setup({
       'npm/npmjs/-/test/1.0.0': {
         coordinates: { namespace: '@scope', name: 'test', revision: '1.0.0' },
-        licensed: { declared: 'MIT' }
+        licensed: { declared: 'MIT' },
+        described: { tools: ['clearlydefined/1.0.0'] }
       }
     })
-    const notice = await service.generate()
-    expect(notice).to.eq('** @scope/test; version 1.0.0 -- \n\n' + spdxLicenseList.MIT.licenseText)
+    const notice = await service.generate(coordinates)
+    expect(notice.content).to.eq('** @scope/test; version 1.0.0 -- \n\n' + spdxLicenseList.MIT.licenseText)
   })
 
   it('includes license for package', async () => {
-    const { service } = setup(
+    const { service, coordinates } = setup(
       {
         'npm/npmjs/-/test/1.0.0': {
           coordinates: { name: 'test', revision: '1.0.0' },
           licensed: { declared: 'MIT' },
-          files: [{ path: 'LICENSE', token: 'abcd', natures: ['license'] }]
+          files: [{ path: 'LICENSE', token: 'abcd', natures: ['license'] }],
+          described: { tools: ['clearlydefined/1.0.0'] }
         }
       },
       { abcd: '%%%This is the attachment%%%' }
     )
-    const notice = await service.generate()
-    expect(notice).to.eq('** test; version 1.0.0 -- \n\n%%%This is the attachment%%%')
+    const notice = await service.generate(coordinates)
+    expect(notice.content).to.eq('** test; version 1.0.0 -- \n\n%%%This is the attachment%%%')
   })
 
   it('renders with custom template', async () => {
-    const { service } = setup({
+    const { service, coordinates } = setup({
       'npm/npmjs/-/test/1.0.0': {
         coordinates: { name: 'test', revision: '1.0.0' },
-        licensed: { declared: 'MIT' }
+        licensed: { declared: 'MIT' },
+        described: { tools: ['clearlydefined/1.0.0'] }
       },
       'npm/npmjs/-/test/2.0.0': {
         coordinates: { name: 'test', revision: '2.0.0' },
-        licensed: { declared: 'Apache-2.0' }
+        licensed: { declared: 'Apache-2.0' },
+        described: { tools: ['clearlydefined/1.0.0'] }
       }
     })
-    const notice = await service.generate(
-      {},
-      'HEADER CONTENT\n\n\n----\n\n{{#buckets}}\n{{#packages}}\n\n----\n\n{{{name}}} {{{version}}} - {{{../name}}}\n{{/packages}}{{/buckets}}\n'
-    )
-    expect(notice).to.eq(
+    const notice = await service.generate(coordinates, 'template', {
+      template:
+        'HEADER CONTENT\n\n\n----\n\n{{#buckets}}\n{{#packages}}\n\n----\n\n{{{name}}} {{{version}}} - {{{../name}}}\n{{/packages}}{{/buckets}}\n'
+    })
+    expect(notice.content).to.eq(
       'HEADER CONTENT\n\n\n----\n\n\n----\n\ntest 2.0.0 - Apache-2.0\n\n----\n\ntest 1.0.0 - MIT\n\n'
     )
   })
 
+  it('buckets warnings', async () => {
+    const { service, coordinates } = setup({
+      'npm/npmjs/-/not-harvested/1.0.0': {
+        coordinates: { name: 'not-harvested', revision: '1.0.0' }
+      },
+      'npm/npmjs/-/no-license/1.0.0': {
+        coordinates: { name: 'no-license', revision: '1.0.0' },
+        licensed: { facets: { core: { attribution: { parties: ['copyright me'] } } } },
+        described: { tools: ['clearlydefined/1.0.0'] }
+      },
+      'npm/npmjs/-/no-copyright/1.0.0': {
+        coordinates: { name: 'no-copyright', revision: '1.0.0' },
+        licensed: { declared: 'MIT' },
+        described: { tools: ['clearlydefined/1.0.0'] }
+      }
+    })
+    const notice = await service.generate(coordinates)
+    expect(notice.content).to.eq('** no-copyright; version 1.0.0 -- \n\n' + spdxLicenseList.MIT.licenseText)
+    expect(notice.summary).to.deep.eq({
+      totalCoordinates: 3,
+      clearlyNoticedCoordinates: 1,
+      warnings: {
+        notHarvested: ['npm/npmjs/-/not-harvested/1.0.0'],
+        noLicenseDeclared: ['npm/npmjs/-/no-license/1.0.0'],
+        noCopyrights: ['npm/npmjs/-/no-copyright/1.0.0']
+      }
+    })
+  })
+
+  it('handles NOASSERTION and NONE licenses', async () => {
+    const { service, coordinates } = setup({
+      'npm/npmjs/-/no-assertion/1.0.0': {
+        coordinates: { name: 'no-assertion', revision: '1.0.0' },
+        licensed: { declared: 'NOASSERTION', facets: { core: { attribution: { parties: ['copyright me'] } } } },
+        described: { tools: ['clearlydefined/1.0.0'] }
+      },
+      'npm/npmjs/-/none/1.0.0': {
+        coordinates: { name: 'none', revision: '1.0.0' },
+        licensed: { declared: 'NONE', facets: { core: { attribution: { parties: ['copyright me'] } } } },
+        described: { tools: ['clearlydefined/1.0.0'] }
+      }
+    })
+    const notice = await service.generate(coordinates)
+    expect(notice.content).to.eq('** none; version 1.0.0 -- \ncopyright me\n\nNONE')
+    expect(notice.summary).to.deep.eq({
+      totalCoordinates: 2,
+      clearlyNoticedCoordinates: 1,
+      warnings: { noCopyrights: [], notHarvested: [], noLicenseDeclared: ['npm/npmjs/-/no-assertion/1.0.0'] }
+    })
+  })
+
   it('generates empty notices for no defintions', async () => {
-    const { service } = setup({})
-    const notice = await service.generate()
-    expect(notice).to.eq('')
+    const { service, coordinates } = setup({})
+    const notice = await service.generate(coordinates)
+    expect(notice.content).to.eq('')
+    expect(notice.summary).to.deep.eq({
+      totalCoordinates: 0,
+      clearlyNoticedCoordinates: 0,
+      warnings: { noCopyrights: [], notHarvested: [], noLicenseDeclared: [] }
+    })
   })
 
   it('gets renderer by choice', () => {
@@ -81,15 +147,23 @@ describe('Notice Service', () => {
     try {
       service._getRenderer('junk')
       expect(true).to.be.false
-    } catch (e) {
-      expect(e.message).to.eq('"junk" is not a supported output')
+    } catch (error) {
+      expect(error.message).to.eq('"junk" is not a supported output')
+    }
+
+    try {
+      service._getRenderer('template', {})
+      expect(true).to.be.false
+    } catch (error) {
+      expect(error.message).to.eq('options.template is required for template output')
     }
   })
 })
 
-function setup(defintions, attachments = {}) {
+function setup(definitions, attachments = {}) {
   const attachmentStore = { get: token => attachments[token] }
-  const definitionService = { getAll: sinon.stub().returns(Promise.resolve(defintions)) }
+  const definitionService = { getAll: sinon.stub().returns(Promise.resolve(definitions)) }
   const service = NoticeService(definitionService, attachmentStore)
-  return { service }
+  const coordinates = Object.keys(definitions).map(x => definitions[x].coordinates)
+  return { service, coordinates }
 }

--- a/test/business/noticeServiceTest.js
+++ b/test/business/noticeServiceTest.js
@@ -69,6 +69,22 @@ describe('Notice Service', () => {
     const notice = await service.generate()
     expect(notice).to.eq('')
   })
+
+  it('gets renderer by choice', () => {
+    const { service } = setup({})
+    expect(service._getRenderer().constructor.name).to.eq('TextRenderer')
+    expect(service._getRenderer('text').constructor.name).to.eq('TextRenderer')
+    expect(service._getRenderer('html', {}).constructor.name).to.eq('HtmlRenderer')
+    expect(service._getRenderer('template', { template: 'template' }).constructor.name).to.eq('TemplateRenderer')
+    expect(service._getRenderer('json').constructor.name).to.eq('JsonRenderer')
+
+    try {
+      service._getRenderer('junk')
+      expect(true).to.be.false
+    } catch (e) {
+      expect(e.message).to.eq('"junk" is not a supported output')
+    }
+  })
 })
 
 function setup(defintions, attachments = {}) {

--- a/test/business/noticeServiceTest.js
+++ b/test/business/noticeServiceTest.js
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const sinon = require('sinon')
+const NoticeService = require('../../business/noticeService')
+const spdxLicenseList = require('spdx-license-list/full')
+
+describe('Notice Service', () => {
+  it('generates simple notice', async () => {
+    const { service } = setup({
+      'npm/npmjs/-/test/1.0.0': {
+        coordinates: { name: 'test', revision: '1.0.0' },
+        licensed: { declared: 'MIT' }
+      }
+    })
+    const notice = await service.generate()
+    expect(notice).to.eq('** test; version 1.0.0 -- \n\n' + spdxLicenseList.MIT.licenseText)
+  })
+
+  it('generates notices with namespace', async () => {
+    const { service } = setup({
+      'npm/npmjs/-/test/1.0.0': {
+        coordinates: { namespace: '@scope', name: 'test', revision: '1.0.0' },
+        licensed: { declared: 'MIT' }
+      }
+    })
+    const notice = await service.generate()
+    expect(notice).to.eq('** @scope/test; version 1.0.0 -- \n\n' + spdxLicenseList.MIT.licenseText)
+  })
+
+  it('includes license for package', async () => {
+    const { service } = setup(
+      {
+        'npm/npmjs/-/test/1.0.0': {
+          coordinates: { name: 'test', revision: '1.0.0' },
+          licensed: { declared: 'MIT' },
+          files: [{ path: 'LICENSE', token: 'abcd', natures: ['license'] }]
+        }
+      },
+      { abcd: '%%%This is the attachment%%%' }
+    )
+    const notice = await service.generate()
+    expect(notice).to.eq('** test; version 1.0.0 -- \n\n%%%This is the attachment%%%')
+  })
+
+  it('renders with custom template', async () => {
+    const { service } = setup({
+      'npm/npmjs/-/test/1.0.0': {
+        coordinates: { name: 'test', revision: '1.0.0' },
+        licensed: { declared: 'MIT' }
+      },
+      'npm/npmjs/-/test/2.0.0': {
+        coordinates: { name: 'test', revision: '2.0.0' },
+        licensed: { declared: 'Apache-2.0' }
+      }
+    })
+    const notice = await service.generate(
+      {},
+      'HEADER CONTENT\n\n\n----\n\n{{#buckets}}\n{{#packages}}\n\n----\n\n{{{name}}} {{{version}}} - {{{../name}}}\n{{/packages}}{{/buckets}}\n'
+    )
+    expect(notice).to.eq(
+      'HEADER CONTENT\n\n\n----\n\n\n----\n\ntest 2.0.0 - Apache-2.0\n\n----\n\ntest 1.0.0 - MIT\n\n'
+    )
+  })
+
+  it('generates empty notices for no defintions', async () => {
+    const { service } = setup({})
+    const notice = await service.generate()
+    expect(notice).to.eq('')
+  })
+})
+
+function setup(defintions, attachments = {}) {
+  const attachmentStore = { get: token => attachments[token] }
+  const definitionService = { getAll: sinon.stub().returns(Promise.resolve(defintions)) }
+  const service = NoticeService(definitionService, attachmentStore)
+  return { service }
+}


### PR DESCRIPTION
See [chive](https://github.com/amzn/tiny-attribution-generator)

Example: 

POST to https://api.clearlydefined.io/notices
body:
```json
{
	"coordinates": [
		"npm/npmjs/-/lodash/4.17.11",
		"npm/npmjs/-/junk/5.88.0",
		"npm/npmjs/@ant-design/icons/1.1.15",
		"nuget/nuget/-/newtonsoft.json/12.0.1"
	],
	"output": "text|html|template|json",
	"options": {"template": "<optional handlebars template>"}	
}
```

see https://github.com/amzn/tiny-attribution-generator/blob/master/default-htmltemplate.hbs for a template example

We will use the default textRenderer in chive if one is not provided