### PR TITLE
fix no coordinates path for curations

### DIFF
--- a/providers/curation/mongoCurationStore.js
+++ b/providers/curation/mongoCurationStore.js
@@ -89,7 +89,7 @@ class MongoCurationStore {
   async list(coordinates) {
     if (!coordinates) throw new Error('must specify coordinates to list')
     const pattern = this._getCurationId(coordinates.asRevisionless())
-    if (!pattern) return []
+    if (!pattern) return null
     const curations = await this.collection
       .find({ _id: new RegExp('^' + pattern) })
       .project({ _id: 0 })

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -50,7 +50,7 @@ router.get('/:type?/:provider?/:namespace?/:name?', asyncMiddleware(listCuration
 async function listCurations(request, response) {
   const coordinates = utils.toEntityCoordinatesFromRequest(request)
   const result = await curationService.list(coordinates)
-  if (!result.contributions.length) return response.sendStatus(404)
+  if (!result || !result.contributions.length) return response.sendStatus(404)
   return response.status(200).send(result)
 }
 

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -127,9 +127,11 @@ describe('Github Curation Service', () => {
       ]
     }
 
-    expect(
+    await expect(
       gitHubService.addOrUpdate(null, gitHubService.github, info, contributionPatch)
-    ).to.eventually.be.rejectedWith(Error)
+    ).to.eventually.be.rejectedWith(
+      'The contribution has failed because some of the supplied component definitions do not exist'
+    )
   })
 
   it('create a PR only if all of the definitions exist', async () => {

--- a/test/providers/curation/mongoCurationStore.js
+++ b/test/providers/curation/mongoCurationStore.js
@@ -135,6 +135,14 @@ describe('Mongo Curation store', () => {
     expect(service.collection.find().sort.args[0][0]).to.deep.eq({ 'pr.number': -1 })
     expect(result.curations).to.deep.eq({ 'npm/npmjs/-/foo/1.0': { described: { projectWebsite: 'http://foo.com' } } })
   })
+
+  it('handles list with no coordinates', async () => {
+    const service = createStore()
+    const result = await service.list(new EntityCoordinates())
+    expect(result).to.be.null
+
+    await expect(service.list()).to.eventually.be.rejectedWith('must specify coordinates to list')
+  })
 })
 
 function createStore() {


### PR DESCRIPTION
This comes up if you request 

https://api.clearlydefined.io/curations/ with no data.
We are incorrectly checking the result and get a null ref

updated test that was not properly awaiting the assertion