### PR TITLE
Bugfix: GitHub events are sent to a queue instead of directly to service

### DIFF
--- a/providers/curation/process.js
+++ b/providers/curation/process.js
@@ -18,6 +18,7 @@ async function work(once) {
         break
       }
       case 'closed': {
+        await curationService.addByMergedCuration(pr)
         await curationService.updateContribution(pr)
         break
       }

--- a/test/providers/curation/processTest.js
+++ b/test/providers/curation/processTest.js
@@ -37,6 +37,8 @@ describe('Curation queue processing', () => {
 
     expect(curationService.getContributedCurations.calledOnce).to.be.false
     expect(curationService.validateContributions.calledOnce).to.be.false
+    expect(curationService.addByMergedCuration.calledOnce).to.be.true
+    expect(curationService.addByMergedCuration.calledBefore(curationService.updateContribution))
     expect(curationService.updateContribution.calledOnce).to.be.true
     expect(logger.info.calledOnce).to.be.true
     expect(logger.info.getCall(0).args[0]).to.eq('Handled GitHub event "closed" for PR#1')
@@ -77,7 +79,8 @@ function setup({ action, merged }) {
   const curationService = {
     getContributedCurations: sinon.stub(),
     validateContributions: sinon.stub(),
-    updateContribution: sinon.stub()
+    updateContribution: sinon.stub(),
+    addByMergedCuration: sinon.stub()
   }
   const logger = {
     info: sinon.stub(),


### PR DESCRIPTION
When curation PR get merged, an auto curation PR should be triggered. The GitHub
event goes to a queue instead of directly sent to service.