### PR TITLE
remove regex from mongo query for namespace/name

### DIFF
--- a/providers/stores/mongo.js
+++ b/providers/stores/mongo.js
@@ -168,8 +168,8 @@ class MongoStore {
     const filter = { '_mongo.page': 1 } // only get page 1 of each definition
     if (parameters.type) filter['coordinates.type'] = parameters.type
     if (parameters.provider) filter['coordinates.provider'] = parameters.provider
-    if (parameters.namespace) filter['coordinates.namespace'] = new RegExp(parameters.namespace, 'i')
-    if (parameters.name) filter['coordinates.name'] = new RegExp(parameters.name, 'i')
+    if (parameters.namespace) filter['coordinates.namespace'] = parameters.namespace
+    if (parameters.name) filter['coordinates.name'] = parameters.name
     if (parameters.type === null) filter['coordinates.type'] = null
     if (parameters.provider === null) filter['coordinates.provider'] = null
     if (parameters.name === null) filter['coordinates.name'] = null

--- a/test/providers/store/mongoDefinition.js
+++ b/test/providers/store/mongoDefinition.js
@@ -103,10 +103,10 @@ describe('Mongo Definition store', () => {
       [{}, { '_mongo.page': 1 }],
       [{ type: 'npm' }, { '_mongo.page': 1, 'coordinates.type': 'npm' }],
       [{ provider: 'npmjs' }, { '_mongo.page': 1, 'coordinates.provider': 'npmjs' }],
-      [{ name: 'package' }, { '_mongo.page': 1, 'coordinates.name': /package/i }],
+      [{ name: 'package' }, { '_mongo.page': 1, 'coordinates.name': 'package' }],
       [
         { namespace: '@owner', name: 'package' },
-        { '_mongo.page': 1, 'coordinates.name': /package/i, 'coordinates.namespace': /@owner/i }
+        { '_mongo.page': 1, 'coordinates.name': 'package', 'coordinates.namespace': '@owner' }
       ],
       [{ license: 'MIT' }, { '_mongo.page': 1, 'licensed.declared': 'MIT' }],
       [{ releasedAfter: '2018-01-01' }, { '_mongo.page': 1, 'described.releaseDate': { $gt: '2018-01-01' } }],
@@ -127,8 +127,8 @@ describe('Mongo Definition store', () => {
     const continuationToken = 'bnBtL25wbWpzLy0vdmVycm9yLzEuMTAuMA'
     const expected = {
       '_mongo.page': 1,
-      'coordinates.name': /package/i,
-      'coordinates.namespace': /@owner/i,
+      'coordinates.name': 'package',
+      'coordinates.namespace': '@owner',
       '_mongo.partitionKey': { $gt: 'npm/npmjs/-/verror/1.10.0' }
     }
     expect(store._buildQuery(parameters, continuationToken)).to.deep.equal(expected)


### PR DESCRIPTION
the regex searches are not indexed
the results are way too slow and expensive to expose