### PR TITLE
[Fossology] make 'See-file' licenseId a noop

### DIFF
--- a/providers/summary/fossology.js
+++ b/providers/summary/fossology.js
@@ -5,6 +5,8 @@ const { mergeDefinitions, setIfValue, isLicenseFile } = require('../../lib/utils
 const SPDX = require('../../lib/spdx')
 const { get, uniq } = require('lodash')
 
+const noOpLicenseIds = new Set(['No_license_found', 'See-file'])
+
 class FOSSologySummarizer {
   constructor(options) {
     this.options = options
@@ -40,7 +42,7 @@ class FOSSologySummarizer {
         const match = /^File (.*?) contains license\(s\) (.*?)$/.exec(file)
         if (!match) return null
         const [, path, rawLicense] = match
-        const license = rawLicense !== 'No_license_found' ? SPDX.normalize(rawLicense) : null
+        const license = noOpLicenseIds.has(rawLicense) ? null : SPDX.normalize(rawLicense)
         if (path && license) return { path, license }
         if (path) return { path }
       })

--- a/test/summary/fossology.js
+++ b/test/summary/fossology.js
@@ -61,6 +61,13 @@ describe('Nomos summarizer', () => {
   })
 })
 
+it('does not apply See-file license detection', () => {
+  const { coordinates, harvested } = setup([buildNomosFile('foo.txt', 'See-file')])
+  const summary = Summarizer().summarize(coordinates, harvested)
+  validate(summary)
+  expect(summary.files).to.deep.eq([{ path: 'foo.txt' }])
+})
+
 describe('Monk summarizer', () => {
   it('gets all the per file license info', () => {
     const { coordinates, harvested } = setup([buildMonkFile('foo.txt', 'MIT'), buildMonkFile('bar.txt', 'GPL-3.0')])


### PR DESCRIPTION
See-file is set when fossology detects a license related comment that references other files
Instead of marking the license for this file as NOASSERTION - we abstain from passing judgement
from the Fossology side