### PR TITLE
Added matching logic, tests, feature flag to multiversion curation

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ function createApp(config) {
   const cachingService = config.caching.service()
   initializers.push(async () => cachingService.initialize())
 
-  const curationService = config.curation.service(null, curationStore, config.endpoints, cachingService)
+  const curationService = config.curation.service(null, curationStore, config.endpoints, cachingService, harvestStore)
 
   const curationQueue = config.curation.queue()
   initializers.push(async () => curationQueue.initialize())

--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -1,6 +1,5 @@
-const { get, first, isEqual: isDeepEqual } = require('lodash')
-const { isLicenseFile } = require('./utils')
-const semver = require('semver')
+const { get, isEqual: isDeepEqual } = require('lodash')
+const { isLicenseFile, getLatestVersion } = require('./utils')
 
 class LicenseMatcher {
   constructor(policies) {
@@ -36,35 +35,62 @@ class DefinitionLicenseMatchPolicy {
     this._compareProps = ['hashes.sha1', 'hashes.sha256', 'token']
   }
 
+  // When license changed name or path even the content has not be changed,
+  // compare will return not match.
   compare(source, target) {
-    const sourceLicenseFiles = source.definition.files.filter(f => isLicenseFile(f.path, source.definition.coordinates))
-    const targetLicenseFiles = target.definition.files.filter(f => isLicenseFile(f.path, target.definition.coordinates))
+    const fileMap = this._generateFileMap(source, target)
+    return this._compareFileInMap(fileMap)
+  }
+
+  _generateFileMap(source, target) {
+    const sourceLicenseFiles = this._getLicenseFile(source.definition)
+    const targetLicenseFiles = this._getLicenseFile(target.definition)
+    const fileMap = new Map()
+    this._addFileToMap(fileMap, sourceLicenseFiles, 'sourceFile')
+    this._addFileToMap(fileMap, targetLicenseFiles, 'targetFile')
+    return fileMap
+  }
+
+  _addFileToMap(fileMap, files, propName) {
+    files.forEach(f => {
+      if (!f.path) return
+      const current = fileMap.get(f.path) || {}
+      current[propName] = f
+      fileMap.set(f.path, current)
+    })
+  }
+
+  _getLicenseFile(definition) {
+    return definition.files.filter(f => isLicenseFile(f.path, definition.coordinates))
+  }
+
+  _compareFileInMap(fileMap) {
     const result = {
       match: [],
       mismatch: []
     }
-    for (const propPath of this._compareProps) {
-      for (const sourceFile of sourceLicenseFiles) {
+    for (const [path, { sourceFile, targetFile }] of fileMap) {
+      for (const propPath of this._compareProps) {
         const sourceValue = get(sourceFile, propPath)
-        for (const targetFile of targetLicenseFiles) {
-          const targetValue = get(targetFile, propPath)
-          if (!sourceValue && !targetValue) {
-            continue
-          }
-          if (sourceValue === targetValue) {
-            result.match.push({
-              policy: this.name,
-              propPath,
-              value: sourceValue
-            })
-          } else {
-            result.mismatch.push({
-              policy: this.name,
-              propPath,
-              source: sourceValue,
-              target: targetValue
-            })
-          }
+        const targetValue = get(targetFile, propPath)
+        if (!sourceValue && !targetValue) {
+          continue
+        }
+        if (sourceValue === targetValue) {
+          result.match.push({
+            policy: this.name,
+            file: path,
+            propPath,
+            value: sourceValue
+          })
+        } else {
+          result.mismatch.push({
+            policy: this.name,
+            file: path,
+            propPath,
+            source: sourceValue,
+            target: targetValue
+          })
         }
       }
     }
@@ -139,8 +165,7 @@ function getLatestToolHarvest(coordinateHarvest, tool) {
   if (!coordinateHarvest[tool]) {
     return
   }
-  const sortedVersions = Object.keys(coordinateHarvest[tool]).sort((a, b) => semver.gt(a, b) ? -1 : 1)
-  const latestVersion = first(sortedVersions)
+  const latestVersion = getLatestVersion(Object.keys(coordinateHarvest[tool]))
   return get(coordinateHarvest, [tool, latestVersion])
 }
 

--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -1,0 +1,110 @@
+const { get, first } = require('lodash')
+
+class LicenseMatcher {
+  constructor(policies) {
+    this._policies = policies || [new DefinitionLicenseMatchPolicy(), new HarvestLicenseMatchPolicy()]
+  }
+
+  /**
+   * Given two coordinate with different revision, decide whether they have the same license and provide reason
+   * @param { definition, harvest } source
+   * @param { definition, harvest } target
+   * @return { isMatching: Boolean, reason: String | undefined, policy: String | undefined }
+   */
+  process(source, target) {
+    for (const policy of this._policies) {
+      const match = policy.isMatching(source, target);
+      if (match.isMatching) {
+        return match
+      }
+    }
+    return { isMatching: false }
+  }
+}
+
+class DefinitionLicenseMatchPolicy {
+  constructor() {
+    this._policyName = 'definition'
+    this._comparePaths = ['hashes.sha1', 'hashes.sha256', 'token']
+  }
+
+  isMatching(source, target) {
+    const licenseFiles = source.definition.files.filter(f => f.path.toLowerCase().includes('license') || f.path.toLowerCase().includes('copying'))
+    if (licenseFiles.length === 0) {
+      return false
+    }
+    for (const file of target.definition.files) {
+      for (const path of this._comparePaths) {
+        const value = get(file, path)
+        const isMatching = licenseFiles.some(licenseFile => noEmptyEqual(get(licenseFile, path), value))
+        if (isMatching) {
+          const reason = `${source.definition.coordinates.revision} and ${target.definition.coordinates.revision} share the same ${path}, ${value}`
+          return {
+            isMatching: true,
+            policy: this._policyName,
+            reason
+          }
+        }
+      }
+    }
+    return { isMatching: false }
+  }
+}
+
+class HarvestLicenseMatchPolicy {
+  constructor() {
+    this._policyName = 'harvest'
+    this._compareProps = [
+      {
+        type: 'npm',
+        path: 'registryData.manifest.license'
+      }
+    ];
+  }
+
+  isMatching(source, target) {
+    const sourceLatestClearlyDefinedToolHarvest = getLatestToolHarvest(source.harvest, 'clearlydefined')
+    const targetLatestClearlyDefinedToolHarvest = getLatestToolHarvest(target.harvest, 'clearlydefined')
+    for (const prop of this._compareProps) {
+      if (prop.type !== source.definition.coordinates.type) {
+        continue
+      }
+      const sourceLicense = get(sourceLatestClearlyDefinedToolHarvest, prop.path)
+      const targetLicense = get(targetLatestClearlyDefinedToolHarvest, prop.path)
+      if (noEmptyEqual(sourceLicense, targetLicense)) {
+        return {
+          isMatching: true,
+          policy: this._policyName,
+          reason: `${source.definition.coordinates.revision} and ${target.definition.coordinates.revision} share the same ${prop.path}, ${sourceLicense}`
+        }
+      }
+    }
+    return { isMatching: false }
+  }
+}
+
+/**
+ * If either source and target is undefined or null, return false. Otherwise, do the ===
+ * @param {*} source
+ * @param {*} target
+ * @return { Boolean }
+ */
+function noEmptyEqual(source, target) {
+  if (!source || !target) {
+    return false
+  }
+  return source === target
+}
+
+function getLatestToolHarvest(coordinateHarvest, tool) {
+  if (!coordinateHarvest[tool]) {
+    return
+  }
+  const sortedVersions = Object.keys(coordinateHarvest[tool]).sort((a, b) => semver.gt(a, b) ? -1 : 1)
+  const latestVersion = first(sortedVersions)
+  return get(coordinateHarvest, [tool, latestVersion])
+}
+
+module.exports = {
+  LicenseMatcher
+}

--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -1,4 +1,5 @@
 const { get, first } = require('lodash')
+const { isLicenseFile } = require('./utils')
 
 class LicenseMatcher {
   constructor(policies) {
@@ -25,20 +26,20 @@ class LicenseMatcher {
 class DefinitionLicenseMatchPolicy {
   constructor() {
     this._policyName = 'definition'
-    this._comparePaths = ['hashes.sha1', 'hashes.sha256', 'token']
+    this._compareProps = ['hashes.sha1', 'hashes.sha256', 'token']
   }
 
   isMatching(source, target) {
-    const licenseFiles = source.definition.files.filter(f => f.path.toLowerCase().includes('license') || f.path.toLowerCase().includes('copying'))
+    const licenseFiles = source.definition.files.filter(f => isLicenseFile(f.path))
     if (licenseFiles.length === 0) {
       return false
     }
     for (const file of target.definition.files) {
-      for (const path of this._comparePaths) {
-        const value = get(file, path)
-        const isMatching = licenseFiles.some(licenseFile => noEmptyEqual(get(licenseFile, path), value))
+      for (const propPath of this._compareProps) {
+        const value = get(file, propPath)
+        const isMatching = licenseFiles.some(licenseFile => noEmptyEqual(get(licenseFile, propPath), value))
         if (isMatching) {
-          const reason = `${source.definition.coordinates.revision} and ${target.definition.coordinates.revision} share the same ${path}, ${value}`
+          const reason = `${source.definition.coordinates.revision} and ${target.definition.coordinates.revision} share the same ${propPath} for file, ${file.path}, ${value}`
           return {
             isMatching: true,
             policy: this._policyName,
@@ -57,7 +58,7 @@ class HarvestLicenseMatchPolicy {
     this._compareProps = [
       {
         type: 'npm',
-        path: 'registryData.manifest.license'
+        propPath: 'registryData.manifest.license'
       }
     ];
   }
@@ -69,13 +70,13 @@ class HarvestLicenseMatchPolicy {
       if (prop.type !== source.definition.coordinates.type) {
         continue
       }
-      const sourceLicense = get(sourceLatestClearlyDefinedToolHarvest, prop.path)
-      const targetLicense = get(targetLatestClearlyDefinedToolHarvest, prop.path)
+      const sourceLicense = get(sourceLatestClearlyDefinedToolHarvest, prop.propPath)
+      const targetLicense = get(targetLatestClearlyDefinedToolHarvest, prop.propPath)
       if (noEmptyEqual(sourceLicense, targetLicense)) {
         return {
           isMatching: true,
           policy: this._policyName,
-          reason: `${source.definition.coordinates.revision} and ${target.definition.coordinates.revision} share the same ${prop.path}, ${sourceLicense}`
+          reason: `${source.definition.coordinates.revision} and ${target.definition.coordinates.revision} share the same ${prop.propPath}, ${sourceLicense}`
         }
       }
     }

--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -1,5 +1,6 @@
 const { get, first, isEqual: isDeepEqual } = require('lodash')
 const { isLicenseFile } = require('./utils')
+const semver = require('semver')
 
 class LicenseMatcher {
   constructor(policies) {

--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -1,4 +1,4 @@
-const { get, first } = require('lodash')
+const { get, first, isEqual: isDeepEqual } = require('lodash')
 const { isLicenseFile } = require('./utils')
 
 class LicenseMatcher {
@@ -13,88 +13,125 @@ class LicenseMatcher {
    * @return { isMatching: Boolean, reason: String | undefined, policy: String | undefined }
    */
   process(source, target) {
-    for (const policy of this._policies) {
-      const match = policy.isMatching(source, target)
-      if (match.isMatching) {
-        return match
+    const compareResults = this._policies.map(policy => policy.compare(source, target))
+      .reduce((acc, cur) => ({ match: acc.match.concat(cur.match), mismatch: acc.mismatch.concat(cur.mismatch) }))
+    const allInconclusive = compareResults.mismatch.length === 0 && compareResults.match.length === 0
+    if (compareResults.mismatch.length || allInconclusive) {
+      return {
+        isMatching: false,
+        mismatch: compareResults.mismatch
       }
     }
-    return { isMatching: false }
+    return {
+      isMatching: true,
+      match: compareResults.match
+    }
   }
 }
 
 class DefinitionLicenseMatchPolicy {
   constructor() {
-    this._policyName = 'definition'
+    this.name = 'definition'
     this._compareProps = ['hashes.sha1', 'hashes.sha256', 'token']
   }
 
-  isMatching(source, target) {
-    const licenseFiles = source.definition.files.filter(f => isLicenseFile(f.path))
-    if (licenseFiles.length === 0) {
-      return false
+  compare(source, target) {
+    const sourceLicenseFiles = source.definition.files.filter(f => isLicenseFile(f.path, source.definition.coordinates))
+    const targetLicenseFiles = target.definition.files.filter(f => isLicenseFile(f.path, target.definition.coordinates))
+    const result = {
+      match: [],
+      mismatch: []
     }
-    for (const file of target.definition.files) {
-      for (const propPath of this._compareProps) {
-        const value = get(file, propPath)
-        const isMatching = licenseFiles.some(licenseFile => noEmptyEqual(get(licenseFile, propPath), value))
-        if (isMatching) {
-          const reason = `${source.definition.coordinates.revision} and ${target.definition.coordinates.revision} share the same ${propPath} for file, ${file.path}, ${value}`
-          return {
-            isMatching: true,
-            policy: this._policyName,
-            reason
+    for (const propPath of this._compareProps) {
+      for (const sourceFile of sourceLicenseFiles) {
+        const sourceValue = get(sourceFile, propPath)
+        for (const targetFile of targetLicenseFiles) {
+          const targetValue = get(targetFile, propPath)
+          if (!sourceValue && !targetValue) {
+            continue
+          }
+          if (sourceValue === targetValue) {
+            result.match.push({
+              policy: this.name,
+              propPath,
+              value: sourceValue
+            })
+          } else {
+            result.mismatch.push({
+              policy: this.name,
+              propPath,
+              source: sourceValue,
+              target: targetValue
+            })
           }
         }
       }
     }
-    return { isMatching: false }
+    return result
   }
 }
 
 class HarvestLicenseMatchPolicy {
   constructor() {
-    this._policyName = 'harvest'
-    this._compareProps = [
-      {
-        type: 'npm',
-        propPath: 'registryData.manifest.license'
-      }
-    ]
+    this.name = 'harvest'
   }
 
-  isMatching(source, target) {
+  compare(source, target) {
     const sourceLatestClearlyDefinedToolHarvest = getLatestToolHarvest(source.harvest, 'clearlydefined')
     const targetLatestClearlyDefinedToolHarvest = getLatestToolHarvest(target.harvest, 'clearlydefined')
-    for (const prop of this._compareProps) {
-      if (prop.type !== source.definition.coordinates.type) {
+    const result = {
+      match: [],
+      mismatch: []
+    }
+    const propPaths = this._getComparePropPaths(source)
+    for (const propPath of propPaths) {
+      const sourceLicense = get(sourceLatestClearlyDefinedToolHarvest, propPath)
+      const targetLicense = get(targetLatestClearlyDefinedToolHarvest, propPath)
+      if (!sourceLicense && !targetLicense) {
         continue
       }
-      const sourceLicense = get(sourceLatestClearlyDefinedToolHarvest, prop.propPath)
-      const targetLicense = get(targetLatestClearlyDefinedToolHarvest, prop.propPath)
-      if (noEmptyEqual(sourceLicense, targetLicense)) {
-        return {
-          isMatching: true,
-          policy: this._policyName,
-          reason: `${source.definition.coordinates.revision} and ${target.definition.coordinates.revision} share the same ${prop.propPath}, ${sourceLicense}`
-        }
+      if (isDeepEqual(sourceLicense, targetLicense)) {
+        result.match.push({
+          policy: this.name,
+          propPath,
+          value: sourceLicense
+        })
+      } else {
+        result.mismatch.push({
+          policy: this.name,
+          propPath,
+          source: sourceLicense,
+          target: targetLicense
+        })
       }
     }
-    return { isMatching: false }
+    return result
   }
-}
 
-/**
- * If either source and target is undefined or null, return false. Otherwise, do the ===
- * @param {*} source
- * @param {*} target
- * @return { Boolean }
- */
-function noEmptyEqual(source, target) {
-  if (!source || !target) {
-    return false
+  _getComparePropPaths(source) {
+    const type = source.definition.coordinates.type;
+    switch (type) {
+      case 'maven':
+        return ['manifest.summary.licenses']
+      case 'crate':
+      case 'pod':
+        return ['registryData.license']
+      case 'nuget':
+        return ['manifest.licenseExpression', 'manifest.licenseUrl']
+      case 'npm':
+      case 'composer':
+        return ['registryData.manifest.license']
+      case 'gem':
+        return ['registryData.licenses']
+      case 'pypi':
+        return ['declaredLicense', 'registryData.info.license']
+      case 'deb':
+      case 'debsrc':
+        return ['declaredLicenses']
+      default:
+        return []
+    }
   }
-  return source === target
 }
 
 function getLatestToolHarvest(coordinateHarvest, tool) {
@@ -107,5 +144,7 @@ function getLatestToolHarvest(coordinateHarvest, tool) {
 }
 
 module.exports = {
-  LicenseMatcher
+  LicenseMatcher,
+  DefinitionLicenseMatchPolicy,
+  HarvestLicenseMatchPolicy
 }

--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -14,7 +14,7 @@ class LicenseMatcher {
    */
   process(source, target) {
     for (const policy of this._policies) {
-      const match = policy.isMatching(source, target);
+      const match = policy.isMatching(source, target)
       if (match.isMatching) {
         return match
       }
@@ -60,7 +60,7 @@ class HarvestLicenseMatchPolicy {
         type: 'npm',
         propPath: 'registryData.manifest.license'
       }
-    ];
+    ]
   }
 
   isMatching(source, target) {

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -153,12 +153,7 @@ class GitHubCurationService {
       revisions.push(coordinateObject.revision)
     })
 
-    // MT_TODO: Why do we store closed but not merged PRs ??
-    // If we have to save those PR, change the query to only get open contribution and merged curation
     curations.contributions.forEach(contribution => {
-      if (contribution.pr.closed_at && !contribution.pr.merge_at) {
-        return
-      }
       contribution.files.forEach(file => {
         const fileRevisions = get(file, 'revisions', {}).map(revision => revision.revision)
         revisions = union(revisions, fileRevisions)
@@ -338,11 +333,6 @@ class GitHubCurationService {
     // MT_TODO: somehow my curation PR is open but it's not stored.
     const revisions = this._getRevisionsFromCurations(curationAndContributions)
     return revisions.includes(definition.coordinates.revision)
-  }
-
-  _isLicenseMatching(definition, harvest, targetDefinition, targetHarvest) {
-    return isLicenseMatchingByDefinition(definition, targetDefinition)
-      || isLicenseMatchingByHarvest(harvest, targetHarvest);
   }
 
   async addOrUpdate(userGithub, serviceGithub, info, patch) {
@@ -643,5 +633,5 @@ class GitHubCurationService {
   }
 }
 
-module.exports = (options, store, endpoints, definition, cache, harvestService) =>
-  new GitHubCurationService(options, store, endpoints, definition, cache, harvestService)
+module.exports = (options, store, endpoints, definition, cache, harvestService, licenseMatcher) =>
+  new GitHubCurationService(options, store, endpoints, definition, cache, harvestService, licenseMatcher)

--- a/providers/curation/githubConfig.js
+++ b/providers/curation/githubConfig.js
@@ -9,7 +9,8 @@ function github(options, store, endpoints, cache, harvestStore) {
     owner: config.get('CURATION_GITHUB_OWNER') || 'clearlydefined',
     repo: config.get('CURATION_GITHUB_REPO') || 'curated-data',
     branch: config.get('CURATION_GITHUB_BRANCH') || 'master',
-    token: config.get('CURATION_GITHUB_TOKEN')
+    token: config.get('CURATION_GITHUB_TOKEN'),
+    multiversionCurationFeatureFlag: config.get('MULTIVERSION_CURATION_FF') === 'true'
   }
   return githubService(realOptions, store, endpoints, null, cache, harvestStore)
 }

--- a/providers/curation/githubConfig.js
+++ b/providers/curation/githubConfig.js
@@ -4,14 +4,14 @@
 const config = require('painless-config')
 const githubService = require('./github')
 
-function github(options, store, endpoints, cache) {
+function github(options, store, endpoints, cache, harvestStore) {
   const realOptions = options || {
     owner: config.get('CURATION_GITHUB_OWNER') || 'clearlydefined',
     repo: config.get('CURATION_GITHUB_REPO') || 'curated-data',
     branch: config.get('CURATION_GITHUB_BRANCH') || 'master',
     token: config.get('CURATION_GITHUB_TOKEN')
   }
-  return githubService(realOptions, store, endpoints, null, cache)
+  return githubService(realOptions, store, endpoints, null, cache, harvestStore)
 }
 
 module.exports = github

--- a/providers/harvest/process.js
+++ b/providers/harvest/process.js
@@ -25,7 +25,7 @@ async function processMessage(message) {
   const urn = get(message, 'data._metadata.links.self.href')
   if (!urn) return
   const coordinates = EntityCoordinates.fromUrn(urn)
-  await definitionService.computeAndStore(coordinates)
+  await definitionService.computeStoreAndCurate(coordinates)
   await queue.delete(message)
   logger.info(`Handled Crawler update event for ${urn}`)
 }

--- a/providers/stores/abstractFileStore.js
+++ b/providers/stores/abstractFileStore.js
@@ -13,7 +13,7 @@ class AbstractFileStore {
     this.options = options
   }
 
-  async initialize() {}
+  async initialize() { }
 
   /**
    * Visit all of the files associated with the given coordinates.

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -56,7 +56,7 @@ async function handleCrawlerCall(request, response) {
   if (!urn) return info(request, response, 400, 'Missing or invalid "self" link')
   const coordinates = EntityCoordinates.fromUrn(urn)
   // TODO validate the coordinates are complete
-  await definitionService.computeAndStore(coordinates)
+  await definitionService.computeStoreAndCurate(coordinates)
   logger.info(`Handled Crawler update event for ${urn}`)
   response.status(200).end()
 }

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -348,7 +348,8 @@ function setup(definition, coordinateSpec, curation) {
   const cache = { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() }
   const curator = {
     get: () => Promise.resolve(curation),
-    apply: (coordinates, curationSpec, definition) => Promise.resolve(Curation.apply(definition, curation))
+    apply: (_coordinates, _curationSpec, definition) => Promise.resolve(Curation.apply(definition, curation)),
+    autoCurate: (_coordinates) => { }
   }
   const harvestStore = { getAll: () => Promise.resolve(null) }
   const harvestService = { harvest: () => sinon.stub() }

--- a/test/lib/licenseMatcher.js
+++ b/test/lib/licenseMatcher.js
@@ -80,6 +80,7 @@ describe('licenseMatcher.js', () => {
       )
       expect(result.match).to.have.lengthOf(1).and.deep.include({
         policy: definitionLicenseMatchPolicy.name,
+        file: 'package/LICENSE',
         propPath: 'hashes.sha1',
         value: 'dbf8c7e394791d3de9a9fff305d8ee7b59196f26'
       })
@@ -112,12 +113,12 @@ describe('licenseMatcher.js', () => {
       )
       expect(result.match).to.have.lengthOf(1).and.deep.include({
         policy: definitionLicenseMatchPolicy.name,
+        file: 'foo-1.0.0/LICENSE',
         propPath: 'hashes.sha256',
         value: 'd9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d'
       })
       expect(result.mismatch).to.have.lengthOf(0)
     })
-
 
     it('Should return match array includes the same token', () => {
       const coordinates = { type: 'maven' }
@@ -141,6 +142,7 @@ describe('licenseMatcher.js', () => {
       )
       expect(result.match).to.have.lengthOf(1).and.deep.include({
         policy: definitionLicenseMatchPolicy.name,
+        file: 'meta-inf/LICENSE',
         propPath: 'token',
         value: 'd9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d'
       })
@@ -196,10 +198,53 @@ describe('licenseMatcher.js', () => {
       expect(result.match).to.have.lengthOf(0)
       expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
         policy: definitionLicenseMatchPolicy.name,
+        file: 'license.md',
         propPath: 'hashes.sha1',
         source: 'dbf8c7e394791d3de9a9fff305d8ee7b59196f26',
         target: 'dbf8c7e394791d3de9a9fff305d8ee7b59196f26-Diff'
       })
+    })
+
+    it(`Should return match array when all license file matched`, () => {
+      const coordinates = { type: 'maven' }
+      const sourceDefinition = {
+        "files": [{
+          "path": "meta-inf/LICENSE",
+          "token": "d9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d"
+        },
+        {
+          "path": "LICENSE",
+          "token": "d9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d"
+        }]
+      }
+
+      const targetDefinition = {
+        "files": [{
+          "path": "LICENSE",
+          "token": "d9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d"
+        }, {
+          "path": "meta-inf/LICENSE",
+          "token": "d9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d"
+        }]
+      }
+
+      const result = definitionLicenseMatchPolicy.compare(
+        { definition: { ...sourceDefinition, coordinates } },
+        { definition: { ...targetDefinition, coordinates } }
+      )
+
+      expect(result.match).to.have.lengthOf(2).and.have.deep.members([{
+        policy: definitionLicenseMatchPolicy.name,
+        file: 'meta-inf/LICENSE',
+        propPath: 'token',
+        value: 'd9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d',
+      }, {
+        policy: definitionLicenseMatchPolicy.name,
+        file: 'LICENSE',
+        propPath: 'token',
+        value: 'd9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d'
+      }])
+      expect(result.mismatch).to.have.lengthOf(0)
     })
   })
 

--- a/test/lib/licenseMatcher.js
+++ b/test/lib/licenseMatcher.js
@@ -1,0 +1,530 @@
+const {
+  LicenseMatcher, DefinitionLicenseMatchPolicy, HarvestLicenseMatchPolicy
+} = require('../../lib/licenseMatcher')
+const EntityCoordinates = require('../../lib/entityCoordinates')
+const { expect } = require('chai')
+
+describe('licenseMatcher.js', () => {
+  describe('LicenseMatcher process()', () => {
+    it('Should return NOT match if any policy returns mismatch', () => {
+      const mismatch = { propPath: 'path.to.license.prop', source: 'license1', target: 'license2' }
+      const matcher = new LicenseMatcher([
+        {
+          compare: () => ({ match: [{}], mismatch: [mismatch] }),
+        },
+        {
+          compare: () => ({ match: [{}], mismatch: [] }),
+        }
+      ])
+      const result = matcher.process({}, {})
+      expect(result).to.have.property('isMatching', false)
+      expect(result.mismatch).to.deep.include(mismatch)
+    })
+
+    it('Should return NOT match if all policy returns empty mismatch and empty match', () => {
+      const matcher = new LicenseMatcher([
+        {
+          compare: () => ({ match: [], mismatch: [] }),
+        },
+        {
+          compare: () => ({ match: [], mismatch: [] }),
+        }
+      ])
+      const result = matcher.process({}, {})
+      expect(result.mismatch).to.have.lengthOf(0)
+      expect(result).to.have.property('isMatching', false)
+    })
+
+    it('Should return match when the every policy match', () => {
+      const firstMatch = { policy: '1', propPath: 'path.to.license.prop1', value: 'license1' }
+      const secondMatch = { policy: '2', propPath: 'path.to.license.prop2', value: 'license2' }
+      const matcher = new LicenseMatcher([
+        {
+          compare: () => ({ match: [firstMatch], mismatch: [] }),
+        },
+        {
+          compare: () => ({ match: [secondMatch], mismatch: [] }),
+        }
+      ])
+      const result = matcher.process({}, {})
+      expect(result).to.have.property('isMatching', true)
+      expect(result.match).to.have.lengthOf(2).and.to.have.deep.members([firstMatch, secondMatch])
+    })
+  })
+
+  describe('DefinitionLicenseMatchPolicy compare()', () => {
+    const definitionLicenseMatchPolicy = new DefinitionLicenseMatchPolicy()
+    it('Should return match array includes the same hashes.sha1', () => {
+      const coordinates = { type: 'npm' }
+      const sourceDefinition = {
+        "files": [{
+          "path": "package/LICENSE",
+          "hashes": {
+            "sha1": "dbf8c7e394791d3de9a9fff305d8ee7b59196f26",
+          }
+        }]
+      }
+
+      const targetDefinition = {
+        "files": [{
+          "path": "package/LICENSE",
+          "hashes": {
+            "sha1": "dbf8c7e394791d3de9a9fff305d8ee7b59196f26",
+          }
+        }]
+      }
+
+      const result = definitionLicenseMatchPolicy.compare(
+        { definition: { ...sourceDefinition, coordinates } },
+        { definition: { ...targetDefinition, coordinates } }
+      )
+      expect(result.match).to.have.lengthOf(1).and.deep.include({
+        policy: definitionLicenseMatchPolicy.name,
+        propPath: 'hashes.sha1',
+        value: 'dbf8c7e394791d3de9a9fff305d8ee7b59196f26'
+      })
+      expect(result.mismatch).to.have.lengthOf(0)
+    })
+
+    it('Should return match array includes the same hashes.sha256', () => {
+      const coordinates = { type: 'pypi', name: 'foo', revision: '1.0.0' }
+      const sourceDefinition = {
+        "files": [{
+          "path": "foo-1.0.0/LICENSE",
+          "hashes": {
+            "sha256": "d9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d",
+          }
+        }]
+      }
+
+      const targetDefinition = {
+        "files": [{
+          "path": "foo-1.0.0/LICENSE",
+          "hashes": {
+            "sha256": "d9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d",
+          }
+        }]
+      }
+
+      const result = definitionLicenseMatchPolicy.compare(
+        { definition: { ...sourceDefinition, coordinates } },
+        { definition: { ...targetDefinition, coordinates } }
+      )
+      expect(result.match).to.have.lengthOf(1).and.deep.include({
+        policy: definitionLicenseMatchPolicy.name,
+        propPath: 'hashes.sha256',
+        value: 'd9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d'
+      })
+      expect(result.mismatch).to.have.lengthOf(0)
+    })
+
+
+    it('Should return match array includes the same token', () => {
+      const coordinates = { type: 'maven' }
+      const sourceDefinition = {
+        "files": [{
+          "path": "meta-inf/LICENSE",
+          "token": "d9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d"
+        }]
+      }
+
+      const targetDefinition = {
+        "files": [{
+          "path": "meta-inf/LICENSE",
+          "token": "d9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d"
+        }]
+      }
+
+      const result = definitionLicenseMatchPolicy.compare(
+        { definition: { ...sourceDefinition, coordinates } },
+        { definition: { ...targetDefinition, coordinates } }
+      )
+      expect(result.match).to.have.lengthOf(1).and.deep.include({
+        policy: definitionLicenseMatchPolicy.name,
+        propPath: 'token',
+        value: 'd9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d'
+      })
+      expect(result.mismatch).to.have.lengthOf(0)
+    })
+
+    it('Should return empty match and mismatch array when no license files found', () => {
+      const sourceDefinition = {
+        "path": "NOT-A-License-File",
+        "files": [{
+          "token": "d9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d"
+        }]
+      }
+
+      const targetDefinition = {
+        "path": "NOT-A-License-File",
+        "files": [{
+          "token": "d9fccda7d1daaec4c1a84d46b48d808e56ee8979c1b62ccc1492b7c27ab7010d"
+        }]
+      }
+
+      const result = definitionLicenseMatchPolicy.compare(
+        { definition: sourceDefinition },
+        { definition: targetDefinition }
+      )
+      expect(result.match).to.have.lengthOf(0)
+      expect(result.mismatch).to.have.lengthOf(0)
+    })
+
+    it(`Should return mismatch array when file license hashes.sha1 are different`, () => {
+      const sourceDefinition = {
+        "files": [{
+          "path": "license.md",
+          "hashes": {
+            "sha1": "dbf8c7e394791d3de9a9fff305d8ee7b59196f26",
+          }
+        }]
+      }
+
+      const targetDefinition = {
+        "files": [{
+          "path": "license.md",
+          "hashes": {
+            "sha1": "dbf8c7e394791d3de9a9fff305d8ee7b59196f26-Diff",
+          }
+        }]
+      }
+
+      const result = definitionLicenseMatchPolicy.compare(
+        { definition: sourceDefinition },
+        { definition: targetDefinition }
+      )
+      expect(result.match).to.have.lengthOf(0)
+      expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
+        policy: definitionLicenseMatchPolicy.name,
+        propPath: 'hashes.sha1',
+        source: 'dbf8c7e394791d3de9a9fff305d8ee7b59196f26',
+        target: 'dbf8c7e394791d3de9a9fff305d8ee7b59196f26-Diff'
+      })
+    })
+  })
+
+  // Even though some matching props are the same for different package type.
+  // However, the value of the props are various. Therefore, it's better to test based on type
+  describe('HarvestLicenseMatchPolicy compare()', () => {
+    const harvestLicenseMatchPolicy = new HarvestLicenseMatchPolicy();
+    describe('Match maven package', () => {
+      const sourceLicenses = [
+        {
+          "license": [
+            {
+              "name": [
+                "The Apache License, Version 2.0"
+              ],
+              "url": [
+                "http://www.apache.org/licenses/LICENSE-2.0.txt"
+              ]
+            }
+          ]
+        }
+      ]
+      function generateMavenDefinitionAndHarvest(revision, licenses) {
+        return {
+          definition: {
+            coordinates: EntityCoordinates.fromString(`maven/mavencentral/io.opentelemetry/opentelemetry-sdk-common/${revision}`)
+          },
+          harvest: {
+            "clearlydefined": {
+              "1.5.0": {
+                "manifest": {
+                  "summary": {
+                    "licenses": licenses
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      it('Should return match array includes harvest manifest.summary.licenses when they are deep equal', () => {
+        const source = generateMavenDefinitionAndHarvest('1.0.0', sourceLicenses)
+        const target = generateMavenDefinitionAndHarvest('2.0.0', sourceLicenses)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(1).and.deep.include({
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'manifest.summary.licenses',
+          value: sourceLicenses
+        })
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
+
+      it('Should return mismatch array includes harvest manifest.summary.licenses when they are NOT deep equal', () => {
+        const targetLicenses = [
+          {
+            "license": [
+              {
+                "name": [
+                  "MIT"
+                ],
+                "url": [
+                  "https://opensource.org/licenses/MIT"
+                ]
+              }
+            ]
+          }
+        ]
+        const source = generateMavenDefinitionAndHarvest('1.0.0', sourceLicenses)
+        const target = generateMavenDefinitionAndHarvest('2.0.0', targetLicenses)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(0)
+        expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'manifest.summary.licenses',
+          source: sourceLicenses,
+          target: targetLicenses
+        })
+      })
+
+      it('Should return empty match and mismatch array when harvest manifest.summary.licenses are both undefined/null', () => {
+        const source = generateMavenDefinitionAndHarvest('1.0.0')
+        const target = generateMavenDefinitionAndHarvest('2.0.0')
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(0)
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
+    })
+
+    describe('Match crate package', () => {
+      const sourceLicense = 'MIT OR Apache-2.0'
+
+      function generateCrateDefinitionAndHarvest(revision, license) {
+        return {
+          definition: {
+            coordinates: EntityCoordinates.fromString(`crate/cratesio/-/libc/${revision}`)
+          },
+          harvest: {
+            "clearlydefined": {
+              "1.2.0": {
+                "registryData": {
+                  "license": license
+                }
+              }
+            }
+          }
+        }
+      }
+
+      it('Should return match array includes harvest registryData.license when they are deep equal', () => {
+        const source = generateCrateDefinitionAndHarvest('0.2.86', sourceLicense)
+        const target = generateCrateDefinitionAndHarvest('0.2.49', sourceLicense)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+
+        expect(result.match).to.have.lengthOf(1).and.deep.include({
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'registryData.license',
+          value: sourceLicense
+        })
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
+
+      it('Should return mismatch array includes harvest registryData.license when they are NOT deep equal', () => {
+        const targetLicense = 'MIT AND Apache-2.0'
+        const source = generateCrateDefinitionAndHarvest('0.2.86', sourceLicense)
+        const target = generateCrateDefinitionAndHarvest('0.2.49', targetLicense)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+
+        expect(result.match).to.have.lengthOf(0)
+        expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'registryData.license',
+          source: sourceLicense,
+          target: targetLicense
+        })
+      })
+
+      it('Should return empty match and mismatch array when harvest manifest.summary.licenses are both undefined/null', () => {
+        const source = generateCrateDefinitionAndHarvest('0.2.86')
+        const target = generateCrateDefinitionAndHarvest('0.2.49')
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(0)
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
+    })
+
+    describe('Match nuget package', () => {
+      const sourceLicense = 'MIT'
+      const sourceLicenseUrl = 'https://licenses.nuget.org/MIT'
+      function generateNugetDefinitionAndHarvest(revision, license, licenseUrl) {
+        return {
+          definition: {
+            coordinates: EntityCoordinates.fromString(`nuget/nuget/-/Microsoft.Identity.Web.MicrosoftGraph/${revision}`)
+          },
+          harvest: {
+            "clearlydefined": {
+              "1.4.2": {
+                "manifest": {
+                  "licenseUrl": `${licenseUrl}`,
+                  "licenseExpression": `${license}`
+                }
+              }
+            }
+          }
+        }
+      }
+
+      it('Should return match array includes both harvest manifest.licenseExpression and manifest.licenseUrl when both are the same', () => {
+        const source = generateNugetDefinitionAndHarvest('1.4.0', sourceLicense, sourceLicenseUrl)
+        const target = generateNugetDefinitionAndHarvest('1.4.6', sourceLicense, sourceLicenseUrl)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(2).and.have.deep.members([{
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'manifest.licenseExpression',
+          value: sourceLicense
+        }, {
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'manifest.licenseUrl',
+          value: sourceLicenseUrl
+        }])
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
+
+      it('Should NOT match when harvest manifest.licenseExpression are NOT deep equal', () => {
+        const targetLicense = 'Apache-2.0'
+        const source = generateNugetDefinitionAndHarvest('1.4.0', sourceLicense)
+        const target = generateNugetDefinitionAndHarvest('1.4.6', targetLicense)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.mismatch).to.have.lengthOf(1).and.have.deep.members([{
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'manifest.licenseExpression',
+          source: sourceLicense,
+          target: targetLicense
+        }])
+      })
+
+      it('Should NOT match when harvest manifest.licenseUrl are NOT deep equal', () => {
+
+        const targetLicenseUrl = 'https://licenses.nuget.org/Apache-2.0'
+        const source = generateNugetDefinitionAndHarvest('1.4.0', undefined, sourceLicenseUrl)
+        const target = generateNugetDefinitionAndHarvest('1.4.6', undefined, targetLicenseUrl)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.mismatch).to.have.lengthOf(1).and.have.deep.members([{
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'manifest.licenseUrl',
+          source: sourceLicenseUrl,
+          target: targetLicenseUrl
+        }])
+      })
+    })
+
+    describe('Match npm package', () => {
+      const sourceLicense = 'MIT'
+      function generateNpmDefinitionAndHarvest(revision, license) {
+        return {
+          definition: {
+            coordinates: EntityCoordinates.fromString(`npm/npmjs/-/mongoose/${revision}`)
+          },
+          harvest: {
+            "clearlydefined": {
+              "1.1.2": {
+                "registryData": {
+                  "manifest": {
+                    "license": license
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      it('Should return match array includes harvest registryData.manifest.license when they are deep equal', () => {
+        const source = generateNpmDefinitionAndHarvest('5.2.5', sourceLicense)
+        const target = generateNpmDefinitionAndHarvest('4.2.7', sourceLicense)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(1).and.deep.include({
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'registryData.manifest.license',
+          value: sourceLicense
+        })
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
+
+      it('Should return mismatch array includes harvest registryData.manifest.license when they are NOT deep equal', () => {
+        const targetLicense = "Apache-2.0"
+        const source = generateNpmDefinitionAndHarvest('5.2.5', sourceLicense)
+        const target = generateNpmDefinitionAndHarvest('4.2.7', targetLicense)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(0)
+        expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'registryData.manifest.license',
+          source: sourceLicense,
+          target: targetLicense
+        })
+      })
+
+      it('Should return empty match and mismatch array when harvest manifest.manifest.license are both undefined/null', () => {
+        const source = generateNpmDefinitionAndHarvest('5.2.5')
+        const target = generateNpmDefinitionAndHarvest('4.2.7')
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(0)
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
+    })
+
+    describe('Match composer package', () => {
+      const sourceLicenses = [
+        "GPL-2.0+"
+      ]
+      function generateComposerDefinitionAndHarvest(revision, licenses) {
+        return {
+          definition: {
+            coordinates: EntityCoordinates.fromString(`composer/packagist/codeinwp/themeisle-sdk/$${revision}`)
+          },
+          harvest: {
+            "clearlydefined": {
+              "1.2.0": {
+                "registryData": {
+                  "manifest": {
+                    "license": licenses
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      it('Should match when harvest registryData.manifest.license are deep equal', () => {
+        const source = generateComposerDefinitionAndHarvest('3.2.9', sourceLicenses)
+        const target = generateComposerDefinitionAndHarvest('3.1.9', sourceLicenses)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(1).and.deep.include({
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'registryData.manifest.license',
+          value: sourceLicenses
+        })
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
+
+      it('Should NOT match when harvest registryData.manifest.license are NOT deep equal', () => {
+        const targetLicenses = [
+          "GPL-2.0"
+        ]
+        const source = generateComposerDefinitionAndHarvest('3.2.9', sourceLicenses)
+        const target = generateComposerDefinitionAndHarvest('3.1.9', targetLicenses)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(0)
+        expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
+          policy: harvestLicenseMatchPolicy.name,
+          propPath: 'registryData.manifest.license',
+          source: sourceLicenses,
+          target: targetLicenses
+        })
+      })
+
+      it('Should return empty match and mismatch array when harvest registryData.manifest.licenses are both undefined/null', () => {
+        const source = generateComposerDefinitionAndHarvest('3.2.9')
+        const target = generateComposerDefinitionAndHarvest('3.1.9')
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(0)
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
+    })
+  })
+})

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -177,6 +177,7 @@ describe('Github Curation Service', () => {
     sinon.stub(gitHubService, '_writePatch').callsFake(() => Promise.resolve())
 
     const contributionPatch = {
+      skipmvc: true,
       contributionInfo: {
         summary: 'test',
         details: 'test',

--- a/test/providers/harvest/processTest.js
+++ b/test/providers/harvest/processTest.js
@@ -13,8 +13,8 @@ describe('Harvest queue processing', () => {
     })
     await process(queue, definitionService, logger, true)
 
-    expect(definitionService.computeAndStore.calledOnce).to.be.true
-    expect(definitionService.computeAndStore.getCall(0).args[0]).to.deep.eq({
+    expect(definitionService.computeStoreAndCurate.calledOnce).to.be.true
+    expect(definitionService.computeStoreAndCurate.getCall(0).args[0]).to.deep.eq({
       type: 'gem',
       provider: 'rubygems',
       name: '0mq',
@@ -31,7 +31,7 @@ describe('Harvest queue processing', () => {
     const { queue, definitionService, logger } = setup({ junk: 'here' })
     await process(queue, definitionService, logger, true)
 
-    expect(definitionService.computeAndStore.calledOnce).to.be.false
+    expect(definitionService.computeStoreAndCurate.calledOnce).to.be.false
     expect(logger.info.calledOnce).to.be.false
     expect(queue.data.length).to.eq(1)
   })
@@ -41,7 +41,7 @@ function setup(data) {
   const queue = memoryQueue()
   queue.queue(JSON.stringify(data))
   const definitionService = {
-    computeAndStore: sinon.stub().returns({})
+    computeStoreAndCurate: sinon.stub().returns({})
   }
   const logger = {
     info: sinon.stub(),

--- a/test/routes/webhookCrawlerTests.js
+++ b/test/routes/webhookCrawlerTests.js
@@ -15,8 +15,8 @@ describe('Webhook Route for Crawler calls', () => {
     const router = webhookRoutes(null, service, logger, 'secret', 'secret', true)
     router._handlePost(request, response)
     expect(response.statusCode).to.be.eq(200)
-    expect(service.computeAndStore.calledOnce).to.be.true
-    expect(service.computeAndStore.getCall(0).args[0].name).to.be.eq('test')
+    expect(service.computeStoreAndCurate.calledOnce).to.be.true
+    expect(service.computeStoreAndCurate.getCall(0).args[0].name).to.be.eq('test')
   })
 
   it('handles missing self', () => {
@@ -27,7 +27,7 @@ describe('Webhook Route for Crawler calls', () => {
     const router = webhookRoutes(null, service, logger, 'secret', 'secret', true)
     router._handlePost(request, response)
     expect(response.statusCode).to.be.eq(400)
-    expect(service.computeAndStore.calledOnce).to.be.false
+    expect(service.computeStoreAndCurate.calledOnce).to.be.false
     expect(logger.info.calledOnce).to.be.true
     expect(logger.info.args[0][0].startsWith('Fatal')).to.be.true
   })
@@ -40,7 +40,7 @@ describe('Webhook Route for Crawler calls', () => {
     const router = webhookRoutes(null, service, logger, 'secret', 'different', true)
     router._handlePost(request, response)
     expect(response.statusCode).to.be.eq(400)
-    expect(service.computeAndStore.calledOnce).to.be.false
+    expect(service.computeStoreAndCurate.calledOnce).to.be.false
     expect(logger.info.calledOnce).to.be.true
     expect(logger.info.args[0][0].startsWith('Fatal')).to.be.true
   })
@@ -52,7 +52,7 @@ function createLogger() {
 
 function createDefinitionService() {
   return {
-    computeAndStore: sinon.stub()
+    computeStoreAndCurate: sinon.stub()
   }
 }
 


### PR DESCRIPTION
Example PRs: 
- [Matching versions on both license file and metadata](https://github.com/clearlydefined/curated-data-dev/pull/1083)
- [Matching versions on multiple metadata](https://github.com/clearlydefined/curated-data-dev/pull/1084)