### PR TITLE
paginate the defintions in the mongo store (fixes #254)

### DIFF
--- a/business/aggregator.js
+++ b/business/aggregator.js
@@ -30,7 +30,7 @@
 //
 
 const { getLatestVersion, mergeDefinitions } = require('../lib/utils')
-const { flattenDeep, get, set, differenceBy, intersectionBy } = require('lodash')
+const { flattenDeep, get, set, intersectionBy } = require('lodash')
 const logger = require('../providers/logging/logger')
 
 class AggregationService {
@@ -77,10 +77,10 @@ class AggregationService {
   _normalizeFiles(result, summarized, coordinates) {
     const cdFiles = get(this._findData('clearlydefined', summarized), 'summary.files')
     if (!cdFiles) return
-    const difference = differenceBy(result.files, cdFiles, 'path')
-    if (!difference.length) return
+    const difference = result.files.length - cdFiles.length
+    if (!difference) return
     this.logger.info('difference between summary file count and cd file count', {
-      count: difference.length,
+      count: difference,
       coordinates: coordinates.toString()
     })
     result.files = intersectionBy(result.files, cdFiles, 'path')

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -181,7 +181,7 @@ class DefinitionService {
     const raw = await this.harvestStore.getAll(coordinates)
     coordinates = this._getCasedCoordinates(raw, coordinates)
     const summaries = await this.summaryService.summarizeAll(coordinates, raw)
-    const aggregatedDefinition = (await this.aggregationService.process(summaries)) || {}
+    const aggregatedDefinition = (await this.aggregationService.process(summaries, coordinates)) || {}
     aggregatedDefinition.coordinates = coordinates
     this._ensureToolScores(coordinates, aggregatedDefinition)
     const definition = await this.curationService.apply(coordinates, curationSpec, aggregatedDefinition)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,7 @@ const semver = require('semver')
 const EntityCoordinates = require('./entityCoordinates')
 const ResultCoordinates = require('./resultCoordinates')
 const moment = require('moment')
-const { set, find, unset, union } = require('lodash')
+const { set, unset, union } = require('lodash')
 const extend = require('extend')
 const SPDX = require('./spdx')
 
@@ -96,8 +96,12 @@ function mergeDefinitions(base, proposed) {
 function _mergeFiles(base, proposed) {
   if (!proposed) return base
   if (!base) return proposed
+  const baseLookup = base.reduce((result, item) => {
+    result[item.path] = item
+    return result
+  }, {})
   proposed.forEach(file => {
-    const entry = find(base, current => current.path === file.path)
+    const entry = baseLookup[file.path]
     if (entry) _mergeFile(entry, file)
     else base.push(file)
   })
@@ -119,9 +123,10 @@ function _mergeFile(base, proposed) {
 function _mergeDescribed(base, proposed) {
   if (!proposed) return base
   if (!base) return proposed
-  const result = _mergeExcept(base, proposed, ['facets', 'hashes'])
+  const result = _mergeExcept(base, proposed, ['facets', 'hashes', 'files'])
   setIfValue(result, 'facets', _mergeObject(base.facets, proposed.facets))
   setIfValue(result, 'hashes', _mergeObject(base.hashes, proposed.hashes))
+  setIfValue(result, 'files', Math.max(base.files || 0, proposed.files || 0))
   return result
 }
 

--- a/providers/stores/mongo.js
+++ b/providers/stores/mongo.js
@@ -5,6 +5,7 @@ const MongoClient = require('mongodb').MongoClient
 const promiseRetry = require('promise-retry')
 const EntityCoordinates = require('../../lib/entityCoordinates')
 const logger = require('../logging/logger')
+const { clone, get, range } = require('lodash')
 
 class MongoStore {
   constructor(options) {
@@ -49,18 +50,50 @@ class MongoStore {
    * @param {Coordinates} coordinates - The coordinates of the object to get
    * @returns The loaded object
    */
-  get(coordinates) {
-    return this.collection.findOne({ _id: this._getId(coordinates) }, { projection: { _id: 0 } })
+  async get(coordinates) {
+    const cursor = await this.collection.find(
+      { _id: new RegExp(`^${this._getId(coordinates)}`) },
+      { projection: { _id: 0, _mongo: 0 }, sort: { _id: 1 } }
+    )
+    let definition
+    await cursor.forEach(page => {
+      if (!definition) definition = page
+      else definition.files = definition.files.concat(page.files)
+    })
+    return definition
   }
 
   async store(definition) {
+    const pageSize = 1000
     definition._id = this._getId(definition.coordinates)
-    await this.collection.replaceOne({ _id: definition._id }, definition, { upsert: true })
-    return null
+    await this.collection.deleteMany({ _id: new RegExp(`^${definition._id}(\\/.+)?$`) })
+    const pages = Math.ceil((get(definition, 'files.length') || 1) / pageSize)
+    const result = await this.collection.insertMany(
+      range(pages).map(
+        index => {
+          if (index === 0) {
+            const definitionPage = clone(definition)
+            if (definition.files) definitionPage.files = definition.files.slice(0, pageSize)
+            return { ...definitionPage, _mongo: { partitionKey: definition._id, currentPage: 1, totalPages: pages } }
+          }
+          return {
+            _id: definition._id + `/${index}`,
+            _mongo: {
+              partitionKey: definition._id,
+              currentPage: index + 1,
+              totalPages: pages
+            },
+            files: definition.files.slice(index * pageSize, index * pageSize + pageSize)
+          }
+        },
+        { ordered: false }
+      )
+    )
+    return result
   }
 
   async delete(coordinates) {
-    await this.collection.deleteOne({ _id: this._getId(coordinates) })
+    await this.collection.deleteMany({ _id: new RegExp(`^${this._getId(coordinates)}(\\/.+)?$`) })
     return null
   }
 

--- a/test/providers/store/mongoDefinition.js
+++ b/test/providers/store/mongoDefinition.js
@@ -5,6 +5,7 @@ const Store = require('../../../providers/stores/mongo')
 const sinon = require('sinon')
 const { expect } = require('chai')
 const EntityCoordinates = require('../../../lib/entityCoordinates')
+const { range } = require('lodash')
 
 describe('Mongo Definition store', () => {
   const data = {
@@ -50,15 +51,39 @@ describe('Mongo Definition store', () => {
     const definition = createDefinition('npm/npmjs/-/foo/1.0')
     const store = createStore()
     await store.store(definition)
-    expect(store.collection.replaceOne.callCount).to.eq(1)
-    expect(store.collection.replaceOne.args[0][0]._id).to.eq('npm/npmjs/-/foo/1.0')
+    expect(store.collection.deleteMany.callCount).to.eq(1)
+    expect(store.collection.deleteMany.args[0][0]._id).to.deep.eq(/^npm\/npmjs\/-\/foo\/1.0(\/.+)?$/)
+    expect(store.collection.insertMany.callCount).to.eq(1)
+    expect(store.collection.insertMany.args[0][0][0]._id).to.eq('npm/npmjs/-/foo/1.0')
+    expect(store.collection.insertMany.args[0][0][0]._mongo.currentPage).to.eq(1)
+    expect(store.collection.insertMany.args[0][0][0]._mongo.totalPages).to.eq(1)
+  })
+
+  it('stores a paged definition', async () => {
+    const definition = createDefinition('npm/npmjs/-/foo/1.0')
+    definition.files = range(0, 1500).map(x => {
+      return { path: `/path/to/${x}.txt` }
+    })
+    const store = createStore()
+    await store.store(definition)
+    expect(store.collection.deleteMany.callCount).to.eq(1)
+    expect(store.collection.deleteMany.args[0][0]._id).to.deep.eq(/^npm\/npmjs\/-\/foo\/1.0(\/.+)?$/)
+    expect(store.collection.insertMany.callCount).to.eq(1)
+    expect(store.collection.insertMany.args[0][0][0]._id).to.eq('npm/npmjs/-/foo/1.0')
+    expect(store.collection.insertMany.args[0][0][0].files.length).to.eq(1000)
+    expect(store.collection.insertMany.args[0][0][0]._mongo.currentPage).to.eq(1)
+    expect(store.collection.insertMany.args[0][0][0]._mongo.totalPages).to.eq(2)
+    expect(store.collection.insertMany.args[0][0][1]._id).to.eq('npm/npmjs/-/foo/1.0/1')
+    expect(store.collection.insertMany.args[0][0][1].files.length).to.eq(500)
+    expect(store.collection.insertMany.args[0][0][1]._mongo.currentPage).to.eq(2)
+    expect(store.collection.insertMany.args[0][0][1]._mongo.totalPages).to.eq(2)
   })
 
   it('deletes a definition', async () => {
     const store = createStore()
     await store.delete(EntityCoordinates.fromString('npm/npmjs/-/foo/1.0'))
-    expect(store.collection.deleteOne.callCount).to.eq(1)
-    expect(store.collection.deleteOne.args[0][0]._id).to.eq('npm/npmjs/-/foo/1.0')
+    expect(store.collection.deleteMany.callCount).to.eq(1)
+    expect(store.collection.deleteMany.args[0][0]._id).to.deep.eq(/^npm\/npmjs\/-\/foo\/1.0(\/.+)?$/)
   })
 
   it('gets a definition', async () => {
@@ -90,17 +115,16 @@ function createStore(data) {
             .map(key => (regex.exec(key) ? data[key] : null))
             .filter(e => e)
           return result
+        },
+        forEach: cb => {
+          Object.keys(data).forEach(key => {
+            if (regex.exec(key)) cb(data[key])
+          })
         }
       }
     }),
-    findOne: sinon.stub().callsFake(async filter => {
-      const name = filter._id
-      if (name.includes('error')) throw new Error('test error')
-      if (data[name]) return data[name]
-      throw new Error('not found')
-    }),
-    replaceOne: sinon.stub(),
-    deleteOne: sinon.stub()
+    insertMany: sinon.stub(),
+    deleteMany: sinon.stub()
   }
   const store = Store({})
   store.collection = collectionStub


### PR DESCRIPTION
For documents that have more than 1000 files, we will split them across different documents in the store.

This should be transparent to any callers of the store. we will get and set as one logical document.

Things to note:
 - adding a partitionKey set to the canonical coordinates so we can keep multiple pages of a single document on a single partition
 - storing currentPage and totalPages as metadata on the document in a `_mongo` property specific to this store and not surfaced as part of the definition
 - working with some larger documents surfaced some bugs in our harvested data around the file lists, we are now treating the clearlydefined tool as the source of truth for absolute file list