### PR TITLE
add top level scores definition element

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -285,7 +285,7 @@ class DefinitionService {
 
   _ensureFinalScores(definition) {
     const { described, licensed } = definition
-    set(definition, 'scores.curated', Math.floor((described.score.total + licensed.score.total) / 2))
+    set(definition, 'scores.effective', Math.floor((described.score.total + licensed.score.total) / 2))
     set(definition, 'scores.tool', Math.floor((described.toolScore.total + licensed.toolScore.total) / 2))
   }
 

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -241,6 +241,7 @@ class DefinitionService {
     const definition = await this.curationService.apply(coordinates, curationSpec, aggregatedDefinition)
     await this._finalizeDefinition(coordinates, definition)
     this._ensureCuratedScores(definition)
+    this._ensureFinalScores(definition)
     // protect against any element of the compute producing an invalid definition
     this._ensureNoNulls(definition)
     this._validate(definition)
@@ -280,6 +281,12 @@ class DefinitionService {
     const { describedScore, licensedScore } = this._computeScores(definition)
     set(definition, 'described.score', describedScore)
     set(definition, 'licensed.score', licensedScore)
+  }
+
+  _ensureFinalScores(definition) {
+    const { described, licensed } = definition
+    set(definition, 'scores.curated', Math.floor((described.score.total + licensed.score.total) / 2))
+    set(definition, 'scores.tool', Math.floor((described.toolScore.total + licensed.toolScore.total) / 2))
   }
 
   async _finalizeDefinition(coordinates, definition) {

--- a/providers/stores/mongo.js
+++ b/providers/stores/mongo.js
@@ -16,7 +16,9 @@ const sortOptions = {
   license: 'licensed.declared',
   releaseDate: 'described.releaseDate',
   licensedScore: 'licensed.score.total',
-  describedScore: 'described.score.total'
+  describedScore: 'described.score.total',
+  effectiveScore: 'scores.effective',
+  toolScore: 'scores.tool'
 }
 
 class MongoStore {
@@ -177,6 +179,10 @@ class MongoStore {
     if (parameters.license) filter['licensed.declared'] = parameters.license
     if (parameters.releasedAfter) filter['described.releaseDate'] = { $gt: parameters.releasedAfter }
     if (parameters.releasedBefore) filter['described.releaseDate'] = { $lt: parameters.releasedBefore }
+    if (parameters.minEffectiveScore) filter['scores.effective'] = { $gt: parseInt(parameters.minEffectiveScore) }
+    if (parameters.maxEffectiveScore) filter['scores.effective'] = { $lt: parseInt(parameters.maxEffectiveScore) }
+    if (parameters.minToolScore) filter['scores.tool'] = { $gt: parseInt(parameters.minToolScore) }
+    if (parameters.maxToolScore) filter['scores.tool'] = { $lt: parseInt(parameters.maxToolScore) }
     if (parameters.minLicensedScore) filter['licensed.score.total'] = { $gt: parseInt(parameters.minLicensedScore) }
     if (parameters.maxLicensedScore) filter['licensed.score.total'] = { $lt: parseInt(parameters.maxLicensedScore) }
     if (parameters.minDescribedScore) filter['described.score.total'] = { $gt: parseInt(parameters.minDescribedScore) }

--- a/schemas/definition-1.0.json
+++ b/schemas/definition-1.0.json
@@ -53,6 +53,16 @@
         }
       }
     },
+    "finalScore": {
+      "type": "object",
+      "description": "The total effective and tool scores for the definition",
+      "additionalProperties": false,
+      "required": ["effective", "tool"],
+      "properties": {
+        "effective": { "type": "number" },
+        "tool": { "type": "number" }
+      }
+    },
     "files": {
       "type": "array",
       "items": {
@@ -141,16 +151,6 @@
             "type": "string"
           }
         }
-      }
-    },
-    "finalScore": {
-      "type": "object",
-      "description": "The total scores for the definition",
-      "additionalProperties": false,
-      "required": ["curated", "tool"],
-      "properties": {
-        "curated": { "type": "number" },
-        "tool": { "type": "number" }
       }
     },
     "describedScore": {

--- a/schemas/definition-1.0.json
+++ b/schemas/definition-1.0.json
@@ -9,6 +9,7 @@
   "properties": {
     "_meta": { "$ref": "#/definitions/_meta" },
     "coordinates": { "$ref": "#/definitions/coordinates" },
+    "scores": { "$ref": "#/definitions/finalScore" },
     "files": { "$ref": "#/definitions/files" },
     "described": { "$ref": "#/definitions/described" },
     "licensed": { "$ref": "#/definitions/licensed" }
@@ -140,6 +141,16 @@
             "type": "string"
           }
         }
+      }
+    },
+    "finalScore": {
+      "type": "object",
+      "description": "The total scores for the definition",
+      "additionalProperties": false,
+      "required": ["curated", "tool"],
+      "properties": {
+        "curated": { "type": "number" },
+        "tool": { "type": "number" }
       }
     },
     "describedScore": {

--- a/schemas/definitions-find.json
+++ b/schemas/definitions-find.json
@@ -47,6 +47,30 @@
         "type": "releasedBefore must be a string"
       }
     },
+    "minEffectiveScore": {
+      "type": "number",
+      "errorMessage": {
+        "type": "minEffectiveScore must be a number"
+      }
+    },
+    "maxEffectiveScore": {
+      "type": "number",
+      "errorMessage": {
+        "type": "maxEffectiveScore must be a number"
+      }
+    },
+    "minToolScore": {
+      "type": "number",
+      "errorMessage": {
+        "type": "minToolScore must be a number"
+      }
+    },
+    "maxToolScore": {
+      "type": "number",
+      "errorMessage": {
+        "type": "maxToolScore must be a number"
+      }
+    },
     "minLicensedScore": {
       "type": "number",
       "errorMessage": {
@@ -72,7 +96,18 @@
       }
     },
     "sort": {
-      "enum": ["type", "provider", "name", "namespace", "license", "releaseDate", "licensedScore", "describedScore"],
+      "enum": [
+        "type",
+        "provider",
+        "name",
+        "namespace",
+        "license",
+        "releaseDate",
+        "licensedScore",
+        "describedScore",
+        "effectiveScore",
+        "toolScore"
+      ],
       "type": "string",
       "errorMessage": {
         "type": "sort must be a string"

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -76,6 +76,8 @@ describe('Definition Service', () => {
     expect(definition.described.toolScore.total).to.eq(0)
     expect(definition.licensed.score.total).to.eq(85)
     expect(definition.licensed.toolScore.total).to.eq(0)
+    expect(definition.scores.curated).to.eq(57) // floor(85+30/2)
+    expect(definition.scores.tool).to.eq(0)
   })
 
   it('lists all coordinates found', async () => {

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -76,7 +76,7 @@ describe('Definition Service', () => {
     expect(definition.described.toolScore.total).to.eq(0)
     expect(definition.licensed.score.total).to.eq(85)
     expect(definition.licensed.toolScore.total).to.eq(0)
-    expect(definition.scores.curated).to.eq(57) // floor(85+30/2)
+    expect(definition.scores.effective).to.eq(57) // floor(85+30/2)
     expect(definition.scores.tool).to.eq(0)
   })
 

--- a/test/providers/store/mongoDefinition.js
+++ b/test/providers/store/mongoDefinition.js
@@ -114,7 +114,11 @@ describe('Mongo Definition store', () => {
       [{ minLicensedScore: 50 }, { '_mongo.page': 1, 'licensed.score.total': { $gt: 50 } }],
       [{ maxLicensedScore: 50 }, { '_mongo.page': 1, 'licensed.score.total': { $lt: 50 } }],
       [{ minDescribedScore: 50 }, { '_mongo.page': 1, 'described.score.total': { $gt: 50 } }],
-      [{ maxDescribedScore: 50 }, { '_mongo.page': 1, 'described.score.total': { $lt: 50 } }]
+      [{ maxDescribedScore: 50 }, { '_mongo.page': 1, 'described.score.total': { $lt: 50 } }],
+      [{ minEffectiveScore: 50 }, { '_mongo.page': 1, 'scores.effective': { $gt: 50 } }],
+      [{ maxEffectiveScore: 50 }, { '_mongo.page': 1, 'scores.effective': { $lt: 50 } }],
+      [{ minToolScore: 50 }, { '_mongo.page': 1, 'scores.tool': { $gt: 50 } }],
+      [{ maxToolScore: 50 }, { '_mongo.page': 1, 'scores.tool': { $lt: 50 } }]
     ])
     data.forEach((expected, input) => {
       expect(store._buildQuery(input)).to.deep.equal(expected)
@@ -145,7 +149,9 @@ describe('Mongo Definition store', () => {
       [{ sort: 'license', sortDesc: true }, { 'licensed.declared': -1 }],
       [{ sort: 'releaseDate' }, { 'described.releaseDate': 1 }],
       [{ sort: 'licensedScore', sortDesc: false }, { 'licensed.score.total': 1 }],
-      [{ sort: 'describedScore' }, { 'described.score.total': 1 }]
+      [{ sort: 'describedScore' }, { 'described.score.total': 1 }],
+      [{ sort: 'effectiveScore' }, { 'scores.effective': 1 }],
+      [{ sort: 'toolScore' }, { 'scores.tool': 1 }]
     ])
     data.forEach((expected, input) => {
       expect(store._buildSort(input)).to.deep.equal(expected)


### PR DESCRIPTION
Fixes #436 

Here we add a new top level definition element for `scores`. It captures the average score across all of the dimensions (currently only licensed and described) for both curated and tools scores. The curated score is generally the score that the UI renders for the user.