### PR TITLE
Returns error when coordinates are malformed

### DIFF
--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -335,14 +335,10 @@ ${this._formatDefinitions(patch.patches)}`
   }
 
   async apply(coordinates, curationSpec, definition) {
-    try {
-      const curation = await this.get(coordinates, curationSpec)
-      const result = Curation.apply(definition, curation)
-      this._ensureCurationInfo(result, curation)
-      return result
-    } catch (err) {
-      throw new Error(err.message)
-    }
+    const curation = await this.get(coordinates, curationSpec)
+    const result = Curation.apply(definition, curation)
+    this._ensureCurationInfo(result, curation)
+    return result
   }
 
   _ensureCurationInfo(definition, curation) {

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -259,10 +259,8 @@ ${this._formatDefinitions(patch.patches)}`
   _formatDefinitions(definitions) {
     return definitions.map(
       def =>
-        `- [${def.coordinates.name} ${
-          Object.keys(def.revisions)[0]
-        }](https://clearlydefined.io/definitions/${EntityCoordinates.fromObject(def.coordinates)}/${
-          Object.keys(def.revisions)[0]
+        `- [${def.coordinates.name} ${Object.keys(def.revisions)[0]
+        }](https://clearlydefined.io/definitions/${EntityCoordinates.fromObject(def.coordinates)}/${Object.keys(def.revisions)[0]
         })`
     )
   }
@@ -279,7 +277,7 @@ ${this._formatDefinitions(patch.patches)}`
    * @returns {Object} The requested curation and corresponding revision identifier (e.g., commit sha) if relevant
    */
   async get(coordinates, curation = null) {
-    if (!coordinates.revision) throw new Error('Coordinates must include a revision')
+    if (!coordinates.revision) throw new Error(`Coordinates ${coordinates.toString()} appear to be malformed. Are they missing a namespace or revision?`)
     if (curation && typeof curation !== 'number' && typeof curation !== 'string') return curation
     const all = await this._getCurations(coordinates, curation)
     if (!all || !all.revisions) return null
@@ -337,10 +335,14 @@ ${this._formatDefinitions(patch.patches)}`
   }
 
   async apply(coordinates, curationSpec, definition) {
-    const curation = await this.get(coordinates, curationSpec)
-    const result = Curation.apply(definition, curation)
-    this._ensureCurationInfo(result, curation)
-    return result
+    try {
+      const curation = await this.get(coordinates, curationSpec)
+      const result = Curation.apply(definition, curation)
+      this._ensureCurationInfo(result, curation)
+      return result
+    } catch (err) {
+      throw new Error(err.message)
+    }
   }
 
   _ensureCurationInfo(definition, curation) {

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -70,6 +70,28 @@ async function listDefinitions(request, response) {
   // if running on localhost, allow a force arg for testing without webhooks to invalidate the caches
   const force = request.hostname.includes('localhost') ? request.query.force || false : false
   const expand = request.query.expand === '-files' ? '-files' : null // only support '-files' for now
+  try {
+    const result = await definitionService.getAll(coordinatesList, force, expand)
+    const matchCasing = !(request.query.matchCasing === 'false' || request.query.matchCasing === false)
+    if (matchCasing) {
+      // enforce request casing on keys as per issue #589
+      const requestLowered = request.body.map(k => k.toLowerCase())
+      const casingEnforced = Object
+        .keys(result)
+        .reduce((total, resultKey) => {
+          const idx = requestLowered.indexOf(resultKey.toLowerCase())
+          const key = idx >= 0 ? request.body[idx] : resultKey
+          total[key] = result[resultKey]
+          return total
+        }, {})
+      response.send(casingEnforced)
+    }
+    else {
+      response.send(result)
+    }
+  } catch (err) {
+    response.send(`An error occured when trying to fetch coordinates for one of the components: ${err.message}`)
+  }
   const result = await definitionService.getAll(coordinatesList, force, expand)
   const matchCasing = !(request.query.matchCasing === 'false' || request.query.matchCasing === false)
   if (matchCasing) {

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -92,24 +92,6 @@ async function listDefinitions(request, response) {
   } catch (err) {
     response.send(`An error occured when trying to fetch coordinates for one of the components: ${err.message}`)
   }
-  const result = await definitionService.getAll(coordinatesList, force, expand)
-  const matchCasing = !(request.query.matchCasing === 'false' || request.query.matchCasing === false)
-  if (matchCasing) {
-    // enforce request casing on keys as per issue #589
-    const requestLowered = request.body.map(k => k.toLowerCase())
-    const casingEnforced = Object
-      .keys(result)
-      .reduce((total, resultKey) => {
-        const idx = requestLowered.indexOf(resultKey.toLowerCase())
-        const key = idx >= 0 ? request.body[idx] : resultKey
-        total[key] = result[resultKey]
-        return total
-      }, {})
-    response.send(casingEnforced)
-  }
-  else {
-    response.send(result)
-  }
 }
 
 let definitionService


### PR DESCRIPTION
Fixes #742

One this is merged, if someone makes POST to `definitions` with a malformed component, like this:

```bash
curl -X POST "https://clearlydefined.io/definitions" -H "accept: application/json" -H "Content-Type: application/json" -d "[\"npm/npmjs/redie/0.3.0\",\"npm/npmjs/-/redie/0.3.0\"]"
```

They will receive a more useful error:

```bash
curl -X POST "https://clearlydefined.io/definitions" -H "accept: application/json" -H "Content-Type: application/json" -d "[\"npm/npmjs/redie/0.3.0\",\"npm/npmjs/-/redie/0.3.0\"]"

An error occured when trying to fetch coordinates for one of the components: Coordinates npm/npmjs/redie/0.3.0 appear to be malformed. Are they missing a namespace or revision?
```

