### PR TITLE
update maven summarization for new harvest schema

### DIFF
--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -122,7 +122,8 @@ class ClearlyDescribedSummarizer {
 
   addMavenData(result, data) {
     setIfValue(result, 'described.releaseDate', extractDate(data.releaseDate))
-    const projectSummaryLicenses = get(data, 'manifest.summary.project.licenses')
+    const projectSummaryLicenses =
+      get(data, 'manifest.summary.licenses') || get(data, 'manifest.summary.project.licenses') // the project layer was removed in 1.2.0
     if (!projectSummaryLicenses) return
     const licenseSummaries = flatten(projectSummaryLicenses.map(x => x.license))
     const licenseUrls = uniq(flatten(licenseSummaries.map(license => license.url)))


### PR DESCRIPTION
the project layer was removed in 1.2.0 when we started inheriting poms