### PR TITLE
Nell/curation errors

### DIFF
--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -143,6 +143,7 @@ class GitHubCurationService {
     if (invalidCurations.length) {
       state = 'error'
       description = `Invalid curations: ${invalidCurations.map(x => x.path).join(', ')}`
+      this.logger.error(description, invalidCurations)
 
       let error_string = 'We discovered some errors in this curation when validating it:\n\n'
 

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -149,7 +149,7 @@ class GitHubCurationService {
 
       for (const invalid_curation of invalidCurations) {
         for (const err of invalid_curation.errors) {
-          error_string += err.error
+          error_string += `${err.error}\n`
         }
       }
       await this._postErrorsComment(number, error_string)

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -143,14 +143,14 @@ class GitHubCurationService {
     if (invalidCurations.length) {
       state = 'error'
       description = `Invalid curations: ${invalidCurations.map(x => x.path).join(', ')}`
-      this.logger.error(description, invalidCurations)
 
-      let error_string = 'We discovered some errors in this curation when validating it:\n'
+      let error_string = 'We discovered some errors in this curation when validating it:\n\n'
 
       for (const invalid_curation of invalidCurations) {
-        error_string += invalid_curation.errors.map(e => e.error.message).join('\n')
+        for (const err of invalid_curation.errors) {
+          error_string += err.error
+        }
       }
-
       await this._postErrorsComment(number, error_string)
     }
     return this._postCommitStatus(sha, number, state, description)

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -11,6 +11,7 @@ const Curation = require('../../../lib/curation')
 const sinon = require('sinon')
 const extend = require('extend')
 const { find } = require('lodash')
+const { invalid } = require('moment')
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -54,7 +55,7 @@ describe('Github Curation Service', () => {
     const curations = await service.getContributedCurations(42, 'testBranch')
     service.logger = { // intercept and verify invalid contribution
       error: (description) => {
-        expect(description).to.be.eq('Invalid curations: ')
+        expect(description).to.be.eq('Invalid curations: curations/sdfdsf/npmjs/test.yaml')
       }
     }
     await service.validateContributions('42', 'testBranch', curations)
@@ -539,13 +540,16 @@ function createCuration(curation = simpleCuration) {
 }
 
 function createInvalidCuration() {
-  return new Curation({
+  invalidCuration = new Curation({
     coordinates: {
       type: 'sdfdsf',
       provider: 'npmjs',
       name: 'test'
     }
   })
+
+  invalidCuration.path = 'curations/sdfdsf/npmjs/test.yaml'
+  return invalidCuration
 }
 
 function setup(definition, coordinateSpec, curation) {

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -49,9 +49,8 @@ describe('Github Curation Service', () => {
     const service = createService()
     sinon.stub(service, '_postCommitStatus').returns(Promise.resolve())
     sinon.stub(service, '_postErrorsComment').returns(Promise.resolve())
-    let invalid_curation = createInvalidCuration()
     sinon.stub(service, 'getContributedCurations').callsFake(() => {
-      return [invalid_curation]
+      return [createInvalidCuration()]
     })
 
     const curations = await service.getContributedCurations(42, 'testBranch')

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -64,7 +64,7 @@ describe('Github Curation Service', () => {
     expect(service._postCommitStatus.getCall(0).args[2]).to.be.eq('pending')
     expect(service._postCommitStatus.getCall(1).args[2]).to.be.eq('error')
     expect(service._postErrorsComment.calledOnce).to.be.true
-    expect(service._postErrorsComment.getCall(0).args[1]).to.be.eq('We discovered some errors in this curation when validating it:\n\nThis is an error')
+    expect(service._postErrorsComment.getCall(0).args[1]).to.be.eq('We discovered some errors in this curation when validating it:\n\nThis is an error\n')
   })
 
   it('merges simple changes', async () => {


### PR DESCRIPTION
Currently, when a pull request to https://github.com/clearlydefined/curated-data/ fails validation, the cause of the failure is not displayed to the user. 

This adds functionality so that, when a pull request fails validation, a GitHub comment is opened on the pull request with details about the failure.