### PR TITLE
Bug: duplicate auto curations have been created.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -260,6 +260,23 @@ function _normalizeVersion(version) {
   return semver.valid(version) ? version : null
 }
 
+function parseUrn(urn) {
+  if (!urn) return {}
+  const [scheme, type, provider, namespace, name, revToken, revision, toolToken, tool, toolRevision] = urn.split(':')
+  return {
+    scheme,
+    type,
+    provider,
+    namespace,
+    name,
+    revToken,
+    revision,
+    toolToken,
+    tool,
+    toolRevision
+  }
+}
+
 const _licenseFileNames = [
   'license',
   'license.txt',
@@ -404,5 +421,6 @@ module.exports = {
   updateSourceLocation,
   isLicenseFile,
   simplifyAttributions,
-  isDeclaredLicense
+  isDeclaredLicense,
+  parseUrn
 }

--- a/providers/harvest/process.js
+++ b/providers/harvest/process.js
@@ -3,6 +3,7 @@
 
 const { get } = require('lodash')
 const EntityCoordinates = require('../../lib/entityCoordinates')
+const { parseUrn } = require('../../lib/utils')
 
 async function work(once) {
   let isQueueEmpty = true
@@ -25,7 +26,12 @@ async function processMessage(message) {
   const urn = get(message, 'data._metadata.links.self.href')
   if (!urn) return
   const coordinates = EntityCoordinates.fromUrn(urn)
-  await definitionService.computeStoreAndCurate(coordinates)
+  const { tool } = parseUrn(urn)
+  if (tool === 'clearlydefined') {
+    await definitionService.computeStoreAndCurate(coordinates)
+  } else {
+    await definitionService.computeAndStore(coordinates)
+  }
   await queue.delete(message)
   logger.info(`Handled Crawler update event for ${urn}`)
 }

--- a/test/providers/harvest/processTest.js
+++ b/test/providers/harvest/processTest.js
@@ -7,7 +7,7 @@ const memoryQueue = require('../../../providers/queueing/memoryQueue')
 const sinon = require('sinon')
 
 describe('Harvest queue processing', () => {
-  it('handles new message', async () => {
+  it('handles new message from clearlydefined tool', async () => {
     const { queue, definitionService, logger } = setup({
       _metadata: { links: { self: { href: 'urn:gem:rubygems:-:0mq:revision:0.5.2:tool:clearlydefined:1.3.3' } } }
     })
@@ -27,6 +27,26 @@ describe('Harvest queue processing', () => {
     expect(queue.data.length).to.eq(0)
   })
 
+  it('handles new message from non-clearlydefined tool', async () => {
+    const { queue, definitionService, logger } = setup({
+      _metadata: { links: { self: { href: 'urn:pypi:pypi:-:backports.ssl_match_hostname:revision:3.2a3:tool:scancode:3.2.2' } } }
+    })
+    await process(queue, definitionService, logger, true)
+
+    expect(definitionService.computeAndStore.calledOnce).to.be.true
+    expect(definitionService.computeAndStore.getCall(0).args[0]).to.deep.eq({
+      type: 'pypi',
+      provider: 'pypi',
+      name: 'backports.ssl_match_hostname',
+      revision: '3.2a3'
+    })
+    expect(logger.info.calledOnce).to.be.true
+    expect(logger.info.getCall(0).args[0]).to.eq(
+      'Handled Crawler update event for urn:pypi:pypi:-:backports.ssl_match_hostname:revision:3.2a3:tool:scancode:3.2.2'
+    )
+    expect(queue.data.length).to.eq(0)
+  })
+
   it('handles bogus message', async () => {
     const { queue, definitionService, logger } = setup({ junk: 'here' })
     await process(queue, definitionService, logger, true)
@@ -41,7 +61,8 @@ function setup(data) {
   const queue = memoryQueue()
   queue.queue(JSON.stringify(data))
   const definitionService = {
-    computeStoreAndCurate: sinon.stub().returns({})
+    computeStoreAndCurate: sinon.stub().resolves({}),
+    computeAndStore: sinon.stub().resolves({})
   }
   const logger = {
     info: sinon.stub(),


### PR DESCRIPTION
After creating a curation PR in GitHub, service doesn't save curation data into mongo immediately.
Instead, it saves curation to mongo when GitHub webhook sent PR events. Because of this latency, the auto
curation code may create multiple PRs since harvest events trigger it.

To solve the issue, only run auto curation code for clearlydefined harvest tool event.