### PR TITLE
set up blob indexer for search

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -204,7 +204,6 @@ class DefinitionService {
 
   async _store(definition) {
     await this.definitionStore.store(definition)
-    await this.search.store(definition)
     await this.cache.set(this._getCacheKey(definition.coordinates), definition)
   }
 
@@ -411,7 +410,7 @@ class DefinitionService {
           try {
             const definition = await this.get(coordinates, null, recompute)
             if (recompute) return Promise.resolve(null)
-            return this.search.store(definition)
+            if (this.search.store) return this.search.store(definition)
           } catch (error) {
             this.logger.info('failed to reload in definition service', {
               error,

--- a/business/statsService.js
+++ b/business/statsService.js
@@ -55,10 +55,7 @@ class StatsService {
     const response = await this.searchService.query({
       count: true,
       filter: `type eq '${type}'`,
-      facets: [
-        'describedScore,values:10|20|30|40|50|60|70|80|90|100',
-        'licensedScore,values:10|20|30|40|50|60|70|80|90|100'
-      ],
+      facets: ['describedScore,interval:1', 'licensedScore,interval:1'],
       top: 0
     })
     const totalCount = response['@odata.count']
@@ -69,12 +66,12 @@ class StatsService {
 
   _getMedian(frequencyTable, totalCount) {
     if (totalCount === 0) return 0
-    const cutoff = (totalCount + 1) / 2
+    const cutoff = Math.ceil(totalCount / 2)
     let marker = 0
     let median = 0
     for (let i = 0; marker < cutoff && i < frequencyTable.length; i++) {
       marker += frequencyTable[i].count
-      median = frequencyTable[i].to || frequencyTable[i].from
+      median = frequencyTable[i].value
     }
     return median
   }

--- a/business/statsService.js
+++ b/business/statsService.js
@@ -34,7 +34,7 @@ class StatsService {
 
   _getStatLookup() {
     return {
-      totalcount: this._getTotalCount,
+      total: () => this._getType('total'),
       crate: () => this._getType('crate'),
       gem: () => this._getType('gem'),
       git: () => this._getType('git'),
@@ -46,22 +46,18 @@ class StatsService {
     }
   }
 
-  async _getTotalCount() {
-    const result = await this.searchService.query({ count: true, top: 0 })
-    return result['@odata.count']
-  }
-
   async _getType(type) {
     const response = await this.searchService.query({
       count: true,
-      filter: `type eq '${type}'`,
-      facets: ['describedScore,interval:1', 'licensedScore,interval:1'],
+      filter: type === 'total' ? null : `type eq '${type}'`,
+      facets: ['describedScore,interval:1', 'licensedScore,interval:1', 'declaredLicense'],
       top: 0
     })
     const totalCount = response['@odata.count']
     const describedScoreMedian = this._getMedian(response['@search.facets'].describedScore, totalCount)
     const licensedScoreMedian = this._getMedian(response['@search.facets'].licensedScore, totalCount)
-    return { totalCount, describedScoreMedian, licensedScoreMedian }
+    const declaredLicenseBreakdown = this._getFacet(response['@search.facets'].declaredLicense, totalCount)
+    return { totalCount, describedScoreMedian, licensedScoreMedian, declaredLicenseBreakdown }
   }
 
   _getMedian(frequencyTable, totalCount) {
@@ -74,6 +70,18 @@ class StatsService {
       median = frequencyTable[i].value
     }
     return median
+  }
+
+  _getFacet(frequencyTable, totalCount) {
+    const otherSum = frequencyTable.reduce((result, current) => {
+      result -= current.count
+      return result
+    }, totalCount)
+    frequencyTable.push({
+      count: otherSum,
+      value: 'Other'
+    })
+    return frequencyTable
   }
 
   _getCacheKey(stat) {

--- a/providers/search/azureConfig.js
+++ b/providers/search/azureConfig.js
@@ -7,7 +7,15 @@ const search = require('./azureSearch')
 function serviceFactory(options) {
   const realOptions = options || {
     service: config.get('SEARCH_AZURE_SERVICE'),
-    apiKey: config.get('SEARCH_AZURE_API_KEY')
+    apiKey: config.get('SEARCH_AZURE_API_KEY'),
+    dataSourceConnectionString:
+      config.get('SEARCH_AZURE_DATASOURCE_CONNECTION_STRING') ||
+      config.get('DEFINITION_AZBLOB_CONNECTION_STRING') ||
+      config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
+    dataSourceContainerName:
+      config.get('SEARCH_AZURE_DATASOURCE_CONTAINER_NAME') ||
+      config.get('DEFINITION_AZBLOB_CONTAINER_NAME') ||
+      config.get('HARVEST_AZBLOB_CONTAINER_NAME') + '-definition'
   }
   return search(realOptions)
 }

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -47,9 +47,9 @@ describe('Definition Service', () => {
     const { service, coordinates } = setup(createDefinition(null, null, ['foo']))
     await service.get(coordinates)
     expect(service.definitionStore.store.calledOnce).to.be.true
-    expect(service.search.store.calledOnce).to.be.true
+    expect(service.search.store.notCalled).to.be.true
   })
-  
+
   it('trims files from definitions', async () => {
     const { service, coordinates } = setup(createDefinition(null, [{ path: 'path/to/file' }], ['foo']))
     const definition = await service.get(coordinates, null, null, '-files')

--- a/test/business/statsServiceTest.js
+++ b/test/business/statsServiceTest.js
@@ -7,20 +7,20 @@ const StatsService = require('../../business/statsService')
 describe('Stats Service', () => {
   it('calculates median score given frequency table', () => {
     const input = [
-      { count: 14818, to: 10 },
-      { count: 4224, from: 10, to: 20 },
-      { count: 607, from: 20, to: 30 },
-      { count: 298, from: 30, to: 40 },
-      { count: 5810, from: 40, to: 50 },
-      { count: 1117, from: 50, to: 60 },
-      { count: 14959, from: 60, to: 70 },
-      { count: 30633, from: 70, to: 80 },
-      { count: 2354, from: 80, to: 90 },
-      { count: 320, from: 90, to: 100 },
-      { count: 60, from: 100 }
+      { count: 952, value: 0 },
+      { count: 354, value: 1 },
+      { count: 217, value: 2 },
+      { count: 196, value: 3 },
+      { count: 181, value: 4 },
+      { count: 90, value: 5 },
+      { count: 83, value: 6 },
+      { count: 79, value: 7 },
+      { count: 75, value: 8 },
+      { count: 22, value: 9 },
+      { count: 1039, value: 10 }
     ]
-    const result = StatsService()._getMedian(input, 75200)
-    expect(result).to.eq(70)
+    const result = StatsService()._getMedian(input, 3288)
+    expect(result).to.eq(3)
   })
 
   it('calculates 0 median score for 0 totalCount', () => {

--- a/test/business/statsServiceTest.js
+++ b/test/business/statsServiceTest.js
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const StatsService = require('../../business/statsService')
+
+describe('Stats Service', () => {
+  it('calculates median score given frequency table', () => {
+    const input = [
+      { count: 14818, to: 10 },
+      { count: 4224, from: 10, to: 20 },
+      { count: 607, from: 20, to: 30 },
+      { count: 298, from: 30, to: 40 },
+      { count: 5810, from: 40, to: 50 },
+      { count: 1117, from: 50, to: 60 },
+      { count: 14959, from: 60, to: 70 },
+      { count: 30633, from: 70, to: 80 },
+      { count: 2354, from: 80, to: 90 },
+      { count: 320, from: 90, to: 100 },
+      { count: 60, from: 100 }
+    ]
+    const result = StatsService()._getMedian(input, 75200)
+    expect(result).to.eq(70)
+  })
+
+  it('calculates 0 median score for 0 totalCount', () => {
+    const input = []
+    const result = StatsService()._getMedian(input, 0)
+    expect(result).to.eq(0)
+  })
+})


### PR DESCRIPTION
The search indexer is running now connected to the blob definition store and mapping more of the metadata.
The existing suggester for coordinates is migrated to the new search indexer, so we can remove the old one and keep a single index.

- only store to the search index manually when using in-mem definition preload
- re-enable stats queries for count+median breakdowns by type