### PR TITLE
add queue processing to the service

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,6 +51,9 @@ function createApp(config) {
   const curationQueue = config.curation.queue()
   initializers.push(async () => curationQueue.initialize())
 
+  const harvestQueue = config.harvest.queue()
+  initializers.push(async () => harvestQueue.initialize())
+
   const definitionService = require('./business/definitionService')(
     harvestStore,
     harvestService,
@@ -160,6 +163,11 @@ function createApp(config) {
         // Bit of trick for local hosting. Preload search if using an in-memory search service
         if (searchService.constructor.name === 'MemorySearch') await definitionService.reload('definitions')
         logger.info('Service initialized', { buildNumber: process.env.BUILD_NUMBER })
+
+        // kick off the queue processors
+        require('./providers/curation/process')(curationQueue, curationService, logger)
+        require('./providers/harvest/process')(harvestQueue, definitionService, logger)
+
         // Signal system is up and ok (no error)
         callback()
       },
@@ -168,8 +176,6 @@ function createApp(config) {
         callback(error)
       }
     )
-    // kick off the queue processors
-    require('./providers/curation/process')(curationQueue, curationService, logger)
   }
 
   // error handler

--- a/app.js
+++ b/app.js
@@ -48,6 +48,9 @@ function createApp(config) {
 
   const curationService = config.curation.service(null, curationStore, config.endpoints, cachingService)
 
+  const curationQueue = config.curation.queue()
+  initializers.push(async () => curationQueue.initialize())
+
   const definitionService = require('./business/definitionService')(
     harvestStore,
     harvestService,
@@ -165,6 +168,8 @@ function createApp(config) {
         callback(error)
       }
     )
+    // kick off the queue processors
+    require('./providers/curation/process')(curationQueue, curationService, logger)
   }
 
   // error handler

--- a/bin/config.js
+++ b/bin/config.js
@@ -42,6 +42,7 @@ module.exports = {
     logger: loadFactory(config.get('LOGGING_PROVIDER') || 'winston', 'logging')
   },
   curation: {
+    queue: loadFactory(config.get('CURATION_QUEUE_PROVIDER') || 'azure', 'curation.queue'), // todo: change default to memory queue
     service: loadFactory(config.get('CURATION_PROVIDER') || 'github', 'curation.service'),
     store: loadFactory(config.get('CURATION_STORE_PROVIDER') || 'memory', 'curation.store')
   },

--- a/bin/config.js
+++ b/bin/config.js
@@ -47,6 +47,7 @@ module.exports = {
     store: loadFactory(config.get('CURATION_STORE_PROVIDER') || 'memory', 'curation.store')
   },
   harvest: {
+    queue: loadFactory(config.get('HARVEST_QUEUE_PROVIDER') || 'azure', 'harvest.queue'), // todo: change default to memory queue
     service: loadFactory(config.get('HARVESTER_PROVIDER') || 'crawler', 'harvest.service'),
     store: loadFactory(config.get('HARVEST_STORE_PROVIDER') || 'file', 'harvest.store')
   },

--- a/bin/config.js
+++ b/bin/config.js
@@ -42,12 +42,12 @@ module.exports = {
     logger: loadFactory(config.get('LOGGING_PROVIDER') || 'winston', 'logging')
   },
   curation: {
-    queue: loadFactory(config.get('CURATION_QUEUE_PROVIDER') || 'azure', 'curation.queue'), // todo: change default to memory queue
+    queue: loadFactory(config.get('CURATION_QUEUE_PROVIDER') || 'memory', 'curation.queue'),
     service: loadFactory(config.get('CURATION_PROVIDER') || 'github', 'curation.service'),
     store: loadFactory(config.get('CURATION_STORE_PROVIDER') || 'memory', 'curation.store')
   },
   harvest: {
-    queue: loadFactory(config.get('HARVEST_QUEUE_PROVIDER') || 'azure', 'harvest.queue'), // todo: change default to memory queue
+    queue: loadFactory(config.get('HARVEST_QUEUE_PROVIDER') || 'memory', 'harvest.queue'),
     service: loadFactory(config.get('HARVESTER_PROVIDER') || 'crawler', 'harvest.service'),
     store: loadFactory(config.get('HARVEST_STORE_PROVIDER') || 'file', 'harvest.store')
   },

--- a/providers/curation/azureQueueConfig.js
+++ b/providers/curation/azureQueueConfig.js
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const config = require('painless-config')
+const AzureStorageQueue = require('../queueing/azureStorageQueue')
+
+function azure(options) {
+  const realOptions = options || {
+    connectionString: config.get('CURATION_QUEUE_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
+    queueName: config.get('CURATION_QUEUE_NAME') || 'curations'
+  }
+  return new AzureStorageQueue(realOptions)
+}
+
+module.exports = azure

--- a/providers/curation/process.js
+++ b/providers/curation/process.js
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { get } = require('lodash')
+
+async function work() {
+  try {
+    let message = await queue.dequeue()
+    if (!get(message, 'data.pull_request') || !get(message, 'data.action')) return
+    const pr = message.data.pull_request
+    const action = message.data.action
+    switch (action) {
+      case 'opened':
+      case 'synchronize': {
+        const curations = await curationService.getContributedCurations(pr.number, pr.head.sha)
+        await curationService.validateContributions(pr.number, pr.head.sha, curations)
+        await curationService.updateContribution(pr, curations)
+        break
+      }
+      case 'closed': {
+        await curationService.updateContribution(pr)
+        break
+      }
+    }
+    logger.info(`Handled GitHub event "${action}" for PR#${pr.number}`)
+    await queue.delete(message)
+  } catch (error) {
+    logger.error(error)
+  } finally {
+    setTimeout(work, 30000)
+  }
+}
+
+let queue
+let curationService
+let logger
+
+function setup(_queue, _curationService, _logger) {
+  queue = _queue
+  curationService = _curationService
+  logger = _logger
+  work()
+}
+
+module.exports = setup

--- a/providers/curation/process.js
+++ b/providers/curation/process.js
@@ -3,7 +3,7 @@
 
 const { get } = require('lodash')
 
-async function work() {
+async function work(once) {
   try {
     let message = await queue.dequeue()
     if (!get(message, 'data.pull_request') || !get(message, 'data.action')) return
@@ -27,7 +27,7 @@ async function work() {
   } catch (error) {
     logger.error(error)
   } finally {
-    setTimeout(work, 30000)
+    if (!once) setTimeout(work, 30000, once)
   }
 }
 
@@ -35,11 +35,11 @@ let queue
 let curationService
 let logger
 
-function setup(_queue, _curationService, _logger) {
+function setup(_queue, _curationService, _logger, once = false) {
   queue = _queue
   curationService = _curationService
   logger = _logger
-  return work()
+  return work(once)
 }
 
 module.exports = setup

--- a/providers/curation/process.js
+++ b/providers/curation/process.js
@@ -39,7 +39,7 @@ function setup(_queue, _curationService, _logger) {
   queue = _queue
   curationService = _curationService
   logger = _logger
-  work()
+  return work()
 }
 
 module.exports = setup

--- a/providers/harvest/azureQueueConfig.js
+++ b/providers/harvest/azureQueueConfig.js
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const config = require('painless-config')
+const AzureStorageQueue = require('../queueing/azureStorageQueue')
+
+function azure(options) {
+  const realOptions = options || {
+    connectionString: config.get('HARVEST_QUEUE_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
+    queueName: config.get('HARVEST_QUEUE_NAME') || 'harvests'
+  }
+  return new AzureStorageQueue(realOptions)
+}
+
+module.exports = azure

--- a/providers/harvest/crawlerQueue.js
+++ b/providers/harvest/crawlerQueue.js
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const logger = require('../logging/logger')
+
+class CrawlingQueueHarvester {
+  constructor(options) {
+    this.logger = logger()
+    this.normalQueue = options.normal
+    this.laterQueue = options.later
+  }
+
+  async harvest(spec, turbo) {
+    const entries = Array.isArray(spec) ? spec : [spec]
+    for (let entry of entries) {
+      let message = JSON.stringify({
+        type: entry.tool || 'component',
+        url: `cd:/${entry.coordinates.toString().replace(/[/]+/g, '/')}`,
+        policy: entry.policy || {
+          fetch: 'mutables',
+          freshness: 'match',
+          map: { name: entry.tool || 'component', path: '/' }
+        }
+      })
+      if (turbo) this.normalQueue.queue(message)
+      else this.laterQueue.queue(message)
+    }
+  }
+}
+
+module.exports = options => new CrawlingQueueHarvester(options)

--- a/providers/harvest/crawlerQueueConfig.js
+++ b/providers/harvest/crawlerQueueConfig.js
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const config = require('painless-config')
+const AzureStorageQueue = require('../queueing/azureStorageQueue')
+const crawler = require('./crawlerQueue')
+
+function later(options) {
+  const realOptions = options || {
+    connectionString: config.get('HARVEST_QUEUE_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
+    queueName: `${config.get('HARVEST_QUEUE_PREFIX') || 'cdcrawlerdev'}-later`
+  }
+  return new AzureStorageQueue(realOptions)
+}
+
+function normal(options) {
+  const realOptions = options || {
+    connectionString: config.get('HARVEST_QUEUE_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
+    queueName: `${config.get('HARVEST_QUEUE_PREFIX') || 'cdcrawlerdev'}-normal`
+  }
+  return new AzureStorageQueue(realOptions)
+}
+
+function serviceFactory(options) {
+  const realOptions = options || {
+    later: later(),
+    normal: normal()
+  }
+  realOptions.later.initialize()
+  realOptions.normal.initialize()
+  return crawler(realOptions)
+}
+
+module.exports = serviceFactory

--- a/providers/harvest/process.js
+++ b/providers/harvest/process.js
@@ -28,7 +28,7 @@ function setup(_queue, _definitionService, _logger) {
   queue = _queue
   definitionService = _definitionService
   logger = _logger
-  work()
+  return work()
 }
 
 module.exports = setup

--- a/providers/harvest/process.js
+++ b/providers/harvest/process.js
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { get } = require('lodash')
+const EntityCoordinates = require('../../lib/entityCoordinates')
+
+async function work() {
+  try {
+    let message = await queue.dequeue()
+    const urn = get(message, 'data._metadata.links.self.href')
+    if (!urn) return
+    const coordinates = EntityCoordinates.fromUrn(urn)
+    await definitionService.computeAndStore(coordinates)
+    logger.info(`Handled Crawler update event for ${urn}`)
+    await queue.delete(message)
+  } catch (error) {
+    logger.error(error)
+  } finally {
+    setTimeout(work, 250)
+  }
+}
+
+let queue
+let definitionService
+let logger
+
+function setup(_queue, _definitionService, _logger) {
+  queue = _queue
+  definitionService = _definitionService
+  logger = _logger
+  work()
+}
+
+module.exports = setup

--- a/providers/harvest/process.js
+++ b/providers/harvest/process.js
@@ -4,7 +4,7 @@
 const { get } = require('lodash')
 const EntityCoordinates = require('../../lib/entityCoordinates')
 
-async function work() {
+async function work(once) {
   try {
     let message = await queue.dequeue()
     const urn = get(message, 'data._metadata.links.self.href')
@@ -16,7 +16,7 @@ async function work() {
   } catch (error) {
     logger.error(error)
   } finally {
-    setTimeout(work, 250)
+    if (!once) setTimeout(work, 250)
   }
 }
 
@@ -24,11 +24,11 @@ let queue
 let definitionService
 let logger
 
-function setup(_queue, _definitionService, _logger) {
+function setup(_queue, _definitionService, _logger, once = false) {
   queue = _queue
   definitionService = _definitionService
   logger = _logger
-  return work()
+  return work(once)
 }
 
 module.exports = setup

--- a/providers/index.js
+++ b/providers/index.js
@@ -35,6 +35,7 @@ module.exports = {
     }
   },
   harvest: {
+    queue: { azure: require('../providers/harvest/azureQueueConfig') }, // todo: add memory queue
     service: {
       crawler: require('../providers/harvest/crawlerConfig'),
       crawlerQueue: require('../providers/harvest/crawlerQueueConfig')

--- a/providers/index.js
+++ b/providers/index.js
@@ -27,7 +27,10 @@ module.exports = {
     github: require('../middleware/githubConfig')
   },
   curation: {
-    queue: { azure: require('../providers/curation/azureQueueConfig') }, // todo: add memory queue
+    queue: {
+      azure: require('../providers/curation/azureQueueConfig'),
+      memory: require('../providers/queueing/memoryQueue')
+    },
     service: { github: require('../providers/curation/githubConfig') },
     store: {
       memory: require('../providers/curation/memoryStore'),
@@ -35,7 +38,10 @@ module.exports = {
     }
   },
   harvest: {
-    queue: { azure: require('../providers/harvest/azureQueueConfig') }, // todo: add memory queue
+    queue: {
+      azure: require('../providers/harvest/azureQueueConfig'),
+      memory: require('../providers/queueing/memoryQueue')
+    },
     service: {
       crawler: require('../providers/harvest/crawlerConfig'),
       crawlerQueue: require('../providers/harvest/crawlerQueueConfig')

--- a/providers/index.js
+++ b/providers/index.js
@@ -27,6 +27,7 @@ module.exports = {
     github: require('../middleware/githubConfig')
   },
   curation: {
+    queue: { azure: require('../providers/curation/azureQueueConfig') },
     service: { github: require('../providers/curation/githubConfig') },
     store: {
       memory: require('../providers/curation/memoryStore'),

--- a/providers/index.js
+++ b/providers/index.js
@@ -27,7 +27,7 @@ module.exports = {
     github: require('../middleware/githubConfig')
   },
   curation: {
-    queue: { azure: require('../providers/curation/azureQueueConfig') },
+    queue: { azure: require('../providers/curation/azureQueueConfig') }, // todo: add memory queue
     service: { github: require('../providers/curation/githubConfig') },
     store: {
       memory: require('../providers/curation/memoryStore'),
@@ -35,7 +35,10 @@ module.exports = {
     }
   },
   harvest: {
-    service: { crawler: require('../providers/harvest/crawlerConfig') },
+    service: {
+      crawler: require('../providers/harvest/crawlerConfig'),
+      crawlerQueue: require('../providers/harvest/crawlerQueueConfig')
+    },
     store: {
       azure: require('../providers/stores/azblobConfig').harvest,
       file: require('../providers/stores/fileConfig').harvest

--- a/providers/queueing/azureStorageQueue.js
+++ b/providers/queueing/azureStorageQueue.js
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const azure = require('azure-storage')
+const logger = require('../logging/logger')
+const { promisify } = require('util')
+const base64 = require('base-64')
+
+class AzureStorageQueue {
+  constructor(options) {
+    this.options = options
+    this.logger = logger()
+  }
+
+  async initialize() {
+    this.queueService = azure
+      .createQueueService(this.options.connectionString)
+      .withFilter(new azure.LinearRetryPolicyFilter())
+    await promisify(this.queueService.createQueueIfNotExists).bind(this.queueService)(this.options.queueName)
+  }
+
+  async dequeue() {
+    const message = await promisify(this.queueService.getMessage).bind(this.queueService)(this.options.queueName)
+    if (!message) return null
+    if (message.dequeueCount <= 5) return { original: message, data: JSON.parse(base64.decode(message.messageText)) }
+    await this.delete(message)
+    return this.dequeue()
+  }
+
+  async delete(message) {
+    await promisify(this.queueService.deleteMessage).bind(this.queueService)(
+      this.options.queueName,
+      message.original.messageId,
+      message.original.popReceipt
+    )
+  }
+}
+
+module.exports = AzureStorageQueue

--- a/providers/queueing/azureStorageQueue.js
+++ b/providers/queueing/azureStorageQueue.js
@@ -41,7 +41,7 @@ class AzureStorageQueue {
     const message = await promisify(this.queueService.getMessage).bind(this.queueService)(this.options.queueName)
     if (!message) return null
     if (message.dequeueCount <= 5) return { original: message, data: JSON.parse(base64.decode(message.messageText)) }
-    await this.delete(message)
+    await this.delete({ original: message })
     return this.dequeue()
   }
 

--- a/providers/queueing/memoryQueue.js
+++ b/providers/queueing/memoryQueue.js
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const logger = require('../logging/logger')
+
+class MemoryQueue {
+  constructor(options) {
+    this.options = options
+    this.logger = logger()
+    this.data = []
+    this.messageId = 0
+  }
+
+  async initialize() {}
+
+  /**
+   * Add a message to the queue. Any encoding/stringifying is up to the caller
+   *
+   * @param {string} message
+   */
+  queue(message) {
+    this.data.push({ messageText: message, dequeueCount: 0, messageId: ++this.messageId })
+    return Promise.resolve()
+  }
+
+  /**
+   * Return the top message from the queue
+   * If processing is successful, the caller is expected to call delete()
+   * Returns null if the queue is empty
+   *
+   * @returns {object} - { original: message, data: "JSON parsed, base64 decoded message" }
+   */
+  async dequeue() {
+    const message = this.data[0]
+    if (!message) return null
+    this.data[0].dequeueCount++
+    if (message.dequeueCount <= 5) return Promise.resolve({ original: message, data: JSON.parse(message.messageText) })
+    await this.delete({ original: message })
+    return this.dequeue()
+  }
+
+  /**
+   * Delete a recently DQ'd message from the queue
+   * pass dequeue() result as the message to delete
+   *
+   * @param {object} message
+   */
+  delete(message) {
+    const newData = []
+    for (let i = 0; i < this.data.length; i++) {
+      if (this.data[i].messageId !== message.original.messageId) newData.push(this.data[i])
+    }
+    this.data = newData
+    return Promise.resolve()
+  }
+}
+
+module.exports = () => new MemoryQueue()

--- a/test/providers/curation/processTest.js
+++ b/test/providers/curation/processTest.js
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const process = require('../../../providers/curation/process')
+const memoryQueue = require('../../../providers/queueing/memoryQueue')
+const sinon = require('sinon')
+
+describe('Curation queue processing', () => {
+  it('handles opened message', async () => {
+    const { queue, curationService, logger } = setup({ action: 'opened' })
+    await process(queue, curationService, logger)
+
+    expect(curationService.getContributedCurations.calledOnce).to.be.true
+    expect(curationService.validateContributions.calledOnce).to.be.true
+    expect(curationService.updateContribution.calledOnce).to.be.true
+    expect(logger.info.calledOnce).to.be.true
+    expect(logger.info.getCall(0).args[0]).to.eq('Handled GitHub event "opened" for PR#1')
+    expect(queue.data.length).to.eq(0)
+  })
+
+  it('handles synchronize message', async () => {
+    const { queue, curationService, logger } = setup({ action: 'synchronize' })
+    await process(queue, curationService, logger)
+
+    expect(curationService.getContributedCurations.calledOnce).to.be.true
+    expect(curationService.validateContributions.calledOnce).to.be.true
+    expect(curationService.updateContribution.calledOnce).to.be.true
+    expect(logger.info.calledOnce).to.be.true
+    expect(logger.info.getCall(0).args[0]).to.eq('Handled GitHub event "synchronize" for PR#1')
+    expect(queue.data.length).to.eq(0)
+  })
+
+  it('handles closed message', async () => {
+    const { queue, curationService, logger } = setup({ action: 'closed' })
+    await process(queue, curationService, logger)
+
+    expect(curationService.getContributedCurations.calledOnce).to.be.false
+    expect(curationService.validateContributions.calledOnce).to.be.false
+    expect(curationService.updateContribution.calledOnce).to.be.true
+    expect(logger.info.calledOnce).to.be.true
+    expect(logger.info.getCall(0).args[0]).to.eq('Handled GitHub event "closed" for PR#1')
+    expect(queue.data.length).to.eq(0)
+  })
+
+  it('skips processing for random messages', async () => {
+    const { queue, curationService, logger } = setup({ action: 'rando' })
+    await process(queue, curationService, logger)
+
+    expect(curationService.getContributedCurations.calledOnce).to.be.false
+    expect(curationService.validateContributions.calledOnce).to.be.false
+    expect(curationService.updateContribution.calledOnce).to.be.false
+    expect(logger.info.calledOnce).to.be.true
+    expect(logger.info.getCall(0).args[0]).to.eq('Handled GitHub event "rando" for PR#1')
+    expect(queue.data.length).to.eq(0)
+  })
+})
+
+function setup({ action, merged }) {
+  const queue = memoryQueue()
+
+  queue.queue(
+    JSON.stringify({
+      action,
+      pull_request: {
+        number: 1,
+        title: 'test pr',
+        merged: !!merged,
+        head: {
+          ref: 'changes',
+          sha: '24'
+        }
+      }
+    })
+  )
+
+  const curationService = {
+    getContributedCurations: sinon.stub(),
+    validateContributions: sinon.stub(),
+    updateContribution: sinon.stub()
+  }
+  const logger = {
+    info: sinon.stub(),
+    error: sinon.stub()
+  }
+
+  return { queue, curationService, logger }
+}

--- a/test/providers/curation/processTest.js
+++ b/test/providers/curation/processTest.js
@@ -9,7 +9,7 @@ const sinon = require('sinon')
 describe('Curation queue processing', () => {
   it('handles opened message', async () => {
     const { queue, curationService, logger } = setup({ action: 'opened' })
-    await process(queue, curationService, logger)
+    await process(queue, curationService, logger, true)
 
     expect(curationService.getContributedCurations.calledOnce).to.be.true
     expect(curationService.validateContributions.calledOnce).to.be.true
@@ -21,7 +21,7 @@ describe('Curation queue processing', () => {
 
   it('handles synchronize message', async () => {
     const { queue, curationService, logger } = setup({ action: 'synchronize' })
-    await process(queue, curationService, logger)
+    await process(queue, curationService, logger, true)
 
     expect(curationService.getContributedCurations.calledOnce).to.be.true
     expect(curationService.validateContributions.calledOnce).to.be.true
@@ -33,7 +33,7 @@ describe('Curation queue processing', () => {
 
   it('handles closed message', async () => {
     const { queue, curationService, logger } = setup({ action: 'closed' })
-    await process(queue, curationService, logger)
+    await process(queue, curationService, logger, true)
 
     expect(curationService.getContributedCurations.calledOnce).to.be.false
     expect(curationService.validateContributions.calledOnce).to.be.false
@@ -45,7 +45,7 @@ describe('Curation queue processing', () => {
 
   it('skips processing for random messages', async () => {
     const { queue, curationService, logger } = setup({ action: 'rando' })
-    await process(queue, curationService, logger)
+    await process(queue, curationService, logger, true)
 
     expect(curationService.getContributedCurations.calledOnce).to.be.false
     expect(curationService.validateContributions.calledOnce).to.be.false

--- a/test/providers/harvest/processTest.js
+++ b/test/providers/harvest/processTest.js
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const process = require('../../../providers/harvest/process')
+const memoryQueue = require('../../../providers/queueing/memoryQueue')
+const sinon = require('sinon')
+
+describe('Harvest queue processing', () => {
+  it('handles new message', async () => {
+    const { queue, definitionService, logger } = setup({
+      _metadata: { links: { self: { href: 'urn:gem:rubygems:-:0mq:revision:0.5.2:tool:clearlydefined:1.3.3' } } }
+    })
+    await process(queue, definitionService, logger)
+
+    expect(definitionService.computeAndStore.calledOnce).to.be.true
+    expect(definitionService.computeAndStore.getCall(0).args[0]).to.deep.eq({
+      type: 'gem',
+      provider: 'rubygems',
+      name: '0mq',
+      revision: '0.5.2'
+    })
+    expect(logger.info.calledOnce).to.be.true
+    expect(logger.info.getCall(0).args[0]).to.eq(
+      'Handled Crawler update event for urn:gem:rubygems:-:0mq:revision:0.5.2:tool:clearlydefined:1.3.3'
+    )
+    expect(queue.data.length).to.eq(0)
+  })
+
+  it('handles bogus message', async () => {
+    const { queue, definitionService, logger } = setup({ junk: 'here' })
+    await process(queue, definitionService, logger)
+
+    expect(definitionService.computeAndStore.calledOnce).to.be.false
+    expect(logger.info.calledOnce).to.be.false
+    expect(queue.data.length).to.eq(1)
+  })
+})
+
+function setup(data) {
+  const queue = memoryQueue()
+  queue.queue(JSON.stringify(data))
+  const definitionService = {
+    computeAndStore: sinon.stub()
+  }
+  const logger = {
+    info: sinon.stub(),
+    error: sinon.stub()
+  }
+
+  return { queue, definitionService, logger }
+}

--- a/test/providers/harvest/processTest.js
+++ b/test/providers/harvest/processTest.js
@@ -11,7 +11,7 @@ describe('Harvest queue processing', () => {
     const { queue, definitionService, logger } = setup({
       _metadata: { links: { self: { href: 'urn:gem:rubygems:-:0mq:revision:0.5.2:tool:clearlydefined:1.3.3' } } }
     })
-    await process(queue, definitionService, logger)
+    await process(queue, definitionService, logger, true)
 
     expect(definitionService.computeAndStore.calledOnce).to.be.true
     expect(definitionService.computeAndStore.getCall(0).args[0]).to.deep.eq({
@@ -29,7 +29,7 @@ describe('Harvest queue processing', () => {
 
   it('handles bogus message', async () => {
     const { queue, definitionService, logger } = setup({ junk: 'here' })
-    await process(queue, definitionService, logger)
+    await process(queue, definitionService, logger, true)
 
     expect(definitionService.computeAndStore.calledOnce).to.be.false
     expect(logger.info.calledOnce).to.be.false

--- a/test/providers/queueing/memoryQueueTest.js
+++ b/test/providers/queueing/memoryQueueTest.js
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const assert = require('assert')
+const MemoryQueue = require('../../../providers/queueing/memoryQueue')
+
+describe('memory queue operations', () => {
+  it('queues messages', async () => {
+    const memQueue = MemoryQueue()
+    await memQueue.queue(JSON.stringify({ somekey: 1 }))
+    await memQueue.queue(JSON.stringify({ somekey: 2 }))
+    assert.equal(memQueue.data.length, 2)
+  })
+
+  it('dequeues messages', async () => {
+    const memQueue = MemoryQueue()
+    await memQueue.queue(JSON.stringify({ somekey: 1 }))
+    await memQueue.queue(JSON.stringify({ somekey: 2 }))
+
+    let message1 = await memQueue.dequeue()
+    assert.equal(message1.data.somekey, 1)
+
+    await memQueue.delete(message1)
+
+    let message2 = await memQueue.dequeue()
+    assert.equal(message2.data.somekey, 2)
+
+    await memQueue.delete(message2)
+
+    let message3 = await memQueue.dequeue()
+    assert.equal(message3, null)
+  })
+
+  it('dequeue count increases to 5', async () => {
+    const memQueue = MemoryQueue()
+    await memQueue.queue(JSON.stringify({ somekey: 1 }))
+
+    let message = await memQueue.dequeue()
+    assert.equal(message.original.dequeueCount, 1)
+
+    message = await memQueue.dequeue()
+    assert.equal(message.original.dequeueCount, 2)
+
+    message = await memQueue.dequeue()
+    assert.equal(message.original.dequeueCount, 3)
+
+    message = await memQueue.dequeue()
+    assert.equal(message.original.dequeueCount, 4)
+
+    message = await memQueue.dequeue()
+    assert.equal(message.original.dequeueCount, 5)
+
+    message = await memQueue.dequeue()
+    assert.equal(message, null)
+  })
+})


### PR DESCRIPTION
create a listener on a queue for github webhooks to process new curation events

This adds 
 - `/providers/curation/process.js` to process new curations (curations)
 - `/providers/harvest/process.js` to process new hooks from the crawlers (harvests)
 - `/providers/harvest/crawlerQueueConfig.js` to queue messages directly to the crawler

Instead of having all the crawlers call back to the service over a webhook for harvest complete notifications, moving towards the crawlers queueing messages instead.

Instead of github calling over a webhook directly to the service for curation notifications, moving towards github hooks queueing messages directly instead

Instead of calling the crawlers from the service over HTTP to pass on new harvest requests, queue the request directly into storage so any of the crawlers can pick it up.

This is the first step towards an improved resiliency/disaster recovery setup