### PR TITLE
implement getAll in the definition store

### DIFF
--- a/providers/stores/abstractFileStore.js
+++ b/providers/stores/abstractFileStore.js
@@ -55,6 +55,20 @@ class AbstractFileStore {
     }
   }
 
+  /**
+   * Get and return the objects at the given coordinates list.
+   *
+   * @param {Array<Coordinates>} coordinatesList - Array of the coordinates for the objects to get
+   * @returns Array of the loaded objects
+   */
+  getAll(coordinatesList) {
+    return Promise.all(
+      coordinatesList.map(coordinates => {
+        return this.get(coordinates)
+      })
+    )
+  }
+
   _isValidPath(entry) {
     return AbstractFileStore.isInterestingCoordinates(this._toResultCoordinatesFromStoragePath(entry))
   }


### PR DESCRIPTION
 - instead of going 1 by 1 to mongo we do a $in for the whole list
- the blob and file implementations still go 1 by 1

The thinking is that we will get big performance gains by doing 1 roundtrip to the DB instead of many little trips. This uses the `cursor.forEach()` to stream the results.

Any coordinates that are not found we call the original get() with force=true in order to compute, store, and return the definition if available.