### PR TITLE
add telemetry to defintionService

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -59,7 +59,7 @@ class DefinitionService {
     const existing = force ? null : await this.definitionStore.get(coordinates)
     let result
     if (get(existing, '_meta.schemaVersion') === currentSchema) {
-      this.logger.info('current definition exists', { coordinates: coordinates.toString() })
+      this.logger.info('computed definition available', { coordinates: coordinates.toString() })
       result = existing
     } else result = await this.computeAndStore(coordinates)
     return this._cast(result)
@@ -152,7 +152,7 @@ class DefinitionService {
       this.harvest(coordinates)
       return definition
     }
-    this.logger.info('definition is available', { coordinates: coordinates.toString() })
+    this.logger.info('recomputed definition available', { coordinates: coordinates.toString() })
     await this._store(definition)
     return definition
   }

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -57,8 +57,11 @@ class DefinitionService {
       return this.compute(coordinates, curation)
     }
     const existing = force ? null : await this.definitionStore.get(coordinates)
-    const result =
-      get(existing, '_meta.schemaVersion') === currentSchema ? existing : await this.computeAndStore(coordinates)
+    let result
+    if (get(existing, '_meta.schemaVersion') === currentSchema) {
+      this.logger.info('current definition exists', { coordinates: coordinates.toString() })
+      result = existing
+    } else result = await this.computeAndStore(coordinates)
     return this._cast(result)
   }
 
@@ -145,9 +148,11 @@ class DefinitionService {
     // Note that curation is a tool so no tools really means there the definition is effectively empty.
     const tools = get(definition, 'described.tools')
     if (!tools || tools.length === 0) {
+      this.logger.info('definition not available', { coordinates: coordinates.toString() })
       this.harvest(coordinates)
       return definition
     }
+    this.logger.info('definition is available', { coordinates: coordinates.toString() })
     await this._store(definition)
     return definition
   }

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -96,7 +96,7 @@ class GitHubCurationService {
   }
 
   /**
-   * Process the fact that the given PR has been merged by persisting the curation and invalidating the defintion
+   * Process the fact that the given PR has been merged by persisting the curation and invalidating the definition
    * @param {*} curations - The set of actual proposed changes
    * @returns Promise indicating the operation is complete. The value of the resolved promise is undefined.
    * @throws Exception with `code` === 404 if the given PR is missing. Other exceptions may be thrown related

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -343,6 +343,7 @@ function setup(definition, coordinateSpec, curation) {
   const summary = { summarizeAll: () => Promise.resolve(null) }
   const aggregator = { process: () => Promise.resolve(definition) }
   const service = DefinitionService(harvestStore, harvestService, summary, aggregator, curator, store, search)
+  service.logger = { info: sinon.stub() }
   const coordinates = EntityCoordinates.fromString(coordinateSpec || 'npm/npmjs/-/test/1.0')
   return { coordinates, service }
 }

--- a/test/business/noticeServiceTest.js
+++ b/test/business/noticeServiceTest.js
@@ -125,7 +125,7 @@ describe('Notice Service', () => {
     })
   })
 
-  it('generates empty notices for no defintions', async () => {
+  it('generates empty notices for no definitions', async () => {
     const { service, coordinates } = setup({})
     const notice = await service.generate(coordinates)
     expect(notice.content).to.eq('')


### PR DESCRIPTION
three new log statements:
  - 'current definition exists',
  - 'definition is available'
  - 'definition not available'

we want to be able to query the percentage of requests that we have
information available for. This is the sum of
'current definition exists' and 'definition is available' divided by
the sum of all three