### PR TITLE
add definition store dispatcher

### DIFF
--- a/bin/config.js
+++ b/bin/config.js
@@ -9,10 +9,22 @@ const providers = require('../providers')
  * of the providers module (e.g., search or store). The `spec` is the name of a module (e.g.,
  * file, memory, mongo) and an optional object path within that module that leads to the
  * desired factory.
+ * Dispatch to multiple with + (e.g. spec=dispatch+mongo+azblob)
  * @param {*} spec - indicator of the module and factory to load
  * @param {*} namespace - an optional place to look for built in factories
  */
+
 function loadFactory(spec, namespace) {
+  const names = spec.split('+')
+  const factory = loadOne(names[0], namespace)
+  const factories = names.slice(1).map(name => loadOne(name, namespace))
+  if (factories.length) {
+    return () => factory({ factories })
+  }
+  return factory
+}
+
+function loadOne(spec, namespace) {
   const [requirePath, objectPath] = spec.split('|')
   const getPath = (namespace ? namespace + '.' : '') + requirePath
   let target = get(providers, getPath)

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -155,10 +155,6 @@ class DefinitionService {
     return this.definitionStore.find(query, query.continuationToken)
   }
 
-  average(query, fields) {
-    return this.definitionStore.average(query, fields)
-  }
-
   /**
    * Invalidate the definition for the identified component. This flushes any caches and pre-computed
    * results. The definition will be recomputed on or before the next use.

--- a/business/statsService.js
+++ b/business/statsService.js
@@ -51,9 +51,8 @@ class StatsService {
     return result['@odata.count']
   }
 
-  async _getType(type) {
-    const result = await this.definitionService.average({ type }, ['licensed.score.total', 'described.score.total'])
-    return result
+  async _getType() {
+    return 0
   }
 
   _getCacheKey(stat) {

--- a/providers/index.js
+++ b/providers/index.js
@@ -8,7 +8,8 @@ module.exports = {
   definition: {
     azure: require('../providers/stores/azblobConfig').definition,
     file: require('../providers/stores/fileConfig').definition,
-    mongo: require('../providers/stores/mongoConfig')
+    mongo: require('../providers/stores/mongoConfig'),
+    dispatch: require('../providers/stores/dispatchConfig')
   },
   attachment: {
     azure: require('../providers/stores/azblobConfig').attachment,

--- a/providers/stores/abstractAzblobStore.js
+++ b/providers/stores/abstractAzblobStore.js
@@ -68,14 +68,7 @@ class AbstractAzBlobStore {
    * Unsupported. The Blob definition store is not queryable
    */
   async find() {
-    throw new Error('find() is unsupported')
-  }
-
-  /**
-   * Unsupported. The Blob definition store is not queryable
-   */
-  async average() {
-    throw new Error('average() is unsupported')
+    return null
   }
 
   _toStoragePathFromCoordinates(coordinates) {

--- a/providers/stores/abstractFileStore.js
+++ b/providers/stores/abstractFileStore.js
@@ -94,10 +94,6 @@ class AbstractFileStore {
     })
   }
 
-  async average() {
-    throw new Error('average() is unsupported')
-  }
-
   _isValidPath(entry) {
     return AbstractFileStore.isInterestingCoordinates(this._toResultCoordinatesFromStoragePath(entry))
   }

--- a/providers/stores/azblobDefinitionStore.js
+++ b/providers/stores/azblobDefinitionStore.js
@@ -26,7 +26,7 @@ class AzBlobDefinitionStore extends AbstractAzBlobStore {
 
   store(definition) {
     const blobName = this._toStoragePathFromCoordinates(definition.coordinates) + '.json'
-    return promisify(this.blobService.createBlockBlobFromText)(
+    return promisify(this.blobService.createBlockBlobFromText).bind(this.blobService)(
       this.containerName,
       blobName,
       JSON.stringify(definition),
@@ -41,7 +41,7 @@ class AzBlobDefinitionStore extends AbstractAzBlobStore {
   async delete(coordinates) {
     const blobName = this._toStoragePathFromCoordinates(coordinates) + '.json'
     try {
-      await promisify(this.blobService.deleteBlob)(this.containerName, blobName)
+      await promisify(this.blobService.deleteBlob).bind(this.blobService)(this.containerName, blobName)
     } catch (error) {
       if (error.code !== 'BlobNotFound') throw error
     }

--- a/providers/stores/dispatchConfig.js
+++ b/providers/stores/dispatchConfig.js
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+function definition(options) {
+  if (!options.factories) throw new Error('no factories configured')
+  const stores = options.factories.map(x => x())
+  return require('./dispatchDefinitionStore')({ stores })
+}
+
+module.exports = definition

--- a/providers/stores/dispatchDefinitionStore.js
+++ b/providers/stores/dispatchDefinitionStore.js
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const logger = require('../logging/logger')
+
+class DispatchDefinitionStore {
+  constructor(options) {
+    this.stores = options.stores
+    this.logger = logger()
+  }
+
+  initialize() {
+    return this._perform(store => store.initialize())
+  }
+
+  get(coordinates) {
+    return this._perform(store => store.get(coordinates), true)
+  }
+
+  list(coordinates) {
+    return this._perform(store => store.list(coordinates), true)
+  }
+
+  store(definition) {
+    return this._perform(store => store.store(definition))
+  }
+
+  delete(coordinates) {
+    return this._perform(store => store.delete(coordinates))
+  }
+
+  find(query, continuationToken = '') {
+    return this._perform(store => store.find(query, continuationToken), true)
+  }
+
+  async _perform(operation, first = false) {
+    let result = null
+    for (let i = 0; i < this.stores.length; i++) {
+      const store = this.stores[i]
+      try {
+        const opResult = await operation(store)
+        result = result || opResult
+        if (result && first) return result
+      } catch (error) {
+        this.logger.error('DispatchDefinitionStore failure', error)
+      }
+    }
+    return result
+  }
+}
+
+module.exports = options => new DispatchDefinitionStore(options)

--- a/providers/stores/mongo.js
+++ b/providers/stores/mongo.js
@@ -96,35 +96,6 @@ class MongoStore {
     return { data, continuationToken }
   }
 
-  /**
-   * Query and perform an aggregate average on the defintions
-   *
-   * @param {object} query - The filters for the request
-   * @param {string[]} fields - The fields to average
-   * @returns The result of the aggregation
-   */
-  async average(query, fields) {
-    const filter = this._buildQuery(query)
-    const groups = fields.reduce((result, field) => {
-      result[`avg_${field}`] = { $avg: `$${field}` }
-      return result
-    }, {})
-    const data = await this.collection
-      .aggregate([
-        { $match: filter },
-        {
-          $group: {
-            ...groups,
-            _id: null,
-            totalcount: { $sum: 1 }
-          }
-        }
-      ])
-      .project({ _id: 0 })
-      .toArray()
-    return data[0]
-  }
-
   async store(definition) {
     const pageSize = 1000
     definition._id = this._getId(definition.coordinates)


### PR DESCRIPTION
 - removed average that was DOSing the DB
 - add dispatch to read/write to mongo + blob storage

Plan is to use mongo as the primary and store to both blob and mongo moving forward.
Once we catch up and sync the stores, blob can become primary for listing and point lookups while mongo can be primary for queries.

Blob data will be helpful for mirroring story as well as potential search indexing.