### PR TITLE
Some small fixes

### DIFF
--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -178,17 +178,20 @@ class NugetHarvestLicenseMatchStrategy extends BaseHarvestLicenseMatchStrategy {
   constructor() {
     super('nuget', ['manifest.licenseExpression', 'manifest.licenseUrl'])
     this.logger = logger()
+    this.excludedLicenseUrl = ['github.com', 'aka.ms/deprecateLicenseUrl']
   }
 
   compare(source, target) {
     const result = super.compare(source, target)
-    // For Nuget component, if the licenseUrl point to github,
+    // 1. For Nuget component, if the licenseUrl point to github,
     // the content of the license url is tend to change even the url keeps the same
+    // 2. If the licenseUrl point to https://aka.ms/deprecateLicenseUrl, this means
+    // this a deprecated license url and there is a license file in the package.
     result.match = result.match.filter(m => {
       if (m.propPath === 'manifest.licenseUrl') {
         this.logger.info('NugetHarvestLicenseMatchStrategy.compare.licenseUrl', { url: m.value })
       }
-      if (m.value && m.value.toLowerCase().includes('github.com')) {
+      if (m.value && this.excludedLicenseUrl.some(url => m.value.toLowerCase().includes(url.toLowerCase()))) {
         return false
       }
       return true

--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -1,5 +1,6 @@
 const { get, isEqual: isDeepEqual } = require('lodash')
 const { isLicenseFile, getLatestVersion } = require('./utils')
+const logger = require('../providers/logging/logger')
 
 class LicenseMatcher {
   constructor(policies) {
@@ -176,6 +177,7 @@ class BaseHarvestLicenseMatchStrategy {
 class NugetHarvestLicenseMatchStrategy extends BaseHarvestLicenseMatchStrategy {
   constructor() {
     super('nuget', ['manifest.licenseExpression', 'manifest.licenseUrl'])
+    this.logger = logger()
   }
 
   compare(source, target) {
@@ -183,6 +185,9 @@ class NugetHarvestLicenseMatchStrategy extends BaseHarvestLicenseMatchStrategy {
     // For Nuget component, if the licenseUrl point to github,
     // the content of the license url is tend to change even the url keeps the same
     result.match = result.match.filter(m => {
+      if (m.propPath === 'manifest.licenseUrl') {
+        this.logger.info('NugetHarvestLicenseMatchStrategy.compare.licenseUrl', { url: m.value })
+      }
       if (m.value && m.value.toLowerCase().includes('github.com')) {
         return false
       }

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -201,7 +201,7 @@ class GitHubCurationService {
     const coordinatesList = await this.definitionService.list(revisionlessCoords)
     const filteredCoordinatesList = coordinatesList
       .map(stringCoords => EntityCoordinates.fromString(stringCoords))
-      .filter(coords => coordinates.name === coords.name && coordinates.revision !== coords.revision)
+      .filter(coords => coordinates.name === coords.name && coordinates.revision !== coords.revision && coords.revision !== 'undefined')
 
     const matchingRevisionsAndReasons = await this._startMatching(coordinates, filteredCoordinatesList)
     const curations = await this.list(revisionlessCoords)

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -538,8 +538,8 @@ ${this._formatDefinitions(patch.patches)}`
 
     if (Object.keys(matchingMetadata).length > 0) {
       const metadataText = Object.keys(matchingMetadata).length == 1
-        ? Object.keys(matchingMetadata).map(metadataProp => `${metadataProp}: '${matchingMetadata[metadataProp]}'`)
-        : Object.keys(matchingMetadata).map(metadataProp => `\n- ${metadataProp}: '${matchingMetadata[metadataProp]}'`)
+        ? Object.keys(matchingMetadata).map(metadataProp => `${metadataProp}: ${JSON.stringify(matchingMetadata[metadataProp])}`)
+        : Object.keys(matchingMetadata).map(metadataProp => `\n- ${metadataProp}: ${JSON.stringify(matchingMetadata[metadataProp])}`)
       output += `\nMatching metadata: ${metadataText}`
     }
     return output

--- a/test/lib/licenseMatcher.js
+++ b/test/lib/licenseMatcher.js
@@ -471,6 +471,15 @@ describe('licenseMatcher.js', () => {
         expect(result.match).to.have.lengthOf(0)
         expect(result.mismatch).to.have.lengthOf(0)
       })
+
+      it('Should return empty match and mismatch when manifest.licenseExpression is empty and manifest.licenseUrl including aka.ms/deprecateLicenseUrl', () => {
+        const deprecatedLicenseUrl = 'https://aka.ms/deprecateLicenseUrl'
+        const source = generateNugetDefinitionAndHarvest('1.4.0', undefined, deprecatedLicenseUrl)
+        const target = generateNugetDefinitionAndHarvest('1.4.6', undefined, deprecatedLicenseUrl)
+        const result = harvestLicenseMatchPolicy.compare(source, target)
+        expect(result.match).to.have.lengthOf(0)
+        expect(result.mismatch).to.have.lengthOf(0)
+      })
     })
 
     describe('Match npm package', () => {

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -225,7 +225,7 @@ describe('Github Curation Service', () => {
       const licenseMetadataMatch = {
         policy: 'metadata match',
         propPath: 'registryData.manifest.license',
-        value: 'LICENSE METADATA'
+        value: ['LICENSE METADATA']
       }
       processStub.onFirstCall().returns({ isMatching: true, match: [licenseFileMatch] })
       processStub.onSecondCall().returns({ isMatching: true, match: [licenseMetadataMatch] })
@@ -276,10 +276,10 @@ describe('Github Curation Service', () => {
         {
           version: '1.2', matchingProperties: [{
             propPath: 'registryData.manifest.license',
-            value: 'LICENSE METADATA'
+            value: ['LICENSE METADATA']
           }]
         }]
-      const expectedDescription = '- 1.1\n- 1.2\n\nMatching license file(s): LICENSE.txt\nMatching metadata: registryData.manifest.license: \'LICENSE METADATA\''
+      const expectedDescription = '- 1.1\n- 1.2\n\nMatching license file(s): LICENSE.txt\nMatching metadata: registryData.manifest.license: ["LICENSE METADATA"]'
       const description = gitHubService._formatMultiversionCuratedRevisions(expectedResults)
       expect(description).to.be.deep.equal(expectedDescription)
 


### PR DESCRIPTION
1. Fix this wrong PR description: clearlydefined/curated-data#10605
2. Log Nuget license URL for future analysis
3. Filter out Nuget deprecated license URL
4. Avoid auto curation for an undefined version of a component. https://github.com/clearlydefined/curated-data/pull/10530/files