### PR TITLE
Restoring Configuration section to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ You may want to get the sample data. Clone the [Havested-data](https://github.co
 
 TBD
 
+# Configuration
+
+Configuration properties can be found at:
+
+* [service/full.env.json](https://github.com/clearlydefined/service/blob/master/full.env.json)
+* [service/bin/config.js](https://github.com/clearlydefined/service/blob/master/bin/config.js)
+
 # Contributing
 
 This project welcomes contributions and suggestions, and we've documented the details in the [contribution policy](CONTRIBUTING.md).


### PR DESCRIPTION
In multiple places the README references a Configuration section that
does not exist. The README should not reference a section that does
not exist. This section did exist but was removed in commit c1d49f6
"update readme and swagger". The Configuration section has been
restored from that commit.

Fixes #680