### PR TITLE
Fix bugs for multi-version curation feature

### DIFF
--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -221,11 +221,11 @@ class GitHubCurationService {
   }
 
   async _filterRevisionWithScannedDeclaredLicense(coordinates, curation, matchingRevisionAndReason) {
-    const filtered = [];
+    const filtered = []
     for (const revisionAndReason of matchingRevisionAndReason) {
-      const { version } = revisionAndReason;
-      const matchingCoordinates = EntityCoordinates.fromObject({ ...coordinates, revision: version });
-      const matchingDefinition = await this.definitionService.getStored(matchingCoordinates);
+      const { version } = revisionAndReason
+      const matchingCoordinates = EntityCoordinates.fromObject({ ...coordinates, revision: version })
+      const matchingDefinition = await this.definitionService.getStored(matchingCoordinates)
       if (get(matchingDefinition, 'licensed.declared')) {
         if (get(matchingDefinition, 'licensed.declared') !== get(curation, 'licensed.declared')) {
           this.logger.info('GitHubCurationService._filterRevisionWithScannedDeclaredLicense.ScannedLicenseNotEqualToCuratedLicense', {
@@ -239,7 +239,7 @@ class GitHubCurationService {
         filtered.push(revisionAndReason)
       }
     }
-    return filtered;
+    return filtered
   }
 
   _updateContent(coordinates, currentContent, newContent) {

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -220,6 +220,28 @@ class GitHubCurationService {
     return uncuratedMatchingRevisions
   }
 
+  async _filterRevisionWithScannedDeclaredLicense(coordinates, curation, matchingRevisionAndReason) {
+    const filtered = [];
+    for (const revisionAndReason of matchingRevisionAndReason) {
+      const { version } = revisionAndReason;
+      const matchingCoordinates = EntityCoordinates.fromObject({ ...coordinates, revision: version });
+      const matchingDefinition = await this.definitionService.getStored(matchingCoordinates);
+      if (get(matchingDefinition, 'licensed.declared')) {
+        if (get(matchingDefinition, 'licensed.declared') !== get(curation, 'licensed.declared')) {
+          this.logger.info('GitHubCurationService._filterRevisionWithScannedDeclaredLicense.ScannedLicenseNotEqualToCuratedLicense', {
+            coordinates: coordinates.toString(),
+            revisionAndReason,
+            curation,
+            scannedLicense: get(matchingDefinition, 'licensed.declared')
+          })
+        }
+      } else {
+        filtered.push(revisionAndReason)
+      }
+    }
+    return filtered;
+  }
+
   _updateContent(coordinates, currentContent, newContent) {
     const newCoordinates = EntityCoordinates.fromObject(coordinates).asRevisionless()
     const result = {
@@ -415,7 +437,8 @@ class GitHubCurationService {
         return
       }
       this.logger.info('eligible component for multiversion curation', { coordinates: curatedCoordinates.toString() })
-      const matchingRevisionAndReason = await this._calculateMatchingRevisionAndReason(curatedCoordinates)
+      let matchingRevisionAndReason = await this._calculateMatchingRevisionAndReason(curatedCoordinates)
+      matchingRevisionAndReason = await this._filterRevisionWithScannedDeclaredLicense(curatedCoordinates, get(curationRevisions, [revision]), matchingRevisionAndReason)
       if (matchingRevisionAndReason.length === 0) {
         return
       }
@@ -837,6 +860,7 @@ ${this._formatDefinitions(patch.patches)}`
       const curatedCoordinates = EntityCoordinates.fromString(curatedCoordinatesStr)
       let matchingRevisionAndReason = await this._calculateMatchingRevisionAndReason(curatedCoordinates)
       matchingRevisionAndReason = matchingRevisionAndReason.filter(r => !processedRevisions.has(r.version))
+      matchingRevisionAndReason = await this._filterRevisionWithScannedDeclaredLicense(curatedCoordinates, curation, matchingRevisionAndReason)
       if (matchingRevisionAndReason.length === 0) {
         contributions.push({ coordinates: curatedCoordinates.toString() })
         continue

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -105,6 +105,11 @@ router.post('/reprocess', permissionsCheck('curate'), asyncMiddleware(reprocessM
 
 async function reprocessMergedCurations(request, respond) {
   const coordinatesArray = request.body.map(EntityCoordinates.fromString)
+  // Reprocess consume a lot of resource. Limit the size of the reprocess request.
+  const reprocessThreshold = 100;
+  if (coordinatesArray.length >= reprocessThreshold) {
+    return respond.status(403).send({ message: `Reprocess coordinates number exceed ${reprocessThreshold} threshold.` })
+  }
   const result = await curationService.reprocessMergedCurations(coordinatesArray)
   respond.status(200).send(result)
 }

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -106,7 +106,7 @@ router.post('/reprocess', permissionsCheck('curate'), asyncMiddleware(reprocessM
 async function reprocessMergedCurations(request, respond) {
   const coordinatesArray = request.body.map(EntityCoordinates.fromString)
   // Reprocess consume a lot of resource. Limit the size of the reprocess request.
-  const reprocessThreshold = 100;
+  const reprocessThreshold = 100
   if (coordinatesArray.length >= reprocessThreshold) {
     return respond.status(403).send({ message: `Reprocess coordinates number exceed ${reprocessThreshold} threshold.` })
   }


### PR DESCRIPTION
1. Skip auto curation for components with existing scanned declared license
2. Add reprocess API protection. (100 is not a very accurate number. Use it for now.)