### PR TITLE
remove regex markers from suggestions queries

### DIFF
--- a/business/suggestionService.js
+++ b/business/suggestionService.js
@@ -35,8 +35,7 @@ class SuggestionService {
    */
   async _getRelatedDefinitions(coordinates) {
     const query = { ...coordinates.asRevisionless(), sort: 'releaseDate' }
-    query.name = `^${query.name}$` // exact name matches only
-    query.namespace = query.namespace ? `^${query.namespace}$` : null // exact namespace matches only
+    query.namespace = query.namespace ? query.namespace : null // explicitly exclude namespace
     const results = await this.definitionService.find(query)
     const definitions = results.data
     // If the related array only has one entry then return early

--- a/test/business/suggestionServiceTest.js
+++ b/test/business/suggestionServiceTest.js
@@ -25,7 +25,7 @@ describe('Suggestion Service', () => {
     expect(service.definitionService.find.getCall(0).args[0]).to.deep.eq({
       type: 'npm',
       provider: 'npmjs',
-      name: '^test$',
+      name: 'test',
       namespace: null,
       sort: 'releaseDate'
     })
@@ -50,7 +50,7 @@ describe('Suggestion Service', () => {
     expect(service.definitionService.find.getCall(0).args[0]).to.deep.eq({
       type: 'npm',
       provider: 'npmjs',
-      name: '^test$',
+      name: 'test',
       namespace: null,
       sort: 'releaseDate'
     })
@@ -75,8 +75,8 @@ describe('Suggestion Service', () => {
     expect(service.definitionService.find.getCall(0).args[0]).to.deep.eq({
       type: 'npm',
       provider: 'npmjs',
-      name: '^scope-test$',
-      namespace: '^@scope$',
+      name: 'scope-test',
+      namespace: '@scope',
       sort: 'releaseDate'
     })
   })


### PR DESCRIPTION
this was leftover from when we switched to exact match in #431 