### PR TITLE
Quiets noisy npm tests

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,8 +65,7 @@ function simplifyAttributions(entries) {
 
 function extractDate(dateAndTime) {
   if (!dateAndTime) return null
-  const result = moment.utc(dateAndTime,
-                            [moment.ISO_8601, "MM-DD-YYYY", "YYYY-MM-DD"]);
+  const result = moment.utc(dateAndTime, [moment.ISO_8601, 'MM-DD-YYYY', 'YYYY-MM-DD'])
   if (!result.isValid()) return null
   if (result.isBefore('1950-01-01') || result.isAfter(moment().add(30, 'days'))) return null
   return result.format('YYYY-MM-DD')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,7 +65,8 @@ function simplifyAttributions(entries) {
 
 function extractDate(dateAndTime) {
   if (!dateAndTime) return null
-  const result = moment.utc(dateAndTime)
+  const result = moment.utc(dateAndTime,
+                            [moment.ISO_8601, "MM-DD-YYYY", "YYYY-MM-DD"]);
   if (!result.isValid()) return null
   if (result.isBefore('1950-01-01') || result.isAfter(moment().add(30, 'days'))) return null
   return result.format('YYYY-MM-DD')

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -52,10 +52,10 @@ describe('Github Curation Service', () => {
     })
     const curations = await service.getContributedCurations(42, 'testBranch')
     service.logger = { // intercept and verify invalid contribution
-      error: function(description, invalidCurations) {
+      error: function(description /* , invalidCurations */) {
         expect(description).to.be.eq('Invalid curations: ')
       }
-    };
+    }
     await service.validateContributions('42', 'testBranch', curations)
     expect(service._postCommitStatus.calledTwice).to.be.true
     expect(service._postCommitStatus.getCall(0).args[2]).to.be.eq('pending')

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -51,6 +51,11 @@ describe('Github Curation Service', () => {
       return [createInvalidCuration()]
     })
     const curations = await service.getContributedCurations(42, 'testBranch')
+    service.logger = { // intercept and verify invalid contribution
+      error: function(description, invalidCurations) {
+        expect(description).to.be.eq('Invalid curations: ')
+      }
+    };
     await service.validateContributions('42', 'testBranch', curations)
     expect(service._postCommitStatus.calledTwice).to.be.true
     expect(service._postCommitStatus.getCall(0).args[2]).to.be.eq('pending')
@@ -255,6 +260,7 @@ function createService(definitionService = null, endpoints = { website: 'http://
             number: 143
           }
         })
+
     }
   }
   return service

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -52,7 +52,7 @@ describe('Github Curation Service', () => {
     })
     const curations = await service.getContributedCurations(42, 'testBranch')
     service.logger = { // intercept and verify invalid contribution
-      error: function(description /* , invalidCurations */) {
+      error: (description) => {
         expect(description).to.be.eq('Invalid curations: ')
       }
     }

--- a/test/providers/curation/githubPRs.js
+++ b/test/providers/curation/githubPRs.js
@@ -173,7 +173,7 @@ describe('Curation service pr events', () => {
             expect(ref).to.eq('branch')
             return Promise.resolve()
           },
-          blob: () => Promise.resolve(new Buffer())
+          blob: () => Promise.resolve(new Buffer.alloc(0))
         }
       }
     })
@@ -209,7 +209,7 @@ revisions:
           },
           blob: ref => {
             expect(ref).to.eq('thisisasha')
-            return Promise.resolve(new Buffer(theYaml))
+            return Promise.resolve(new Buffer.from(theYaml))
           }
         }
       }
@@ -239,7 +239,7 @@ revisions:
             expect(ref).to.eq('refs/pull/123/head')
             return Promise.resolve()
           },
-          blob: () => Promise.resolve(new Buffer())
+          blob: () => Promise.resolve(new Buffer.alloc(0))
         }
       }
     })
@@ -268,7 +268,7 @@ function createService({ failsCompute = false, geitStubOverride = null }) {
     (() => {
       return {
         tree: () => Promise.resolve(),
-        blob: () => Promise.resolve(new Buffer())
+        blob: () => Promise.resolve(new Buffer.alloc(0))
       }
     })
   const service = proxyquire('../../../providers/curation/github', { geit: geitStub })(


### PR DESCRIPTION
Updates extractDate momentjs date parsing to use the recommended
'String+Format' method to explicity test for ISO 8601, "MM-DD-YYYY", or
"YYYY-MM-DD" date formats. FFI https://momentjs.com/docs/#/parsing/string/

Intercepts and verifies the logging output from an invalid contribution
as to quiet the 'validates invalid PR change' test.

Updates nodejs constructors for Buffer to safer alternatives in githubPRs.js per
https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe

Resolves #676

Signed-off-by: Tom Marble <tmarble@info9.net>