### PR TITLE
incorporate maven direct urls

### DIFF
--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -142,8 +142,11 @@ class ClearlyDescribedSummarizer {
     const projectSummaryLicenses =
       get(data, 'manifest.summary.licenses') || get(data, 'manifest.summary.project.licenses') // the project layer was removed in 1.2.0
     if (!projectSummaryLicenses) return
-    const licenseSummaries = flatten(projectSummaryLicenses.map(x => x.license))
-    const licenseUrls = uniq(flatten(licenseSummaries.map(license => license.url)))
+    const licenseSummaries = flatten(projectSummaryLicenses.map(x => x.license)).filter(x => x)
+    const licenseUrls = uniq([
+      ...flatten(licenseSummaries.map(license => license.url)),
+      ...flatten(projectSummaryLicenses.map(x => x.url))
+    ]).filter(x => x)
     const licenseNames = uniq(flatten(licenseSummaries.map(license => license.name)))
     let licenses = licenseUrls.map(extractLicenseFromLicenseUrl).filter(x => x)
     if (!licenses.length) licenses = licenseNames.map(x => SPDX.lookupByName(x) || x).filter(x => x)

--- a/test/summary/clearlyDefined.js
+++ b/test/summary/clearlyDefined.js
@@ -45,6 +45,16 @@ describe('ClearlyDefined Maven summarizer', () => {
     expect(summary.described.releaseDate).to.eq('2018-03-06')
   })
 
+  it('handles projectSummaryLicenses with just url', () => {
+    const { coordinates, harvested } = setupMaven('2018-03-06T11:38:10.284Z', true, {
+      licenses: [{ url: 'https://opensource.org/licenses/MIT' }]
+    })
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.licensed.declared).to.eq('MIT')
+    expect(summary.described.releaseDate).to.eq('2018-03-06')
+  })
+
   it('handles data with source location', () => {
     const { coordinates, harvested } = setupMaven('2018-03-06T11:38:10.284Z', true)
     const summary = Summarizer().summarize(coordinates, harvested)


### PR DESCRIPTION
couple of different formats found for maven manifest/summary/licenses

```js
{
      licenses: [{ license: { name: 'MIT' } }]
}
```

```js
{
      licenses: [{ license: { url: 'https://opensource.org/licenses/MIT' } }]
}
```

```js
{
      licenses: [{ url: 'https://opensource.org/licenses/MIT' }]
}
```