### PR TITLE
updates the urls set for source archive packages

### DIFF
--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -182,13 +182,13 @@ class ClearlyDescribedSummarizer {
     setIfValue(
       result,
       'described.urls.registry',
-      `http://central.maven.org/maven2/${namespaceAsFolders}/${coordinates.name}`
+      `https://repo1.maven.org/maven2/${namespaceAsFolders}/${coordinates.name}`
     )
     setIfValue(result, 'described.urls.version', `${get(result, 'described.urls.registry')}/${coordinates.revision}`)
     setIfValue(
       result,
       'described.urls.download',
-      `http://central.maven.org/maven2/${namespaceAsFolders}/${coordinates.name}/${coordinates.revision}/${coordinates.name}-${coordinates.revision}.jar`
+      `https://repo1.maven.org/maven2/${namespaceAsFolders}/${coordinates.name}/${coordinates.revision}/${coordinates.name}-${coordinates.revision}.jar`
     )
   }
 

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -543,11 +543,6 @@ describe('ClearlyDescribedSummarizer addSourceArchiveData', () => {
   it('should set the correct urls', () => {
     const data = {
       'https://opensource.org/licenses/MIT': 'MIT',
-      'https://www.apache.org/licenses/LICENSE-2.0': 'Apache-2.0',
-      'See license': null,
-      NOASSERTION: null,
-      '': null,
-      ' ': null
     }
 
     for (let url of Object.keys(data)) {
@@ -564,8 +559,6 @@ describe('ClearlyDescribedSummarizer addSourceArchiveData', () => {
       else assert.deepEqual(result, expectedResult)
     }
   })
-
-
 })
 
 describe('ClearlyDescribedSummarizer addDebData', () => {

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -532,6 +532,42 @@ describe('ClearlyDescribedSummarizer addMavenData', () => {
   })
 })
 
+describe('ClearlyDescribedSummarizer addSourceArchiveData', () => {
+  const expectedUrls = {
+    download: 'https://repo1.maven.org/maven2/io/clearlydefined/test/1.0/test-1.0.jar',
+    registry: 'https://repo1.maven.org/maven2/io/clearlydefined/test',
+    version: 'https://repo1.maven.org/maven2/io/clearlydefined/test/1.0',
+  }
+
+  const expectedResult = { described: { urls: expectedUrls } }
+  it('should set the correct urls', () => {
+    const data = {
+      'https://opensource.org/licenses/MIT': 'MIT',
+      'https://www.apache.org/licenses/LICENSE-2.0': 'Apache-2.0',
+      'See license': null,
+      NOASSERTION: null,
+      '': null,
+      ' ': null
+    }
+
+    for (let url of Object.keys(data)) {
+      let result = {}
+      summarizer.addSourceArchiveData(
+        result,
+        { manifest: { summary: { project: { licenses: [{ license: { url } }] } } } },
+        testCoordinates
+      )
+      if (data[url])
+        assert.deepEqual(result, {
+          ...expectedResult,
+        })
+      else assert.deepEqual(result, expectedResult)
+    }
+  })
+
+
+})
+
 describe('ClearlyDescribedSummarizer addDebData', () => {
   const debTestCoordinates = EntityCoordinates.fromString('deb/debian/-/test/1.0_arch')
   it('decribes releaseDate from data', () => {


### PR DESCRIPTION
This is similar to #794 - only it corrects the maven urls for source archives (which are also maven packages)

Signed-off-by: Nell Shamrell <nells@microsoft.com>