### PR TITLE
Add url Microsoft EULA

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -381,7 +381,8 @@ const _licenseUrlOverrides = [
   { test: /^https?:\/\/pdfium.patagames.com\/faq\/eula/i, license: 'OTHER' },
   { test: /^https?:\/\/specflow.org\/plus\/eula\//i, license: 'OTHER' },
   { test: /^https?:\/\/www.streamcoders.com\/products\/msneteula.html/i, license: 'OTHER' },
-  { test: /^https?:\/\/workflowenginenet.com\/EULA/i, license: 'OTHER' }
+  { test: /^https?:\/\/workflowenginenet.com\/EULA/i, license: 'OTHER' },
+  { test: /^https?:\/\/aka.ms\/azureml-sdk-license/i, license: 'OTHER' }
 ]
 
 module.exports = {


### PR DESCRIPTION
Based on this [issue](https://github.com/clearlydefined/service/issues/757). Add https://aka.ms/azureml-sdk-license to Microsoft EULA.