### PR TITLE
Adds support and test coverage for license{,s} as {string,array}

### DIFF
--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -244,21 +244,20 @@ class ClearlyDescribedSummarizer {
         if (bugs.startsWith('http')) setIfValue(result, 'described.issueTracker', bugs)
       } else setIfValue(result, 'described.issueTracker', bugs.url || bugs.email)
     }
-    // We could have singular licenses such as 'MIT' or licenses in an array ['MIT', 'BSD']
-    // Process licenses depending on whether they are strings or array of strings
+    // Combine multiple licenses with AND (as it is more restrictive than OR)
     let expression = null  // license expression (as input to SPDX.normalize)
     if (typeof manifest.license === 'string') {
       expression = manifest.license
     } else if (Array.isArray(manifest.license)) {
-      expression = manifest.license.join(' OR ')
+      expression = manifest.license.join(' AND ')
     } else if (manifest.license && (typeof manifest.license.type === 'string')) {
       expression = manifest.license.type // handle sub-property 'type'
     } else if (manifest.license && (Array.isArray(manifest.license.type))) {
-      expression = manifest.license.type.join(' OR ')
+      expression = manifest.license.type.join(' AND ')
     } else if (typeof manifest.licenses === 'string') {
       expression = manifest.licenses // handle legacy NPM 'licenses' key
     } else if (Array.isArray(manifest.licenses)) {
-      expression = manifest.licenses.join(' OR ')
+      expression = manifest.licenses.join(' AND ')
     }
     if (expression) {
       const licenses = SPDX.normalize(expression)

--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -246,7 +246,7 @@ class ClearlyDescribedSummarizer {
     }
     // We could have singular licenses such as 'MIT' or licenses in an array ['MIT', 'BSD']
     // Process licenses depending on whether they are strings or array of strings
-    var expression = null  // license expression (as input to SPDX.normalize)
+    let expression = null  // license expression (as input to SPDX.normalize)
     if (typeof manifest.license === 'string') {
       expression = manifest.license
     } else if (Array.isArray(manifest.license)) {
@@ -283,7 +283,7 @@ class ClearlyDescribedSummarizer {
     }
     // We could have singular licenses such as 'MIT' or licenses in an array ['MIT', 'BSD']
     // Process licenses depending on whether they are strings or array of strings
-    var expression = null  // license expression (as input to SPDX.normalize)
+    let expression = null  // license expression (as input to SPDX.normalize)
     if (typeof manifest.license === 'string') {
       expression = manifest.license
     } else if (Array.isArray(manifest.license)) {

--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -267,13 +267,15 @@ class ClearlyDescribedSummarizer {
     }
     // We could have singular licenses such as 'MIT' or licenses in an array ['MIT', 'BSD']
     // Process licenses depending on whether they are strings or array of strings
-    var expression // license expression (as input to SPDX.normalize)
-    if (typeof manifest.license === 'undefined') {
-      expression = null
-    } else if (typeof manifest.license === 'string') {
+    var expression = null  // license expression (as input to SPDX.normalize)
+    if (typeof manifest.license === 'string') {
       expression = manifest.license
     } else if (Array.isArray(manifest.license)) {
       expression = manifest.license.join(' OR ')
+    } else if (typeof manifest.licenses === 'string') {
+      expression = manifest.licenses
+    } else if (Array.isArray(manifest.licenses)) {
+      expression = manifest.licenses.join(' OR ')
     }
     if (expression) {
       const licenses = SPDX.normalize(expression)

--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -267,8 +267,16 @@ class ClearlyDescribedSummarizer {
     }
     // We could have singular licenses such as 'MIT' or licenses in an array ['MIT', 'BSD']
     // Process licenses depending on whether they are strings or array of strings
-    if (Array.isArray(manifest.license)) {
-      const licenses = SPDX.normalize((manifest.license || []).join(' OR '))
+    var expression // license expression (as input to SPDX.normalize)
+    if (typeof manifest.license === 'undefined') {
+      expression = null
+    } else if (typeof manifest.license === 'string') {
+      expression = manifest.license
+    } else if (Array.isArray(manifest.license)) {
+      expression = manifest.license.join(' OR ')
+    }
+    if (expression) {
+      const licenses = SPDX.normalize(expression)
       setIfValue(result, 'licensed.declared', licenses)
     }
   }

--- a/test/summary/clearlyDefined.js
+++ b/test/summary/clearlyDefined.js
@@ -172,6 +172,19 @@ function setupSourceArchive(releaseDate, sourceInfo) {
 
 describe('ClearlyDefined NPM summarizer', () => {
   it('handles with all the data', () => {
+    const { coordinates, harvested } = setupNpm('2018-03-06T11:38:10.284Z', ['MIT'], 'http://homepage', {
+      url: 'http://bugs',
+      email: 'bugs@test.com'
+    })
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.licensed.declared).to.eq('MIT')
+    expect(summary.described.releaseDate).to.eq('2018-03-06')
+    expect(summary.described.issueTracker).to.eq('http://bugs')
+    expect(summary.described.projectWebsite).to.eq('http://homepage')
+  })
+
+  it('handles with all the data and a single license string', () => {
     const { coordinates, harvested } = setupNpm('2018-03-06T11:38:10.284Z', 'MIT', 'http://homepage', {
       url: 'http://bugs',
       email: 'bugs@test.com'
@@ -179,6 +192,19 @@ describe('ClearlyDefined NPM summarizer', () => {
     const summary = Summarizer().summarize(coordinates, harvested)
     validate(summary)
     expect(summary.licensed.declared).to.eq('MIT')
+    expect(summary.described.releaseDate).to.eq('2018-03-06')
+    expect(summary.described.issueTracker).to.eq('http://bugs')
+    expect(summary.described.projectWebsite).to.eq('http://homepage')
+  })
+
+  it('handles with all the data and a disjunctive license array', () => {
+    const { coordinates, harvested } = setupNpm('2018-03-06T11:38:10.284Z', ['MIT', 'Apache-2.0'], 'http://homepage', {
+      url: 'http://bugs',
+      email: 'bugs@test.com'
+    })
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.licensed.declared).to.eq('MIT OR Apache-2.0')
     expect(summary.described.releaseDate).to.eq('2018-03-06')
     expect(summary.described.issueTracker).to.eq('http://bugs')
     expect(summary.described.projectWebsite).to.eq('http://homepage')
@@ -397,6 +423,26 @@ describe('ClearlyDefined PHP composer summarizer', () => {
 
     validate(summary)
     expect(summary.licensed.declared).to.eq('MIT')
+    expect(summary.described.releaseDate).to.eq('2018-03-06')
+    expect(summary.described.projectWebsite).to.eq('http://homepage')
+  })
+
+  it('handles with all the data and a single license string', () => {
+    const { coordinates, harvested } = setupComposer('2018-03-06T11:38:10.284Z', 'v1.0.0', 'MIT', 'http://homepage')
+    const summary = Summarizer().summarize(coordinates, harvested)
+
+    validate(summary)
+    expect(summary.licensed.declared).to.eq('MIT')
+    expect(summary.described.releaseDate).to.eq('2018-03-06')
+    expect(summary.described.projectWebsite).to.eq('http://homepage')
+  })
+
+  it('handles with all the data and a disjunctive license array', () => {
+    const { coordinates, harvested } = setupComposer('2018-03-06T11:38:10.284Z', 'v1.0.0', ['MIT', 'Apache-2.0'], 'http://homepage')
+    const summary = Summarizer().summarize(coordinates, harvested)
+
+    validate(summary)
+    expect(summary.licensed.declared).to.eq('MIT OR Apache-2.0')
     expect(summary.described.releaseDate).to.eq('2018-03-06')
     expect(summary.described.projectWebsite).to.eq('http://homepage')
   })

--- a/test/summary/clearlyDefined.js
+++ b/test/summary/clearlyDefined.js
@@ -197,14 +197,14 @@ describe('ClearlyDefined NPM summarizer', () => {
     expect(summary.described.projectWebsite).to.eq('http://homepage')
   })
 
-  it('handles with all the data and a disjunctive license array', () => {
+  it('handles with all the data and a license array', () => {
     const { coordinates, harvested } = setupNpm('2018-03-06T11:38:10.284Z', ['MIT', 'Apache-2.0'], 'http://homepage', {
       url: 'http://bugs',
       email: 'bugs@test.com'
     })
     const summary = Summarizer().summarize(coordinates, harvested)
     validate(summary)
-    expect(summary.licensed.declared).to.eq('MIT OR Apache-2.0')
+    expect(summary.licensed.declared).to.eq('MIT AND Apache-2.0')
     expect(summary.described.releaseDate).to.eq('2018-03-06')
     expect(summary.described.issueTracker).to.eq('http://bugs')
     expect(summary.described.projectWebsite).to.eq('http://homepage')

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -275,7 +275,7 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
     const licenseArray = ['MIT', 'Apache-2.0']
     let result = {}
     summarizer.addNpmData(result, { registryData: { manifest: { licenses: licenseArray } } }, npmTestCoordinates)
-    assert.deepEqual(result, {...expectedResult, licensed: { declared: 'MIT OR Apache-2.0'}})
+    assert.deepEqual(result, {...expectedResult, licensed: { declared: 'MIT AND Apache-2.0'}})
   })
 
   it('should set release date', () => {

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -164,30 +164,6 @@ describe('ClearlyDescribedSummarizer addComposerData', () => {
     assert.strictEqual(get(result, 'licensed.declared'), 'MIT OR Apache-2.0')
   })
 
-  it('declares legacy licenses from registryData that is a singular license as a string', () => {
-    let result = {}
-    summarizer.addComposerData(result, { registryData: { manifest: { licenses: 'MIT' } } }, composerTestCoordinates)
-
-    assert.strictEqual(get(result, 'licensed.declared'), 'MIT')
-  })
-
-  it('declares legacy licenses from registryData that is a singular license in an array', () => {
-    let result = {}
-    summarizer.addComposerData(result, { registryData: { manifest: { licenses: ['MIT'] } } }, composerTestCoordinates)
-
-    assert.strictEqual(get(result, 'licensed.declared'), 'MIT')
-  })
-
-  it('declares legacy licenses with dual license from registryData', () => {
-    let result = {}
-    summarizer.addComposerData(
-      result,
-      { registryData: { manifest: { licenses: ['MIT', 'Apache-2.0'] } } },
-      composerTestCoordinates
-    )
-    assert.strictEqual(get(result, 'licensed.declared'), 'MIT OR Apache-2.0')
-  })
-
   it('normalizes to spdx only', () => {
     let result = {}
     summarizer.addComposerData(

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -133,6 +133,20 @@ describe('ClearlyDescribedSummarizer addCrateData', () => {
 describe('ClearlyDescribedSummarizer addComposerData', () => {
   const composerTestCoordinates = EntityCoordinates.fromString('composer/packagist/vendor/test/1.0')
 
+  it('does not declare license when manifest is silent on the license', () => {
+    let result = {}
+    summarizer.addComposerData(result, { registryData: { manifest: { } } }, composerTestCoordinates)
+
+    assert.strictEqual(get(result, 'licensed.declared'), undefined)
+  })
+
+  it('declares license from registryData that is a singular license as a string', () => {
+    let result = {}
+    summarizer.addComposerData(result, { registryData: { manifest: { license: 'MIT' } } }, composerTestCoordinates)
+
+    assert.strictEqual(get(result, 'licensed.declared'), 'MIT')
+  })
+
   it('declares license from registryData that is a singular license in an array', () => {
     let result = {}
     summarizer.addComposerData(result, { registryData: { manifest: { license: ['MIT'] } } }, composerTestCoordinates)

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -164,6 +164,30 @@ describe('ClearlyDescribedSummarizer addComposerData', () => {
     assert.strictEqual(get(result, 'licensed.declared'), 'MIT OR Apache-2.0')
   })
 
+  it('declares legacy licenses from registryData that is a singular license as a string', () => {
+    let result = {}
+    summarizer.addComposerData(result, { registryData: { manifest: { licenses: 'MIT' } } }, composerTestCoordinates)
+
+    assert.strictEqual(get(result, 'licensed.declared'), 'MIT')
+  })
+
+  it('declares legacy licenses from registryData that is a singular license in an array', () => {
+    let result = {}
+    summarizer.addComposerData(result, { registryData: { manifest: { licenses: ['MIT'] } } }, composerTestCoordinates)
+
+    assert.strictEqual(get(result, 'licensed.declared'), 'MIT')
+  })
+
+  it('declares legacy licenses with dual license from registryData', () => {
+    let result = {}
+    summarizer.addComposerData(
+      result,
+      { registryData: { manifest: { licenses: ['MIT', 'Apache-2.0'] } } },
+      composerTestCoordinates
+    )
+    assert.strictEqual(get(result, 'licensed.declared'), 'MIT OR Apache-2.0')
+  })
+
   it('normalizes to spdx only', () => {
     let result = {}
     summarizer.addComposerData(

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -257,6 +257,25 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
         })
       else assert.deepEqual(result, expectedResult)
     }
+
+    // should work with legacy licenses
+    for (let license of Object.keys(data)) {
+      let result = {}
+      summarizer.addNpmData(result, { registryData: { manifest: { licenses: license } } }, npmTestCoordinates)
+      if (data[license]) {
+        assert.deepEqual(result, {
+          ...expectedResult,
+          licensed: { declared: data[license] }
+        })
+      }
+      else assert.deepEqual(result, expectedResult)
+    }
+
+    // should work with license as an array
+    const licenseArray = ['MIT', 'Apache-2.0']
+    let result = {}
+    summarizer.addNpmData(result, { registryData: { manifest: { licenses: licenseArray } } }, npmTestCoordinates)
+    assert.deepEqual(result, {...expectedResult, licensed: { declared: 'MIT OR Apache-2.0'}})
   })
 
   it('should set release date', () => {


### PR DESCRIPTION
Note: disjuctinve (`OR`) of license array previously handled.