### PR TITLE
add See-URL to fossology no-op list

### DIFF
--- a/providers/summary/fossology.js
+++ b/providers/summary/fossology.js
@@ -5,7 +5,7 @@ const { mergeDefinitions, setIfValue, isLicenseFile } = require('../../lib/utils
 const SPDX = require('../../lib/spdx')
 const { get, uniq } = require('lodash')
 
-const noOpLicenseIds = new Set(['No_license_found', 'See-file'])
+const noOpLicenseIds = new Set(['No_license_found', 'See-file', 'See-URL'])
 
 class FOSSologySummarizer {
   constructor(options) {


### PR DESCRIPTION
saw this one come up with https://clearlydefined.io/definitions/npm/npmjs/-/augur-ui-react-components/3.6.24