### PR TITLE
check the store for existing curations

### DIFF
--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -287,17 +287,13 @@ ${this._formatDefinitions(patch.patches)}`
    */
   async _getCurations(coordinates, pr = null) {
     // Check to see if there is content for the given coordinates
-    const path = this._getCurationPath(coordinates)
-    const { owner, repo } = this.options
-    const branch = await this._getBranchAndSha(pr)
-    const branchName = branch.sha || branch.ref
-    const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branchName}/${path}`
-    const content = await requestPromise({ url, method: 'HEAD', resolveWithFullResponse: true, simple: false })
-    if (content.statusCode !== 200) return null
+    const curation = await this.store.getCuration(coordinates)
+    if (!get(curation, `revisions['${coordinates.revision}']`)) return null
     // If there is content, go and get it. This is a little wasteful (two calls) but
     // a) the vast majority of coordinates will not have any curation
     // b) we need the sha of the curation to form part of the final definition tool chain
     // At some point in the future we can look at caching and etags etc
+    const branch = await this._getBranchAndSha(pr)
     return this._getFullContent(coordinates, branch.ref)
   }
 

--- a/providers/curation/memoryStore.js
+++ b/providers/curation/memoryStore.js
@@ -25,6 +25,10 @@ class MemoryStore {
     return this.contributions[prNumber]
   }
 
+  getCuration(coordinates) {
+    return this.curations[this._getCurationId(coordinates)]
+  }
+
   updateContribution(pr, curations = null) {
     if (curations) {
       const files = {}

--- a/providers/curation/mongoCurationStore.js
+++ b/providers/curation/mongoCurationStore.js
@@ -54,6 +54,15 @@ class MongoCurationStore {
   }
 
   /**
+   * Retrieve the curation by coordinates
+   * @param {EntityCoordinates} coordinates
+   * @returns the Curations found if any
+   */
+  getCuration(coordinates) {
+    return this.collection.findOne({ _id: this._getCurationId(coordinates.asRevisionless()) })
+  }
+
+  /**
    * Update the contribution entry for the given PR and record the associated curations -- the
    * actual file content in the PR. If the curations are not provided, just the PR data is updated,
    * any existing curation data is preserved.


### PR DESCRIPTION
we were checking github directly with HEAD requests
this was happening on the order of ~50K per day
our new curation requests started getting throttled
This increases load on the DB, but should reduce our rate in GitHub