### PR TITLE
add statusService with service and crawler queries

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,6 +64,9 @@ function createApp(config) {
   const noticeService = require('./business/noticeService')(definitionService, attachmentStore)
   const noticesRoute = require('./routes/notices')(noticeService)
 
+  const statusService = require('./business/statusService')(config.insights)
+  const statusRoute = require('./routes/status')(statusService)
+
   const attachmentsRoute = require('./routes/attachments')(attachmentStore)
 
   const githubSecret = config.webhook.githubSecret
@@ -130,6 +133,7 @@ function createApp(config) {
   app.use('/notices', noticesRoute)
   app.use('/attachments', attachmentsRoute)
   app.use('/suggestions', suggestionsRoute)
+  app.use('/status', statusRoute)
 
   // catch 404 and forward to error handler
   const requestHandler = (req, res, next) => {

--- a/bin/config.js
+++ b/bin/config.js
@@ -66,5 +66,11 @@ module.exports = {
   },
   search: {
     service: loadFactory(config.get('SEARCH_PROVIDER') || 'memory', 'search')
+  },
+  insights: {
+    serviceId: config.get('APPINSIGHTS_SERVICE_APPLICATIONID'),
+    serviceKey: config.get('APPINSIGHTS_SERVICE_APIKEY'),
+    crawlerId: config.get('APPINSIGHTS_CRAWLER_APPLICATIONID'),
+    crawlerKey: config.get('APPINSIGHTS_CRAWLER_APIKEY')
   }
 }

--- a/business/statusService.js
+++ b/business/statusService.js
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const requestPromise = require('request-promise-native')
+
+class StatusService {
+  constructor(options) {
+    this.options = options
+    this.statusLookup = this._getStatusLookup()
+  }
+
+  async get(key) {
+    key = key.toLowerCase()
+    if (!this.statusLookup[key]) throw new Error('Not found')
+    try {
+      return this.statusLookup[key].bind(this)()
+    } catch (error) {
+      this.logger.error(`Status service failed for ${key}`, error)
+      throw new Error('unexpected error')
+    }
+  }
+
+  list() {
+    return Object.keys(this.statusLookup)
+  }
+
+  _getStatusLookup() {
+    return {
+      requestcount: this._requestCount,
+      definitionavailability: this._definitionAvailability,
+      processedperday: this._processedPerDay,
+      recentlycrawled: this._recentlyCrawled
+    }
+  }
+
+  async _requestCount() {
+    const data = await requestPromise(
+      this._serviceQuery(`
+      requests
+      | where timestamp > ago(90d)
+      | summarize count() by bin(timestamp, 1d)
+      | order by timestamp asc`)
+    )
+    return data.tables[0].rows.reduce((result, row) => {
+      result[row[0]] = row[1]
+      return result
+    }, {})
+  }
+
+  async _definitionAvailability() {
+    const data = await requestPromise(
+      this._serviceQuery(`
+      traces
+      | where timestamp > ago(90d)
+      | where message == "recomputed definition available" or message == "definition not available"  or message == "computed definition available"
+      | summarize count() by message`)
+    )
+    return data.tables[0].rows.reduce((result, row) => {
+      result[row[0]] = row[1]
+      return result
+    }, {})
+  }
+
+  async _processedPerDay() {
+    const data = await requestPromise(
+      this._crawlerQuery(`
+      traces
+      | where timestamp > ago(90d)
+      | where strlen(customDimensions.crawlerHost) > 0
+      | where customDimensions.outcome == 'Processed'
+      | summarize count() by bin(timestamp, 1d) , tostring(customDimensions.crawlerHost)
+      | order by timestamp asc`)
+    )
+    const grouped = data.tables[0].rows.reduce((result, row) => {
+      let date = row[0]
+      result[date] = result[data] || {}
+      result[date][row[1]] = row[2]
+      return result
+    }, {})
+    return Object.keys(grouped).map(date => {
+      return { ...grouped[date], date }
+    })
+  }
+
+  async _recentlyCrawled() {
+    const data = await requestPromise(
+      this._crawlerQuery(`
+      traces
+      | where timestamp > ago(1d)
+      | where strlen(customDimensions.crawlerHost) > 0
+      | where customDimensions.outcome == 'Processed'
+      | extend root = tostring(customDimensions.root)
+      | parse root with type "@cd:/" coordinates
+      | project coordinates, timestamp
+      | summarize when=max(timestamp) by coordinates
+      | order by when desc
+      | take 50`)
+    )
+    return data.tables[0].rows.map(row => {
+      return { coordinates: row[0], timestamp: row[1] }
+    })
+  }
+
+  _serviceQuery(query) {
+    return {
+      method: 'POST',
+      url: `https://api.applicationinsights.io/v1/apps/${this.options.serviceId}/query`,
+      headers: { 'X-Api-Key': this.options.serviceKey, 'Content-Type': 'application/json; charset=utf-8' },
+      body: { query },
+      withCredentials: false,
+      json: true
+    }
+  }
+
+  _crawlerQuery(query) {
+    return {
+      method: 'POST',
+      url: `https://api.applicationinsights.io/v1/apps/${this.options.crawlerId}/query`,
+      headers: { 'X-Api-Key': this.options.crawlerKey, 'Content-Type': 'application/json; charset=utf-8' },
+      body: { query },
+      withCredentials: false,
+      json: true
+    }
+  }
+}
+
+module.exports = options => new StatusService(options)

--- a/business/statusService.js
+++ b/business/statusService.js
@@ -73,7 +73,7 @@ class StatusService {
     )
     const grouped = data.tables[0].rows.reduce((result, row) => {
       let date = row[0]
-      result[date] = result[data] || {}
+      result[date] = result[date] || {}
       result[date][row[1]] = row[2]
       return result
     }, {})

--- a/routes/status.js
+++ b/routes/status.js
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const asyncMiddleware = require('../middleware/asyncMiddleware')
+const express = require('express')
+const router = express.Router()
+
+router.get('', (request, response) => {
+  response.send(statusService.list())
+})
+
+router.get('/:key', asyncMiddleware(getRequests))
+async function getRequests(request, response) {
+  const result = await statusService.get(request.params.key)
+  response.send(result)
+}
+
+let statusService
+
+function setup(service) {
+  statusService = service
+  return router
+}
+
+module.exports = setup


### PR DESCRIPTION
list the available statuses queries: `/status/`
![image](https://user-images.githubusercontent.com/5168796/52312461-78fd2a00-295f-11e9-9817-72739faff91d.png)

request counts per day: `/status/requestcount`
![image](https://user-images.githubusercontent.com/5168796/52312492-96ca8f00-295f-11e9-889c-91197e428c66.png)

definition availability distribution: `/status/definitionAvailability`
![image](https://user-images.githubusercontent.com/5168796/52312514-aa75f580-295f-11e9-8fae-2d4f33eb4219.png)

components processed per day per host: `/status/processedperday`
![image](https://user-images.githubusercontent.com/5168796/52312533-b82b7b00-295f-11e9-98db-ff6bd979c46a.png)/

recently crawled coordinates: `/status/recentlycrawled`
![image](https://user-images.githubusercontent.com/5168796/52312561-d5f8e000-295f-11e9-8e82-d4ba0b6764de.png)

