### PR TITLE
Failing requests to /notices when coordinates exceed 5K.

### DIFF
--- a/schemas/notice-request.json
+++ b/schemas/notice-request.json
@@ -8,6 +8,7 @@
   "properties": {
     "coordinates": {
       "type": "array",
+      "maxItems": 5000,
       "items": { "type": "string" },
       "errorMessage": {
         "type": "coordinates type must be an array"


### PR DESCRIPTION
When a POST request is made to /notices with a 'coordinates' array
exceeding a length of 5000 we return status 400 and indicate that the
array's maximum length is 5000.

Fixes #359

I was unable to find tests for the HTTP interface itself only tests that call the NoticeService which would bypass this change. I tested by hand. If there are tests for the HTTP interface as well I can add a new one there.