### PR TITLE
Updated mavencentral source url

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -193,7 +193,7 @@ function buildSourceUrl(spec) {
       return `https://github.com/${spec.namespace}/${spec.name}/tree/${spec.revision}`
     case 'mavencentral': {
       const fullName = `${spec.namespace}/${spec.name}`.replace(/\./g, '/')
-      return `http://central.maven.org/maven2/${fullName}/${spec.revision}/${spec.name}-${spec.revision}-sources.jar`
+      return `https://search.maven.org/remotecontent?filepath=${fullName}/${spec.revision}/${spec.name}-${spec.revision}-sources.jar`
     }
     default:
       return null


### PR DESCRIPTION
Before (broken): http://central.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-scala_2/11/2.11.1/jackson-module-scala_2.11-2.11.1-sources.jar

After (not broken): https://search.maven.org/remotecontent?filepath=com/fasterxml/jackson/module/jackson-module-scala_2.11/2.11.1/jackson-module-scala_2.11-2.11.1-sources.jar

RE: [issue 707](https://github.com/clearlydefined/service/issues/707)