### PR TITLE
Flesh out types and providers

### DIFF
--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -535,6 +535,7 @@ components:
           - crate
           - pypi
           - nuget
+          - sourcearchive
     provider:
       name: provider
       in: path
@@ -548,6 +549,7 @@ components:
           - cratesio
           - pypi
           - nuget
+          - mavencentral
     namespace:
       name: namespace
       in: path

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -541,6 +541,7 @@ components:
           - gem
           - pod
           - deb
+          - debsrc
     provider:
       name: provider
       in: path

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -530,18 +530,18 @@ components:
       schema:
         type: string
         enum:
-          - npm
-          - git
-          - crate
-          - pypi
-          - nuget
-          - maven
-          - sourcearchive
           - composer
-          - gem
-          - pod
+          - crate
           - deb
           - debsrc
+          - gem
+          - git
+          - maven
+          - npm
+          - nuget
+          - pod
+          - pypi
+          - sourcearchive
     provider:
       name: provider
       in: path
@@ -550,16 +550,16 @@ components:
       schema:
         type: string
         enum:
-          - npmjs
-          - github
-          - cratesio
-          - pypi
-          - nuget
-          - mavencentral
-          - packagist
-          - rubygems
           - cocoapods
+          - cratesio
           - debian
+          - github
+          - mavencentral
+          - npmjs
+          - nuget
+          - packagist
+          - pypi
+          - rubygems
     namespace:
       name: namespace
       in: path

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -538,6 +538,7 @@ components:
           - maven
           - sourcearchive
           - composer
+          - gem
     provider:
       name: provider
       in: path
@@ -553,6 +554,7 @@ components:
           - nuget
           - mavencentral
           - packagist
+          - rubygems
     namespace:
       name: namespace
       in: path

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -540,6 +540,7 @@ components:
           - composer
           - gem
           - pod
+          - deb
     provider:
       name: provider
       in: path
@@ -557,6 +558,7 @@ components:
           - packagist
           - rubygems
           - cocoapods
+          - debian
     namespace:
       name: namespace
       in: path

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -533,6 +533,7 @@ components:
           - npm
           - git
           - crate
+          - pypi
     provider:
       name: provider
       in: path
@@ -544,6 +545,7 @@ components:
           - npmjs
           - github
           - cratesio
+          - pypi
     namespace:
       name: namespace
       in: path

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -539,6 +539,7 @@ components:
           - sourcearchive
           - composer
           - gem
+          - pod
     provider:
       name: provider
       in: path
@@ -555,6 +556,7 @@ components:
           - mavencentral
           - packagist
           - rubygems
+          - cocoapods
     namespace:
       name: namespace
       in: path

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -532,6 +532,7 @@ components:
         enum:
           - npm
           - git
+          - crate
     provider:
       name: provider
       in: path
@@ -542,6 +543,7 @@ components:
         enum:
           - npmjs
           - github
+          - cratesio
     namespace:
       name: namespace
       in: path

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -534,6 +534,7 @@ components:
           - git
           - crate
           - pypi
+          - nuget
     provider:
       name: provider
       in: path
@@ -546,6 +547,7 @@ components:
           - github
           - cratesio
           - pypi
+          - nuget
     namespace:
       name: namespace
       in: path

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -537,6 +537,7 @@ components:
           - nuget
           - maven
           - sourcearchive
+          - composer
     provider:
       name: provider
       in: path
@@ -551,6 +552,7 @@ components:
           - pypi
           - nuget
           - mavencentral
+          - packagist
     namespace:
       name: namespace
       in: path

--- a/schemas/swagger.yaml
+++ b/schemas/swagger.yaml
@@ -535,6 +535,7 @@ components:
           - crate
           - pypi
           - nuget
+          - maven
           - sourcearchive
     provider:
       name: provider


### PR DESCRIPTION
This PR adds all of the types and providers actually supported by clearlydefined to the swagger API docs.