### PR TITLE
Changing github harvest recommendations to sort by best match.

### DIFF
--- a/routes/originGitHub.js
+++ b/routes/originGitHub.js
@@ -69,7 +69,7 @@ router.get(
       })
       return response.status(200).send(result)
     }
-    const answer = await github.search.users({ q: `${login}+repos:>0`, sort: 'repositories', per_page: 100 })
+    const answer = await github.search.users({ q: `${login}+repos:>0`, per_page: 100 })
     const result = answer.data.items.map(item => {
       return { id: item.login }
     })


### PR DESCRIPTION
The user/organization recommendations sorting for GitHub Harvest have
been changed from "repositories" to best match (the GitHub
default). This fixes an issue where an exact match is not the first
item in the results and a case where an exact match doesn't show up at
all in the recommendations (the user/org has few repos but their ID is
a substring of many other IDs; since we limit to first 100 results).

Fixes #661