### PR TITLE
Omit files

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -5,7 +5,7 @@ const throat = require('throat')
 const {
   get,
   set,
-  sortedUniq,
+  omit,
   remove,
   pullAllWith,
   isEqual,
@@ -60,7 +60,7 @@ class DefinitionService {
    * @param {bool} force - whether or not to force re-computation of the requested definition
    * @returns {Definition} The fully rendered definition
    */
-  async get(coordinates, pr = null, force = false) {
+  async get(coordinates, pr = null, force = false, expand = null) {
     if (pr) {
       const curation = this.curationService.get(coordinates, pr)
       return this.compute(coordinates, curation)
@@ -71,7 +71,7 @@ class DefinitionService {
       this.logger.info('computed definition available', { coordinates: coordinates.toString() })
       result = existing
     } else result = await this.computeAndStore(coordinates)
-    return this._cast(result)
+    return this._trimDefinition(this._cast(result), expand)
   }
 
   async _cacheExistingAside(coordinates, force) {
@@ -82,6 +82,11 @@ class DefinitionService {
     const stored = await this.definitionStore.get(coordinates)
     if (stored) await this.cache.set(cacheKey, stored)
     return stored
+  }
+
+  _trimDefinition(definition, expand) {
+    if (expand === '-files') return omit(definition, 'files')
+    return definition
   }
 
   // ensure the definition is a properly classed object
@@ -98,11 +103,11 @@ class DefinitionService {
    * @param {bool} force - whether or not to force re-computation of the requested definitions
    * @returns A list of all components that have definitions and the definitions that are available
    */
-  async getAll(coordinatesList, force = false) {
+  async getAll(coordinatesList, force = false, expand = null) {
     const result = {}
     const promises = coordinatesList.map(
       throat(10, async coordinates => {
-        const definition = await this.get(coordinates, null, force)
+        const definition = await this.get(coordinates, null, force, expand)
         if (!definition) return
         const key = definition.coordinates.toString()
         result[key] = definition

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -5,6 +5,7 @@ const throat = require('throat')
 const {
   get,
   set,
+  sortedUniq,
   omit,
   remove,
   pullAllWith,

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -18,7 +18,8 @@ async function getDefinition(request, response) {
   const pr = request.params.pr
   // if running on localhost, allow a force arg for testing without webhooks to invalidate the caches
   const force = request.hostname.includes('localhost') ? request.query.force || false : false
-  const result = await definitionService.get(coordinates, pr, force)
+  const expand = request.query.expand === '-files' ? '-files' : null // only support '-files' for now
+  const result = await definitionService.get(coordinates, pr, force, expand)
   response.status(200).send(result)
 }
 
@@ -68,7 +69,8 @@ async function listDefinitions(request, response) {
     return response.status(400).send(`Body contains too many coordinates: ${coordinatesList.length}`)
   // if running on localhost, allow a force arg for testing without webhooks to invalidate the caches
   const force = request.hostname.includes('localhost') ? request.query.force || false : false
-  const result = await definitionService.getAll(coordinatesList, force)
+  const expand = request.query.expand === '-files' ? '-files' : null // only support '-files' for now
+  const result = await definitionService.getAll(coordinatesList, force, expand)
   response.send(result)
 }
 

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -50,6 +50,14 @@ describe('Definition Service', () => {
     expect(service.search.store.calledOnce).to.be.true
   })
 
+  it('trims files from definitions', async () => {
+    const { service, coordinates } = setup(createDefinition(null, [{ path: 'path/to/file' }], ['foo']))
+    const definition = await service.get(coordinates, null, null, '-files')
+    expect(definition.files).to.be.undefined
+    const fullDefinition = await service.get(coordinates)
+    expect(fullDefinition.files).to.deep.eq([{ path: 'path/to/file' }])
+  })
+
   it('harvests new definitions with empty tools', async () => {
     const { service, coordinates } = setup(createDefinition(null, null, []))
     await service.get(coordinates)


### PR DESCRIPTION
if you POST or GET for definitions you can pass `?expand=-files` to chop off the files array from the response

Thinking expand can be extended to do more interesting things later if needed