### PR TITLE
lower the coordinates on both sides when comparing

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -148,7 +148,11 @@ class DefinitionService {
     )
     const foundDefinitions = flatten(await Promise.all(concat(promises)))
     // Filter only the revisions matching the found definitions
-    return intersectionWith(coordinatesList, foundDefinitions, (a, b) => a.toString().toLowerCase() === b)
+    return intersectionWith(
+      coordinatesList,
+      foundDefinitions,
+      (a, b) => a && b && a.toString().toLowerCase() === b.toString().toLowerCase()
+    )
   }
 
   /**


### PR DESCRIPTION
stringify and lowercase before comparing so it supports bot entityCoordinates and raw strings, no matter the casing