### PR TITLE
Fixes NPM summarizer for legacy licenses key

### DIFF
--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -218,7 +218,7 @@ class ClearlyDescribedSummarizer {
   parseLicenseExpression(manifest, packageType) {
     const combineLicenses = (exp, license) => {
       if (exp) {
-        return exp + ' ' + (packageType==='npm'?'AND':'OR') + ' ' +
+        return exp + ' ' + (packageType === 'npm'?'AND':'OR') + ' ' +
           stringObjectArray(license)
       }
       return stringObjectArray(license)
@@ -238,7 +238,7 @@ class ClearlyDescribedSummarizer {
       return null
     }
     return stringObjectArray(manifest.license) ||
-      (packageType==='npm' && stringObjectArray(manifest.licenses))
+      (packageType === 'npm' && stringObjectArray(manifest.licenses))
   }
 
   addNpmData(result, data, coordinates) {

--- a/test/summary/clearlyDefined.js
+++ b/test/summary/clearlyDefined.js
@@ -171,19 +171,6 @@ function setupSourceArchive(releaseDate, sourceInfo) {
 }
 
 describe('ClearlyDefined NPM summarizer', () => {
-  it('handles with all the data', () => {
-    const { coordinates, harvested } = setupNpm('2018-03-06T11:38:10.284Z', ['MIT'], 'http://homepage', {
-      url: 'http://bugs',
-      email: 'bugs@test.com'
-    })
-    const summary = Summarizer().summarize(coordinates, harvested)
-    validate(summary)
-    expect(summary.licensed.declared).to.eq('MIT')
-    expect(summary.described.releaseDate).to.eq('2018-03-06')
-    expect(summary.described.issueTracker).to.eq('http://bugs')
-    expect(summary.described.projectWebsite).to.eq('http://homepage')
-  })
-
   it('handles with all the data and a single license string', () => {
     const { coordinates, harvested } = setupNpm('2018-03-06T11:38:10.284Z', 'MIT', 'http://homepage', {
       url: 'http://bugs',
@@ -197,7 +184,20 @@ describe('ClearlyDefined NPM summarizer', () => {
     expect(summary.described.projectWebsite).to.eq('http://homepage')
   })
 
-  it('handles with all the data and a license array', () => {
+  it('handles with all the data and a license array of one string', () => {
+    const { coordinates, harvested } = setupNpm('2018-03-06T11:38:10.284Z', ['MIT'], 'http://homepage', {
+      url: 'http://bugs',
+      email: 'bugs@test.com'
+    })
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.licensed.declared).to.eq('MIT')
+    expect(summary.described.releaseDate).to.eq('2018-03-06')
+    expect(summary.described.issueTracker).to.eq('http://bugs')
+    expect(summary.described.projectWebsite).to.eq('http://homepage')
+  })
+
+  it('handles with all the data and a license array of strings', () => {
     const { coordinates, harvested } = setupNpm('2018-03-06T11:38:10.284Z', ['MIT', 'Apache-2.0'], 'http://homepage', {
       url: 'http://bugs',
       email: 'bugs@test.com'
@@ -208,6 +208,22 @@ describe('ClearlyDefined NPM summarizer', () => {
     expect(summary.described.releaseDate).to.eq('2018-03-06')
     expect(summary.described.issueTracker).to.eq('http://bugs')
     expect(summary.described.projectWebsite).to.eq('http://homepage')
+  })
+
+  it('handles a license as an object', () => {
+    const { coordinates, harvested } = setupNpm(null, { type: 'MIT' })
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.licensed.declared).to.eq('MIT')
+    expect(summary.described.urls).not.to.be.undefined
+  })
+
+  it('handles a license as an object with an array of strings ', () => {
+    const { coordinates, harvested } = setupNpm(null, { type: ['MIT', 'Apache-2.0'] })
+    const summary = Summarizer().summarize(coordinates, harvested)
+    validate(summary)
+    expect(summary.licensed.declared).to.eq('MIT AND Apache-2.0')
+    expect(summary.described.urls).not.to.be.undefined
   })
 
   it('handles data with source location', () => {
@@ -252,14 +268,6 @@ describe('ClearlyDefined NPM summarizer', () => {
     const summary = Summarizer().summarize(coordinates, harvested)
     validate(summary)
     expect(summary.licensed).to.be.undefined
-    expect(summary.described.urls).not.to.be.undefined
-  })
-
-  it('handles object license', () => {
-    const { coordinates, harvested } = setupNpm(null, { type: 'MIT' })
-    const summary = Summarizer().summarize(coordinates, harvested)
-    validate(summary)
-    expect(summary.licensed.declared).to.eq('MIT')
     expect(summary.described.urls).not.to.be.undefined
   })
 })

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -235,7 +235,6 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
       ' ': null
     }
 
-    // #1 single license string
     for (let license of Object.keys(data)) {
       let result = {}
       summarizer.addNpmData(result, { registryData: { manifest: { license: license } } }, npmTestCoordinates)
@@ -247,7 +246,6 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
       else assert.deepEqual(result, expectedResult)
     }
 
-    // #3 license as an object
     for (let license of Object.keys(data)) {
       let result = {}
       summarizer.addNpmData(result, { registryData: { manifest: { license: { type: license } } } }, npmTestCoordinates)
@@ -259,7 +257,6 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
       else assert.deepEqual(result, expectedResult)
     }
 
-    // #5 should work with legacy licenses key, single string
     for (let license of Object.keys(data)) {
       let result = {}
       summarizer.addNpmData(result, { registryData: { manifest: { licenses: license } } }, npmTestCoordinates)
@@ -272,7 +269,6 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
       else assert.deepEqual(result, expectedResult)
     }
 
-    // #6 should work with legacy licenses key, license as an object
     for (let license of Object.keys(data)) {
       let result = {}
       summarizer.addNpmData(result, { registryData: { manifest: { licenses: { type: license } } } }, npmTestCoordinates)
@@ -285,29 +281,24 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
       else assert.deepEqual(result, expectedResult)
     }
 
-    // #2 license array of one string
     const licenseArray = ['MIT']
     let result = {}
     summarizer.addNpmData(result, { registryData: { manifest: { license: licenseArray } } }, npmTestCoordinates)
     assert.deepEqual(result, {...expectedResult, licensed: { declared: 'MIT'}})
 
-    // #2 license array of strings
     const licenseArray2 = ['MIT', 'Apache-2.0']
     let result2 = {}
     summarizer.addNpmData(result2, { registryData: { manifest: { license: licenseArray2 } } }, npmTestCoordinates)
     assert.deepEqual(result2, {...expectedResult, licensed: { declared: 'MIT AND Apache-2.0'}})
 
-    // #4 license as an object with an array of strings
     let result3 = {}
     summarizer.addNpmData(result3, { registryData: { manifest: { license: { type: licenseArray2 } } } }, npmTestCoordinates)
     assert.deepEqual(result3, {...expectedResult, licensed: { declared: 'MIT AND Apache-2.0'}})
 
-    // #7 legacy licenses array of strings
     let result4 = {}
     summarizer.addNpmData(result4, { registryData: { manifest: { licenses: licenseArray2 } } }, npmTestCoordinates)
     assert.deepEqual(result4, {...expectedResult, licensed: { declared: 'MIT AND Apache-2.0'}})
 
-    // #8 legacy licenses as an array of objects
     const licenseArray3 = [ { type: 'MIT'} , { type: 'Apache-2.0'} ]
     let result5 = {}
     summarizer.addNpmData(result5, { registryData: { manifest: { licenses: licenseArray3 } } }, npmTestCoordinates)

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -235,6 +235,7 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
       ' ': null
     }
 
+    // #1 single license string
     for (let license of Object.keys(data)) {
       let result = {}
       summarizer.addNpmData(result, { registryData: { manifest: { license: license } } }, npmTestCoordinates)
@@ -246,7 +247,7 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
       else assert.deepEqual(result, expectedResult)
     }
 
-    // should work in the type field as well
+    // #3 license as an object
     for (let license of Object.keys(data)) {
       let result = {}
       summarizer.addNpmData(result, { registryData: { manifest: { license: { type: license } } } }, npmTestCoordinates)
@@ -258,7 +259,7 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
       else assert.deepEqual(result, expectedResult)
     }
 
-    // should work with legacy licenses
+    // #5 should work with legacy licenses key, single string
     for (let license of Object.keys(data)) {
       let result = {}
       summarizer.addNpmData(result, { registryData: { manifest: { licenses: license } } }, npmTestCoordinates)
@@ -271,11 +272,46 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
       else assert.deepEqual(result, expectedResult)
     }
 
-    // should work with license as an array
-    const licenseArray = ['MIT', 'Apache-2.0']
+    // #6 should work with legacy licenses key, license as an object
+    for (let license of Object.keys(data)) {
+      let result = {}
+      summarizer.addNpmData(result, { registryData: { manifest: { licenses: { type: license } } } }, npmTestCoordinates)
+      if (data[license]) {
+        assert.deepEqual(result, {
+          ...expectedResult,
+          licensed: { declared: data[license] }
+        })
+      }
+      else assert.deepEqual(result, expectedResult)
+    }
+
+    // #2 license array of one string
+    const licenseArray = ['MIT']
     let result = {}
-    summarizer.addNpmData(result, { registryData: { manifest: { licenses: licenseArray } } }, npmTestCoordinates)
-    assert.deepEqual(result, {...expectedResult, licensed: { declared: 'MIT AND Apache-2.0'}})
+    summarizer.addNpmData(result, { registryData: { manifest: { license: licenseArray } } }, npmTestCoordinates)
+    assert.deepEqual(result, {...expectedResult, licensed: { declared: 'MIT'}})
+
+    // #2 license array of strings
+    const licenseArray2 = ['MIT', 'Apache-2.0']
+    let result2 = {}
+    summarizer.addNpmData(result2, { registryData: { manifest: { license: licenseArray2 } } }, npmTestCoordinates)
+    assert.deepEqual(result2, {...expectedResult, licensed: { declared: 'MIT AND Apache-2.0'}})
+
+    // #4 license as an object with an array of strings
+    let result3 = {}
+    summarizer.addNpmData(result3, { registryData: { manifest: { license: { type: licenseArray2 } } } }, npmTestCoordinates)
+    assert.deepEqual(result3, {...expectedResult, licensed: { declared: 'MIT AND Apache-2.0'}})
+
+    // #7 legacy licenses array of strings
+    let result4 = {}
+    summarizer.addNpmData(result4, { registryData: { manifest: { licenses: licenseArray2 } } }, npmTestCoordinates)
+    assert.deepEqual(result4, {...expectedResult, licensed: { declared: 'MIT AND Apache-2.0'}})
+
+    // #8 legacy licenses as an array of objects
+    const licenseArray3 = [ { type: 'MIT'} , { type: 'Apache-2.0'} ]
+    let result5 = {}
+    summarizer.addNpmData(result5, { registryData: { manifest: { licenses: licenseArray3 } } }, npmTestCoordinates)
+    assert.deepEqual(result5, {...expectedResult, licensed: { declared: 'MIT AND Apache-2.0'}})
   })
 
   it('should set release date', () => {


### PR DESCRIPTION
Handles legacy licenses key as either:
- a string
- an array of strings
- an array of objects (where each type key has the license string)

Resolves: #458 (bis)

Signed-off-by: Tom Marble <tmarble@info9.net>