### PR TITLE
bump up the size limit on webhook body

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,7 +98,7 @@ function createApp(config) {
 
   const swaggerOptions = { swaggerUrl: `${config.endpoints.service}/schemas/swagger.yaml` }
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(null, swaggerOptions))
-  app.use('/webhook', bodyParser.raw({ limit: '5mb', type: '*/*' }), webhookRoute)
+  app.use('/webhook', bodyParser.raw({ limit: '10mb', type: '*/*' }), webhookRoute)
 
   // OAuth app initialization; skip if not configured (middleware can cope)
   const auth = config.auth.service.route(null, config.endpoints)


### PR DESCRIPTION
we've been dropping a lot of webhooks because of `PayloadTooLargeError` 

Want to see if we can bring the number of dropped hooks down without causing too much trouble