### PR TITLE
update commons-clause exception handling

### DIFF
--- a/lib/spdx.js
+++ b/lib/spdx.js
@@ -33,7 +33,7 @@ function parse(expression, licenseVisitor) {
  * @returns {string} the SPDX expression
  */
 function stringify(obj) {
-  if (obj.hasOwnProperty('noassertion')) return NOASSERTION
+  if (obj.hasOwnProperty('noassertion') || obj.exception === NOASSERTION) return NOASSERTION
   if (obj.license) return `${obj.license}${obj.plus ? '+' : ''}${obj.exception ? ` WITH ${obj.exception}` : ''}`
   const left = obj.left.conjunction === 'or' ? `(${stringify(obj.left)})` : stringify(obj.left)
   const right = obj.right.conjunction === 'or' ? `(${stringify(obj.right)})` : stringify(obj.right)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6168,7 +6168,7 @@
       "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
     },
     "spdx-expression-parse": {
-      "version": "github:clearlydefined/spdx-expression-parse.js#c4827de980e293302e225fe924c9edd89f7d1064",
+      "version": "github:clearlydefined/spdx-expression-parse.js#9c9211181d82c9df70dae6e2599ee84fd19e4858",
       "from": "github:clearlydefined/spdx-expression-parse.js#fork",
       "requires": {
         "spdx-exceptions": "^2.1.0",

--- a/test/lib/spdx.js
+++ b/test/lib/spdx.js
@@ -48,7 +48,9 @@ describe('SPDX utility functions', () => {
             right: { license: 'Apache-2.0' }
           }
         }
-      ]
+      ],
+      ['Apache-2.0 WITH Autoconf-exception-2.0', { license: 'Apache-2.0', exception: 'Autoconf-exception-2.0' }],
+      ['Apache-2.0 WITH commons-clause', { license: 'Apache-2.0', exception: 'NOASSERTION' }]
     ])
 
     data.forEach((expected, input) => {
@@ -96,7 +98,9 @@ describe('SPDX utility functions', () => {
           }
         },
         'MIT AND BSD-3-Clause WITH GCC-exception-3.1 OR CC-BY-4.0 AND Apache-2.0'
-      ]
+      ],
+      [{ license: 'Apache-2.0', exception: 'Autoconf-exception-2.0' }, 'Apache-2.0 WITH Autoconf-exception-2.0'],
+      [{ license: 'Apache-2.0', exception: 'NOASSERTION' }, 'NOASSERTION']
     ])
 
     data.forEach((expected, input) => {
@@ -138,6 +142,7 @@ describe('SPDX utility functions', () => {
       'MIT ': 'MIT',
       ' MIT': 'MIT',
       'GPL-1.0+': 'GPL-1.0+',
+      'Apache-2.0 WITH commons-clause': 'NOASSERTION',
       'NOASSERTION': 'NOASSERTION',
       'See license': 'NOASSERTION',
       'MIT OR Apache-2.0': 'MIT OR Apache-2.0',

--- a/test/providers/summary/scancode.js
+++ b/test/providers/summary/scancode.js
@@ -125,7 +125,7 @@ describe('ScancodeSummarizer fixtures', () => {
     })
   })
 
-  it('summarizes common-clause in 3.0.2', () => {
+  it('summarizes commons-clause as NOASSERTION in 3.0.2', () => {
     const coordinates = {
       type: 'git',
       provider: 'github',
@@ -136,13 +136,13 @@ describe('ScancodeSummarizer fixtures', () => {
     const harvestData = getHarvestData('3.0.2', 'commons-clause')
     const result = summarizer.summarize(coordinates, harvestData)
     assert.deepEqual(result.described, { releaseDate: '2019-01-31' })
-    assert.deepEqual(result.licensed, { declared: 'Apache-2.0 WITH commons-clause' })
+    assert.deepEqual(result.licensed, { declared: 'NOASSERTION' })
     assert.deepEqual(result.files.length, 576)
     assert.deepEqual(uniq(flatten(result.files.map(x => x.attributions))).filter(x => x).length, 21)
     assert.deepEqual(result.files.filter(x => x.natures), [
       {
         path: 'LICENSE',
-        license: 'Apache-2.0 WITH commons-clause',
+        license: 'NOASSERTION',
         natures: ['license'],
         attributions: ['Copyright 2018-2019 Redis Labs Ltd. and Contributors.'],
         hashes: { sha1: '6c9da49858267f91fa10f08ad556f02fdc689e63' }


### PR DESCRIPTION
we should not be accepting of all exceptions
if a non-spdx exception is used then the license is NOASSERTION