### PR TITLE
Skip Nuget licenseUrl if it's from the GitHub

### DIFF
--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -99,8 +99,46 @@ class DefinitionLicenseMatchPolicy {
 }
 
 class HarvestLicenseMatchPolicy {
-  constructor() {
-    this.name = 'harvest'
+
+  compare(source, target) {
+    const type = source.definition.coordinates.type
+    const strategy = this._getStrategy(type)
+    return strategy.compare(source, target)
+  }
+
+  _getStrategy(type) {
+    switch (type) {
+      case 'maven':
+        return new BaseHarvestLicenseMatchStrategy('maven', ['manifest.summary.licenses'])
+      case 'crate':
+        return new BaseHarvestLicenseMatchStrategy('crate', ['registryData.license'])
+      case 'pod':
+        return new BaseHarvestLicenseMatchStrategy('pod', ['registryData.license'])
+      case 'nuget':
+        return new NugetHarvestLicenseMatchStrategy()
+      case 'npm':
+        return new BaseHarvestLicenseMatchStrategy('npm', ['registryData.manifest.license'])
+      case 'composer':
+        return new BaseHarvestLicenseMatchStrategy('composer', ['registryData.manifest.license'])
+      case 'gem':
+        return new BaseHarvestLicenseMatchStrategy('gem', ['registryData.licenses'])
+      case 'pypi':
+        return new BaseHarvestLicenseMatchStrategy('pypi', ['declaredLicense', 'registryData.info.license'])
+      case 'deb':
+        return new BaseHarvestLicenseMatchStrategy('deb', ['declaredLicenses'])
+      case 'debsrc':
+        return new BaseHarvestLicenseMatchStrategy('debsrc', ['declaredLicenses'])
+      default:
+        return new BaseHarvestLicenseMatchStrategy('default')
+    }
+  }
+}
+
+class BaseHarvestLicenseMatchStrategy {
+  constructor(type, propPaths = []) {
+    this.name = `harvest`
+    this.type = type
+    this.propPaths = propPaths
   }
 
   compare(source, target) {
@@ -110,8 +148,7 @@ class HarvestLicenseMatchPolicy {
       match: [],
       mismatch: []
     }
-    const propPaths = this._getComparePropPaths(source)
-    for (const propPath of propPaths) {
+    for (const propPath of this.propPaths) {
       const sourceLicense = get(sourceLatestClearlyDefinedToolHarvest, propPath)
       const targetLicense = get(targetLatestClearlyDefinedToolHarvest, propPath)
       if (!sourceLicense && !targetLicense) {
@@ -134,30 +171,24 @@ class HarvestLicenseMatchPolicy {
     }
     return result
   }
+}
 
-  _getComparePropPaths(source) {
-    const type = source.definition.coordinates.type
-    switch (type) {
-      case 'maven':
-        return ['manifest.summary.licenses']
-      case 'crate':
-      case 'pod':
-        return ['registryData.license']
-      case 'nuget':
-        return ['manifest.licenseExpression', 'manifest.licenseUrl']
-      case 'npm':
-      case 'composer':
-        return ['registryData.manifest.license']
-      case 'gem':
-        return ['registryData.licenses']
-      case 'pypi':
-        return ['declaredLicense', 'registryData.info.license']
-      case 'deb':
-      case 'debsrc':
-        return ['declaredLicenses']
-      default:
-        return []
-    }
+class NugetHarvestLicenseMatchStrategy extends BaseHarvestLicenseMatchStrategy {
+  constructor() {
+    super('nuget', ['manifest.licenseExpression', 'manifest.licenseUrl'])
+  }
+
+  compare(source, target) {
+    const result = super.compare(source, target)
+    // For Nuget component, if the licenseUrl point to github,
+    // the content of the license url is tend to change even the url keeps the same
+    result.match = result.match.filter(m => {
+      if (m.value && m.value.toLowerCase().includes('github.com')) {
+        return false
+      }
+      return true
+    })
+    return result
   }
 }
 

--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -136,7 +136,7 @@ class HarvestLicenseMatchPolicy {
 
 class BaseHarvestLicenseMatchStrategy {
   constructor(type, propPaths = []) {
-    this.name = `harvest`
+    this.name = 'harvest'
     this.type = type
     this.propPaths = propPaths
   }

--- a/test/lib/licenseMatcher.js
+++ b/test/lib/licenseMatcher.js
@@ -292,7 +292,7 @@ describe('licenseMatcher.js', () => {
         const target = generateMavenDefinitionAndHarvest('2.0.0', sourceLicenses)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'manifest.summary.licenses',
           value: sourceLicenses
         })
@@ -319,7 +319,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'manifest.summary.licenses',
           source: sourceLicenses,
           target: targetLicenses
@@ -361,7 +361,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
 
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'registryData.license',
           value: sourceLicense
         })
@@ -376,7 +376,7 @@ describe('licenseMatcher.js', () => {
 
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'registryData.license',
           source: sourceLicense,
           target: targetLicense
@@ -418,11 +418,11 @@ describe('licenseMatcher.js', () => {
         const target = generateNugetDefinitionAndHarvest('1.4.6', sourceLicense, sourceLicenseUrl)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(2).and.have.deep.members([{
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'manifest.licenseExpression',
           value: sourceLicense
         }, {
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'manifest.licenseUrl',
           value: sourceLicenseUrl
         }])
@@ -435,7 +435,7 @@ describe('licenseMatcher.js', () => {
         const target = generateNugetDefinitionAndHarvest('1.4.6', targetLicense)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.mismatch).to.have.lengthOf(1).and.have.deep.members([{
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'manifest.licenseExpression',
           source: sourceLicense,
           target: targetLicense
@@ -448,7 +448,7 @@ describe('licenseMatcher.js', () => {
         const target = generateNugetDefinitionAndHarvest('1.4.6', undefined, targetLicenseUrl)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.mismatch).to.have.lengthOf(1).and.have.deep.members([{
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'manifest.licenseUrl',
           source: sourceLicenseUrl,
           target: targetLicenseUrl
@@ -458,6 +458,15 @@ describe('licenseMatcher.js', () => {
       it('Should return empty match and mismatch array when harvest manifest.licenseExpression and manifest.licenseUrl are both undefined/null', () => {
         const source = generateNugetDefinitionAndHarvest('0.2.86')
         const target = generateNugetDefinitionAndHarvest('0.2.49')
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(0)
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
+
+      it('Should return empty match and mismatch when manifest.licenseExpression is empty and manifest.licenseUrl including github.com', () => {
+        const githubLicenseUrl = `https://github.com/Sustainsys/Saml2/blob/master/LICENSE`
+        const source = generateNugetDefinitionAndHarvest('1.4.0', undefined, githubLicenseUrl)
+        const target = generateNugetDefinitionAndHarvest('1.4.6', undefined, githubLicenseUrl)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(0)
@@ -490,7 +499,7 @@ describe('licenseMatcher.js', () => {
         const target = generateNpmDefinitionAndHarvest('4.2.7', sourceLicense)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'registryData.manifest.license',
           value: sourceLicense
         })
@@ -504,7 +513,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'registryData.manifest.license',
           source: sourceLicense,
           target: targetLicense
@@ -548,7 +557,7 @@ describe('licenseMatcher.js', () => {
         const target = generateComposerDefinitionAndHarvest('3.1.9', sourceLicenses)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'registryData.manifest.license',
           value: sourceLicenses
         })
@@ -564,7 +573,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'registryData.manifest.license',
           source: sourceLicenses,
           target: targetLicenses
@@ -606,7 +615,7 @@ describe('licenseMatcher.js', () => {
         const target = generateGemDefinitionAndHarvest('0.1.1', sourceLicenses)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'registryData.licenses',
           value: sourceLicenses
         })
@@ -622,7 +631,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'registryData.licenses',
           source: sourceLicenses,
           target: targetLicenses
@@ -666,11 +675,11 @@ describe('licenseMatcher.js', () => {
         const target = generatePypiDefinitionAndHarvest('1.25.3', sourceLicenseInfo, sourceDeclaredLicense)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(2).and.have.deep.members([{
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'registryData.info.license',
           value: sourceLicenseInfo
         }, {
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'declaredLicense',
           value: sourceDeclaredLicense
         }])
@@ -683,7 +692,7 @@ describe('licenseMatcher.js', () => {
         const target = generatePypiDefinitionAndHarvest('1.25.3', undefined, targetDeclaredLicense)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.mismatch).to.have.lengthOf(1).and.have.deep.members([{
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'declaredLicense',
           source: sourceDeclaredLicense,
           target: targetDeclaredLicense
@@ -696,7 +705,7 @@ describe('licenseMatcher.js', () => {
         const target = generatePypiDefinitionAndHarvest('1.25.3', targetLicenseInfo)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.mismatch).to.have.lengthOf(1).and.have.deep.members([{
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'registryData.info.license',
           source: sourceLicenseInfo,
           target: targetLicenseInfo
@@ -741,7 +750,7 @@ describe('licenseMatcher.js', () => {
         const target = generateDebDefinitionAndHarvest('8.7.0-4_i386', sourceLicenses)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'declaredLicenses',
           value: sourceLicenses
         })
@@ -761,7 +770,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'declaredLicenses',
           source: sourceLicenses,
           target: targetLicenses
@@ -805,7 +814,7 @@ describe('licenseMatcher.js', () => {
         const target = generateDebDefinitionAndHarvest('2019.10-2', sourceLicenses)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'declaredLicenses',
           value: sourceLicenses
         })
@@ -824,7 +833,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: harvestLicenseMatchPolicy.name,
+          policy: `harvest`,
           propPath: 'declaredLicenses',
           source: sourceLicenses,
           target: targetLicenses

--- a/test/lib/licenseMatcher.js
+++ b/test/lib/licenseMatcher.js
@@ -292,7 +292,7 @@ describe('licenseMatcher.js', () => {
         const target = generateMavenDefinitionAndHarvest('2.0.0', sourceLicenses)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'manifest.summary.licenses',
           value: sourceLicenses
         })
@@ -319,7 +319,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'manifest.summary.licenses',
           source: sourceLicenses,
           target: targetLicenses
@@ -361,7 +361,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
 
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'registryData.license',
           value: sourceLicense
         })
@@ -376,7 +376,7 @@ describe('licenseMatcher.js', () => {
 
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'registryData.license',
           source: sourceLicense,
           target: targetLicense
@@ -418,11 +418,11 @@ describe('licenseMatcher.js', () => {
         const target = generateNugetDefinitionAndHarvest('1.4.6', sourceLicense, sourceLicenseUrl)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(2).and.have.deep.members([{
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'manifest.licenseExpression',
           value: sourceLicense
         }, {
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'manifest.licenseUrl',
           value: sourceLicenseUrl
         }])
@@ -435,7 +435,7 @@ describe('licenseMatcher.js', () => {
         const target = generateNugetDefinitionAndHarvest('1.4.6', targetLicense)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.mismatch).to.have.lengthOf(1).and.have.deep.members([{
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'manifest.licenseExpression',
           source: sourceLicense,
           target: targetLicense
@@ -448,7 +448,7 @@ describe('licenseMatcher.js', () => {
         const target = generateNugetDefinitionAndHarvest('1.4.6', undefined, targetLicenseUrl)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.mismatch).to.have.lengthOf(1).and.have.deep.members([{
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'manifest.licenseUrl',
           source: sourceLicenseUrl,
           target: targetLicenseUrl
@@ -464,7 +464,7 @@ describe('licenseMatcher.js', () => {
       })
 
       it('Should return empty match and mismatch when manifest.licenseExpression is empty and manifest.licenseUrl including github.com', () => {
-        const githubLicenseUrl = `https://github.com/Sustainsys/Saml2/blob/master/LICENSE`
+        const githubLicenseUrl = 'https://github.com/Sustainsys/Saml2/blob/master/LICENSE'
         const source = generateNugetDefinitionAndHarvest('1.4.0', undefined, githubLicenseUrl)
         const target = generateNugetDefinitionAndHarvest('1.4.6', undefined, githubLicenseUrl)
         const result = harvestLicenseMatchPolicy.compare(source, target)
@@ -499,7 +499,7 @@ describe('licenseMatcher.js', () => {
         const target = generateNpmDefinitionAndHarvest('4.2.7', sourceLicense)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'registryData.manifest.license',
           value: sourceLicense
         })
@@ -513,7 +513,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'registryData.manifest.license',
           source: sourceLicense,
           target: targetLicense
@@ -557,7 +557,7 @@ describe('licenseMatcher.js', () => {
         const target = generateComposerDefinitionAndHarvest('3.1.9', sourceLicenses)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'registryData.manifest.license',
           value: sourceLicenses
         })
@@ -573,7 +573,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'registryData.manifest.license',
           source: sourceLicenses,
           target: targetLicenses
@@ -615,7 +615,7 @@ describe('licenseMatcher.js', () => {
         const target = generateGemDefinitionAndHarvest('0.1.1', sourceLicenses)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'registryData.licenses',
           value: sourceLicenses
         })
@@ -631,7 +631,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'registryData.licenses',
           source: sourceLicenses,
           target: targetLicenses
@@ -675,11 +675,11 @@ describe('licenseMatcher.js', () => {
         const target = generatePypiDefinitionAndHarvest('1.25.3', sourceLicenseInfo, sourceDeclaredLicense)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(2).and.have.deep.members([{
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'registryData.info.license',
           value: sourceLicenseInfo
         }, {
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'declaredLicense',
           value: sourceDeclaredLicense
         }])
@@ -692,7 +692,7 @@ describe('licenseMatcher.js', () => {
         const target = generatePypiDefinitionAndHarvest('1.25.3', undefined, targetDeclaredLicense)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.mismatch).to.have.lengthOf(1).and.have.deep.members([{
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'declaredLicense',
           source: sourceDeclaredLicense,
           target: targetDeclaredLicense
@@ -705,7 +705,7 @@ describe('licenseMatcher.js', () => {
         const target = generatePypiDefinitionAndHarvest('1.25.3', targetLicenseInfo)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.mismatch).to.have.lengthOf(1).and.have.deep.members([{
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'registryData.info.license',
           source: sourceLicenseInfo,
           target: targetLicenseInfo
@@ -750,7 +750,7 @@ describe('licenseMatcher.js', () => {
         const target = generateDebDefinitionAndHarvest('8.7.0-4_i386', sourceLicenses)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'declaredLicenses',
           value: sourceLicenses
         })
@@ -770,7 +770,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'declaredLicenses',
           source: sourceLicenses,
           target: targetLicenses
@@ -814,7 +814,7 @@ describe('licenseMatcher.js', () => {
         const target = generateDebDefinitionAndHarvest('2019.10-2', sourceLicenses)
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'declaredLicenses',
           value: sourceLicenses
         })
@@ -833,7 +833,7 @@ describe('licenseMatcher.js', () => {
         const result = harvestLicenseMatchPolicy.compare(source, target)
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(1).and.deep.include({
-          policy: `harvest`,
+          policy: 'harvest',
           propPath: 'declaredLicenses',
           source: sourceLicenses,
           target: targetLicenses


### PR DESCRIPTION
For Nuget component, the matching logic will produce a false positive. 

[Here](https://github.com/clearlydefined/curated-data/pull/10279) is an example. For Sustainsys.Saml2, any version before 2.0.0 should be `LGPL-3.0-or-later` and any version after 2.0.0 should be `MIT`. But the matching logic adds 1.x version as `MIT`. The reason is that both 2.x and 1.x have empty license files and license expression property. What’s more, the `licenseUrl` point to the same GitHub license page, but the license page content has changed. Let's first skip `licenseUrl` for Nuget component if the URL point to a GitHub file.