### PR TITLE
correct spelling error in environmental variable name

### DIFF
--- a/providers/stores/mongoConfig.js
+++ b/providers/stores/mongoConfig.js
@@ -8,7 +8,7 @@ function definition(options) {
     options || {
       connectionString: config.get('DEFINITION_MONGO_CONNECTION_STRING'),
       dbName: config.get('DEFINITION_MONGO_DB_NAME') || 'clearlydefined',
-      collectionName: config.get('DEFINITON_MONGO_COLLECTION_NAME') || 'definitions'
+      collectionName: config.get('DEFINITION_MONGO_COLLECTION_NAME') || 'definitions'
     }
   )
 }


### PR DESCRIPTION
Before deploy, need to add the corrected environmental variable to dev-api and prod-api Azure app services.

Signed-off-by: Nell Shamrell <nells@microsoft.com>