### PR TITLE
Fix for Rust multi-license declaration, plus new Rust license tests

### DIFF
--- a/providers/summary/fossology.js
+++ b/providers/summary/fossology.js
@@ -92,6 +92,8 @@ class FOSSologySummarizer {
 
   _declareLicense(coordinates, result) {
     if (!result.files) return
+    // For Rust crates, leave the license declaration to the ClearlyDefined summarizer which parses Cargo.toml
+    if (get(coordinates, 'type') === 'crate') return
     // if we know this is a license file by the name of it and it has a license detected in it
     // then let's declare the license for the component
     const licenses = uniq(

--- a/providers/summary/licensee.js
+++ b/providers/summary/licensee.js
@@ -47,6 +47,8 @@ class LicenseeSummarizer {
 
   _addLicenseFromFiles(result, coordinates) {
     if (!result.files) return
+    // For Rust crates, leave the license declaration to the ClearlyDefined summarizer which parses Cargo.toml
+    if (get(coordinates, 'type') === 'crate') return
     const licenses = result.files
       .map(file => (isDeclaredLicense(file.license) && isLicenseFile(file.path, coordinates) ? file.license : null))
       .filter(x => x)

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -32,9 +32,12 @@ class ScanCodeSummarizer {
     if (!scancodeVersion) throw new Error('Not valid ScanCode data')
     const result = {}
     this.addDescribedInfo(result, harvested)
-    const declaredLicense =
-      this._readDeclaredLicense(harvested) || this._getDeclaredLicense(scancodeVersion, harvested, coordinates)
-    setIfValue(result, 'licensed.declared', declaredLicense)
+    // For Rust crates, leave the license declaration to the ClearlyDefined summarizer which parses Cargo.toml
+    if (get(coordinates, 'type') !== 'crate') {
+      const declaredLicense =
+        this._readDeclaredLicense(harvested) || this._getDeclaredLicense(scancodeVersion, harvested, coordinates)
+      setIfValue(result, 'licensed.declared', declaredLicense)
+    }
     result.files = this._summarizeFileInfo(harvested.content.files, coordinates)
     return result
   }

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -321,27 +321,64 @@ describe('Aggregation service', () => {
     expect(aggregated.files[1].license).to.eq('GPL-2.0')
   })
 
-  it('handles Rust quote crate with dual licenses', async () => {
-    const coordSpec = 'crate/cratesio/-/quote/1.0.9'
-    //const coordSpec = 'crate/cratesio/-/quote/0.6.4'
-    const coords = EntityCoordinates.fromString(coordSpec)
-    const raw = require('./evidence/crate-quote-1.0.9.json')
-    //const raw = require('./evidence/crate-quote-0.6.4.json')
-    const tools = [['clearlydefined', 'licensee', 'scancode']]
-    //const tools = [['clearlydefined', 'licensee', 'scancode', 'fossology']]
+  it('handles Rust crates with license choices', async () => {
+    const testcases = [
+      {
+        name: 'slog',
+        version: '2.7.0',
+        tools: [['clearlydefined', 'licensee', 'scancode']],
+        // Ideally this would be declared without any parentheses, but currently
+        // the SPDX normalization adds them.
+        expected: 'MPL-2.0 OR (MIT OR Apache-2.0)',
+      },
+      {
+        name: 'quote',
+        version: '0.6.4',
+        tools: [['clearlydefined', 'fossology', 'licensee', 'scancode']],
+        expected: 'MIT OR Apache-2.0',
+      },
+      {
+        name: 'quote',
+        version: '1.0.9',
+        tools: [['clearlydefined', 'licensee', 'scancode']],
+        expected: 'MIT OR Apache-2.0',
+      },
+      {
+        name: 'rand',
+        version: '0.8.2',
+        tools: [['clearlydefined', 'licensee', 'scancode']],
+        expected: 'MIT OR Apache-2.0',
+      },
+      {
+        name: 'regex',
+        version: '1.5.3',
+        tools: [['clearlydefined', 'licensee', 'scancode']],
+        expected: 'MIT OR Apache-2.0',
+      },
+      {
+        name: 'serde',
+        version: '1.0.123',
+        tools: [['clearlydefined', 'licensee', 'scancode']],
+        expected: 'MIT OR Apache-2.0',
+      },
+    ]
+
     const summary_options = {}
     const summaryService = SummaryService(summary_options)
-    const summaries = summaryService.summarizeAll(coords, raw)
-    const { service } = setupAggregatorWithParams(coordSpec, tools)
-    const aggregated = service.process(summaries)
-    console.log(`${summaries}`)
-    console.log(`${aggregated}`)
-    expect(aggregated.licensed.declared == 'Apache-2.0 OR MIT')
+
+    for (let i = 0; i < testcases.length; i++) {
+      let testcase = testcases[i]
+      const coordSpec = `crate/cratesio/-/${testcase.name}/${testcase.version}`
+      const coords = EntityCoordinates.fromString(coordSpec)
+      const raw = require(`./evidence/crate-${testcase.name}-${testcase.version}.json`)
+      const tools = testcase.tools
+      const summaries = summaryService.summarizeAll(coords, raw)
+      const { service } = setupAggregatorWithParams(coordSpec, tools)
+      const aggregated = service.process(summaries)
+      expect(aggregated.licensed.declared, `${testcase.name}-${testcase.version}`).to.eq(testcase.expected)
+    }
   })
 })
-
-
-
 
 function validate(definition) {
   // Tack on a dummy coordinates to keep the schema happy. Tool summarizations do not have to include coordinates

--- a/test/business/evidence/crate-quote-0.6.4.json
+++ b/test/business/evidence/crate-quote-0.6.4.json
@@ -1,0 +1,2319 @@
+{
+  "clearlydefined": {
+    "1.2.0": {
+      "_metadata": {
+        "type": "crate",
+        "url": "cd:/crate/cratesio/-/quote/0.6.4",
+        "fetchedAt": "2019-03-12T20:16:24.968Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:clearlydefined:1.2.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:clearlydefined",
+            "type": "collection"
+          },
+          "licensee": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:licensee",
+            "type": "collection"
+          },
+          "fossology": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:fossology",
+            "type": "collection"
+          },
+          "scancode": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:scancode",
+            "type": "collection"
+          },
+          "source": {
+            "href": "urn:git:github:dtolnay:quote:revision:0642d0efa7416da39b55fb67b64639db25a84288",
+            "type": "resource"
+          }
+        },
+        "schemaVersion": "1.2.0",
+        "toolVersion": "1.0.0"
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-APACHE",
+          "token": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+        },
+        {
+          "path": "LICENSE-MIT",
+          "token": "c9a75f18b9ab2927829a208fc6aa2cf4e63b8420887ba29cdb265d6619ae82d5"
+        }
+      ],
+      "summaryInfo": {
+        "k": 61,
+        "count": 9,
+        "hashes": {
+          "sha1": "d796ccf841b0cb6280b52cdc5c92fe88c6433828",
+          "sha256": "b71f9f575d55555aa9c06188be9d4e2bfc83ed02537948ac0d520c24d0419f1a"
+        }
+      },
+      "files": [
+        {
+          "path": "Cargo.toml",
+          "hashes": {
+            "sha1": "aa1aa2b801f0210b0b79f4d4dfe7a717a005dfb8",
+            "sha256": "a02686a992d472d3cc92326977fb38432dd6ccdcc65189c52fdef6f34ddb5338"
+          }
+        },
+        {
+          "path": "Cargo.toml.orig",
+          "hashes": {
+            "sha1": "0fb532d4e9329c097bee636e72c3c7bf0fbc322f",
+            "sha256": "40412e9fe124fb756963330536b3e3c4189ce31438282d92c4f395336127dcee"
+          }
+        },
+        {
+          "path": "LICENSE-APACHE",
+          "hashes": {
+            "sha1": "5798832c31663cedc1618d18544d445da0295229",
+            "sha256": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+          }
+        },
+        {
+          "path": "LICENSE-MIT",
+          "hashes": {
+            "sha1": "9a2b6b4ad55ec42cf19fc686c74668d3a6303ae7",
+            "sha256": "c9a75f18b9ab2927829a208fc6aa2cf4e63b8420887ba29cdb265d6619ae82d5"
+          }
+        },
+        {
+          "path": "README.md",
+          "hashes": {
+            "sha1": "1423e115c1e0353c62b4e9c8efc4f8180f911178",
+            "sha256": "61dc7827fb2e29185f0d73594db326bfdbec8393ca7a48429b259711d42e80f9"
+          }
+        },
+        {
+          "path": "src/ext.rs",
+          "hashes": {
+            "sha1": "5caeb8b25737f6a43fd3a78b97cafa6890266aba",
+            "sha256": "2e2f71fca8c8580eeed138da42d93dc21fc48d7a8da973ae6d3b616da6a3b0e3"
+          }
+        },
+        {
+          "path": "src/lib.rs",
+          "hashes": {
+            "sha1": "ce8f375964eaa14cec0e6255f0be1752913d871b",
+            "sha256": "391e133920eefc7d5ec4d2208e83f073f23601a932f3f2e36dbf317d9edafafa"
+          }
+        },
+        {
+          "path": "src/to_tokens.rs",
+          "hashes": {
+            "sha1": "f8605b297ea0270a0d2f37037f2434cc221af0c8",
+            "sha256": "10dc32fbe69798408ee1f49ec25770b90eeb6b069552f50cd4e03228b8e85847"
+          }
+        },
+        {
+          "path": "tests/test.rs",
+          "hashes": {
+            "sha1": "23ed488bbc53132e9c7df99e6b74371065d10a1b",
+            "sha256": "90fe0e9a704e628339fe9298f0cb8307e94ebadfe28fffd7b2fc2d94203bc342"
+          }
+        }
+      ],
+      "manifest": {
+        "id": "quote",
+        "name": "quote",
+        "updated_at": "2019-01-20T02:55:01.528634+00:00",
+        "versions": [
+          129093,
+          116896,
+          114976,
+          104920,
+          104918,
+          103619,
+          102399,
+          100822,
+          94579,
+          93669,
+          93621,
+          93609,
+          89818,
+          87127,
+          87126,
+          76815,
+          76799,
+          76779,
+          47123,
+          46487,
+          45869,
+          42741,
+          42675,
+          38562,
+          38480,
+          38422,
+          38421,
+          38419,
+          36663,
+          36601,
+          35513,
+          35512,
+          35511,
+          35427,
+          35405,
+          35377,
+          35119,
+          35095,
+          35015,
+          34770,
+          34363,
+          33834,
+          33819,
+          33112,
+          33026
+        ],
+        "keywords": [
+          "syn"
+        ],
+        "categories": [
+          "development-tools::procedural-macro-helpers"
+        ],
+        "badges": [
+          {
+            "badge_type": "travis-ci",
+            "attributes": {
+              "branch": null,
+              "repository": "dtolnay/quote"
+            }
+          }
+        ],
+        "created_at": "2016-09-03T05:42:05.484129+00:00",
+        "downloads": 7537476,
+        "recent_downloads": 1765042,
+        "max_version": "0.6.11",
+        "description": "Quasi-quoting macro quote!(...)",
+        "homepage": null,
+        "documentation": "https://docs.rs/quote/",
+        "repository": "https://github.com/dtolnay/quote",
+        "links": {
+          "version_downloads": "/api/v1/crates/quote/downloads",
+          "versions": null,
+          "owners": "/api/v1/crates/quote/owners",
+          "owner_team": "/api/v1/crates/quote/owner_team",
+          "owner_user": "/api/v1/crates/quote/owner_user",
+          "reverse_dependencies": "/api/v1/crates/quote/reverse_dependencies"
+        },
+        "exact_match": false
+      },
+      "registryData": {
+        "id": 100822,
+        "crate": "quote",
+        "num": "0.6.4",
+        "dl_path": "/api/v1/crates/quote/0.6.4/download",
+        "readme_path": "/api/v1/crates/quote/0.6.4/readme",
+        "updated_at": "2018-07-22T18:07:39.239122+00:00",
+        "created_at": "2018-07-22T18:07:39.239122+00:00",
+        "downloads": 124870,
+        "features": {
+          "default": [
+            "proc-macro"
+          ],
+          "proc-macro": [
+            "proc-macro2/proc-macro"
+          ]
+        },
+        "yanked": false,
+        "license": "MIT/Apache-2.0",
+        "links": {
+          "dependencies": "/api/v1/crates/quote/0.6.4/dependencies",
+          "version_downloads": "/api/v1/crates/quote/0.6.4/downloads",
+          "authors": "/api/v1/crates/quote/0.6.4/authors"
+        },
+        "crate_size": null,
+        "published_by": null
+      },
+      "sourceInfo": {
+        "type": "git",
+        "provider": "github",
+        "namespace": "dtolnay",
+        "name": "quote",
+        "revision": "0642d0efa7416da39b55fb67b64639db25a84288",
+        "url": null,
+        "path": null
+      }
+    }
+  },
+  "fossology": {
+    "3.6.0": {
+      "_metadata": {
+        "type": "fossology",
+        "url": "cd:/crate/cratesio/-/quote/0.6.4/tool/licensee",
+        "fetchedAt": "2019-03-13T03:42:02.887Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:fossology:3.6.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:licensee",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "3.6.0",
+        "toolVersion": "3.4.0",
+        "processedAt": "2019-03-13T03:42:06.434Z"
+      },
+      "nomos": {
+        "version": "3.4.0",
+        "parameters": "",
+        "output": {
+          "contentType": "text/plain",
+          "content": "File LICENSE-MIT contains license(s) MIT\nFile Cargo.toml contains license(s) MIT\nFile README.md contains license(s) Apache-2.0,MIT\nFile src/lib.rs contains license(s) No_license_found\nFile tests/test.rs contains license(s) No_license_found\nFile Cargo.toml.orig contains license(s) MIT\nFile LICENSE-APACHE contains license(s) Apache-2.0\nFile src/ext.rs contains license(s) No_license_found\nFile src/to_tokens.rs contains license(s) No_license_found\n"
+        }
+      },
+      "copyright": {
+        "version": "0.0.0",
+        "parameters": [
+          "-J"
+        ],
+        "output": {
+          "contentType": "application/json",
+          "content": [
+            {
+              "path": "Cargo.toml",
+              "output": {
+                "results": [
+                  {
+                    "content": "https://docs.rs/quote/\"",
+                    "end": 805,
+                    "start": 782,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://github.com/dtolnay/quote\"",
+                    "end": 920,
+                    "start": 887,
+                    "type": "url"
+                  },
+                  {
+                    "content": "dtolnay@gmail.com",
+                    "end": 610,
+                    "start": 593,
+                    "type": "email"
+                  },
+                  {
+                    "content": "authors",
+                    "end": 574,
+                    "start": 567,
+                    "type": "author"
+                  }
+                ]
+              }
+            },
+            {
+              "path": "Cargo.toml.orig",
+              "output": {
+                "results": [
+                  {
+                    "content": "https://github.com/dtolnay/quote\"",
+                    "end": 291,
+                    "start": 258,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://docs.rs/quote/\"",
+                    "end": 332,
+                    "start": 309,
+                    "type": "url"
+                  },
+                  {
+                    "content": "dtolnay@gmail.com",
+                    "end": 165,
+                    "start": 148,
+                    "type": "email"
+                  },
+                  {
+                    "content": "authors",
+                    "end": 129,
+                    "start": 122,
+                    "type": "author"
+                  }
+                ]
+              }
+            },
+            {
+              "path": "LICENSE-APACHE",
+              "output": {
+                "results": [
+                  {
+                    "content": "copyright owner or by an individual or Legal Entity authorized to submit on behalf of",
+                    "end": 2580,
+                    "start": 2492,
+                    "type": "statement"
+                  },
+                  {
+                    "content": "(c) You must retain, in the Source form of any Derivative Works",
+                    "end": 5261,
+                    "start": 5198,
+                    "type": "statement"
+                  },
+                  {
+                    "content": "copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and",
+                    "end": 5487,
+                    "start": 5294,
+                    "type": "statement"
+                  },
+                  {
+                    "content": "Copyright [yyyy] [name of copyright owner]",
+                    "end": 10324,
+                    "start": 10282,
+                    "type": "statement"
+                  },
+                  {
+                    "content": "http://www.apache.org/licenses/",
+                    "end": 147,
+                    "start": 116,
+                    "type": "url"
+                  },
+                  {
+                    "content": "http://www.apache.org/licenses/LICENSE-2.0",
+                    "end": 10539,
+                    "start": 10497,
+                    "type": "url"
+                  },
+                  {
+                    "content": "authorized by",
+                    "end": 442,
+                    "start": 429,
+                    "type": "author"
+                  },
+                  {
+                    "content": "authorship, whether in Source or",
+                    "end": 1567,
+                    "start": 1535,
+                    "type": "author"
+                  },
+                  {
+                    "content": "authorship.",
+                    "end": 2025,
+                    "start": 2014,
+                    "type": "author"
+                  },
+                  {
+                    "content": "authorship, including",
+                    "end": 2295,
+                    "start": 2274,
+                    "type": "author"
+                  },
+                  {
+                    "content": "authorized to submit on behalf of",
+                    "end": 2580,
+                    "start": 2547,
+                    "type": "author"
+                  },
+                  {
+                    "content": "Contributor hereby grants to You a perpetual",
+                    "end": 3482,
+                    "start": 3438,
+                    "type": "author"
+                  },
+                  {
+                    "content": "Contributor hereby grants to You a perpetual",
+                    "end": 3878,
+                    "start": 3834,
+                    "type": "author"
+                  },
+                  {
+                    "content": "Contributor that are necessarily infringed by their",
+                    "end": 4220,
+                    "start": 4169,
+                    "type": "author"
+                  },
+                  {
+                    "content": "contributory patent infringement, then any patent licenses",
+                    "end": 4622,
+                    "start": 4564,
+                    "type": "author"
+                  },
+                  {
+                    "content": "Contributor provides its Contributions",
+                    "end": 7841,
+                    "start": 7803,
+                    "type": "author"
+                  },
+                  {
+                    "content": "Contributor be",
+                    "end": 8554,
+                    "start": 8540,
+                    "type": "author"
+                  },
+                  {
+                    "content": "Contributor has been advised of the possibility of such damages.",
+                    "end": 9018,
+                    "start": 8951,
+                    "type": "author"
+                  },
+                  {
+                    "content": "Contributor harmless for any liability",
+                    "end": 9558,
+                    "start": 9520,
+                    "type": "author"
+                  },
+                  {
+                    "content": "Contributor by reason",
+                    "end": 9629,
+                    "start": 9608,
+                    "type": "author"
+                  }
+                ]
+              }
+            },
+            {
+              "path": "LICENSE-MIT",
+              "output": {
+                "results": [
+                  {
+                    "content": "Copyright (c) 2016 The Rust Project Developers",
+                    "end": 46,
+                    "start": 0,
+                    "type": "statement"
+                  },
+                  {
+                    "content": "AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY",
+                    "end": 880,
+                    "start": 834,
+                    "type": "author"
+                  }
+                ]
+              }
+            },
+            {
+              "path": "README.md",
+              "output": {
+                "results": [
+                  {
+                    "content": "https://api.travis-ci.org/dtolnay/quote.svg?branch=master)](https://travis-ci.org/dtolnay/quote)",
+                    "end": 152,
+                    "start": 56,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://img.shields.io/crates/v/quote.svg)](https://crates.io/crates/quote)",
+                    "end": 247,
+                    "start": 172,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://img.shields.io/badge/api-rustdoc-blue.svg)](https://docs.rs/quote/)",
+                    "end": 346,
+                    "start": 271,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://docs.rs/quote/0.6/quote/macro.quote.html",
+                    "end": 523,
+                    "start": 475,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://github.com/dtolnay/quote/releases)",
+                    "end": 1690,
+                    "start": 1648,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://docs.rs/proc-macro2/0.4/proc_macro2/struct.TokenStream.html",
+                    "end": 2228,
+                    "start": 2161,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://docs.rs/quote/0.6/quote/trait.ToTokens.html",
+                    "end": 2533,
+                    "start": 2482,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://github.com/dtolnay/syn",
+                    "end": 2573,
+                    "start": 2543,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://docs.rs/proc-macro2/0.4/proc_macro2/struct.Span.html#method.call_site",
+                    "end": 4201,
+                    "start": 4124,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://docs.rs/quote/0.6/quote/macro.quote_spanned.html",
+                    "end": 4362,
+                    "start": 4306,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://github.com/dtolnay/quote/issues/7",
+                    "end": 4615,
+                    "start": 4574,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://github.com/dtolnay/quote/issues/8",
+                    "end": 4663,
+                    "start": 4622,
+                    "type": "url"
+                  },
+                  {
+                    "content": "http://www.apache.org/licenses/LICENSE-2.0)",
+                    "end": 5200,
+                    "start": 5157,
+                    "type": "url"
+                  },
+                  {
+                    "content": "http://opensource.org/licenses/MIT)",
+                    "end": 5282,
+                    "start": 5247,
+                    "type": "url"
+                  }
+                ]
+              }
+            },
+            {
+              "path": "src/ext.rs",
+              "output": {
+                "results": null
+              }
+            },
+            {
+              "path": "src/lib.rs",
+              "output": {
+                "results": [
+                  {
+                    "content": "https://serde.rs/",
+                    "end": 1982,
+                    "start": 1965,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://docs.rs/quote/0.6.4\")]",
+                    "end": 3377,
+                    "start": 3347,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://docs.rs/proc-macro2/0.4/proc_macro2/struct.TokenStream.html",
+                    "end": 4237,
+                    "start": 4170,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://github.com/dtolnay/syn",
+                    "end": 4742,
+                    "start": 4712,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://docs.rs/proc-macro2/0.4/proc_macro2/struct.Span.html#method.call_site",
+                    "end": 5715,
+                    "start": 5638,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://docs.rs/proc-macro2/0.4/proc_macro2/struct.Span.html",
+                    "end": 7430,
+                    "start": 7370,
+                    "type": "url"
+                  },
+                  {
+                    "content": "https://doc.rust-lang.org/std/marker/trait.Sync.html",
+                    "end": 8894,
+                    "start": 8842,
+                    "type": "url"
+                  }
+                ]
+              }
+            },
+            {
+              "path": "src/to_tokens.rs",
+              "output": {
+                "results": null
+              }
+            },
+            {
+              "path": "tests/test.rs",
+              "output": {
+                "results": null
+              }
+            }
+          ]
+        }
+      },
+      "monk": {
+        "version": "0.0.0",
+        "parameters": [
+          "-k",
+          "monk_knowledgebase"
+        ],
+        "output": {
+          "contentType": "text/plain",
+          "content": "found full match between \"LICENSE-MIT\" and \"MIT\" (rf_pk=311); matched: 48+1022\nWARNING: cannot re-encode 'src/lib.rs', going binary from now on\nfound diff match between \"LICENSE-APACHE\" and \"Apache-2.0\" (rf_pk=213); rank 99; diffs: {t[30+4937] M0 s[0+4717], t[4972+3] M+ s[4721], t[4976+101] M0 s[4721+94], t[5082+3] M+ s[4820], t[5086+107] M0 s[4820+100], t[5198+3] M+ s[4925], t[5202+285] M0 s[4925+257], t[5492+3] M+ s[5187], t[5496+4277] M0 s[5187+4058], t[9774+5] MR s[9246+4], t[9784+1062] M0 s[9254+1089]}\n"
+        }
+      }
+    }
+  },
+  "licensee": {
+    "9.12.1": {
+      "_metadata": {
+        "type": "licensee",
+        "url": "cd:/crate/cratesio/-/quote/0.6.4",
+        "fetchedAt": "2019-03-13T03:42:02.578Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:licensee:9.12.1",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:licensee",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "9.12.1",
+        "toolVersion": "9.10.1",
+        "processedAt": "2019-03-13T03:42:04.951Z"
+      },
+      "licensee": {
+        "version": "9.10.1",
+        "parameters": [
+          "--json",
+          "--no-readme"
+        ],
+        "output": {
+          "contentType": "application/json",
+          "content": {
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "spdx_id": "Apache-2.0",
+                "meta": {
+                  "title": "Apache License 2.0",
+                  "source": "https://spdx.org/licenses/Apache-2.0.html",
+                  "description": "A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.",
+                  "using": [
+                    {
+                      "Kubernetes": "https://github.com/kubernetes/kubernetes/blob/master/LICENSE"
+                    },
+                    {
+                      "PDF.js": "https://github.com/mozilla/pdf.js/blob/master/LICENSE"
+                    },
+                    {
+                      "Swift": "https://github.com/apple/swift/blob/master/LICENSE.txt"
+                    }
+                  ],
+                  "featured": true,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": "The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix."
+                },
+                "url": "http://choosealicense.com/licenses/apache-2.0/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "patent-use",
+                      "label": "Patent use",
+                      "description": "This license provides an express grant of patent rights from contributors."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    },
+                    {
+                      "tag": "document-changes",
+                      "label": "State changes",
+                      "description": "Changes made to the code must be documented."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "trademark-use",
+                      "label": "Trademark use",
+                      "description": "This license explicitly states that it does NOT grant trademark rights, even though licenses without such a statement probably do not grant any implicit trademark rights."
+                    },
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "mit",
+                "spdx_id": "MIT",
+                "meta": {
+                  "title": "MIT License",
+                  "source": "https://spdx.org/licenses/MIT.html",
+                  "description": "A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.",
+                  "using": [
+                    {
+                      "Babel": "https://github.com/babel/babel/blob/master/LICENSE"
+                    },
+                    {
+                      ".NET Core": "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+                    },
+                    {
+                      "Rails": "https://github.com/rails/rails/blob/master/MIT-LICENSE"
+                    }
+                  ],
+                  "featured": true,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": null
+                },
+                "url": "http://choosealicense.com/licenses/mit/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [
+                  {
+                    "name": "year",
+                    "description": "The current year"
+                  },
+                  {
+                    "name": "fullname",
+                    "description": "The full name or username of the repository owner"
+                  }
+                ],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "other",
+                "spdx_id": "NOASSERTION",
+                "meta": {
+                  "title": null,
+                  "source": null,
+                  "description": null,
+                  "how": null,
+                  "using": null,
+                  "featured": false,
+                  "hidden": true,
+                  "nickname": null,
+                  "note": null
+                },
+                "url": "http://choosealicense.com/licenses/other/",
+                "rules": {
+                  "permissions": [],
+                  "conditions": [],
+                  "limitations": []
+                },
+                "fields": [],
+                "other": true,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              }
+            ],
+            "matched_files": [
+              {
+                "filename": "LICENSE-APACHE",
+                "content": "                              Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
+                "content_hash": "38af80cfcd81261023ea4c45f5335800a5a4cc97",
+                "content_normalized": "https://www.apache.org/licenses/ terms and conditions for use, reproduction, and distribution - definitions. \"license\" shall mean the terms and conditions for use, reproduction, and distribution as defined by sections 1 through 9 of this document. \"licensor\" shall mean the copyright owner or entity authorized by the copyright owner that is granting the license. \"legal entity\" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. for the purposes of this definition, \"control\" means i the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or ii ownership of fifty percent 50% or more of the outstanding shares, or iii beneficial ownership of such entity. \"you\" or \"your\" shall mean an individual or legal entity exercising permissions granted by this license. \"source\" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files. \"object\" form shall mean any form resulting from mechanical transformation or translation of a source form, including but not limited to compiled object code, generated documentation, and conversions to other media types. \"work\" shall mean the work of authorship, whether in source or object form, made available under the license, as indicated by a copyright notice that is included in or attached to the work an example is provided in the appendix below . \"derivative works\" shall mean any work, whether in source or object form, that is based on or derived from the work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. for the purposes of this license, derivative works shall not include works that remain separable from, or merely link or bind by name to the interfaces of, the work and derivative works thereof. \"contribution\" shall mean any work of authorship, including the original version of the work and any modifications or additions to that work or derivative works thereof, that is intentionally submitted to licensor for inclusion in the work by the copyright owner or by an individual or legal entity authorized to submit on behalf of the copyright owner. for the purposes of this definition, \"submitted\" means any form of electronic, verbal, or written communication sent to the licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the licensor for the purpose of discussing and improving the work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as \"not a contribution.\" \"contributor\" shall mean licensor and any individual or legal entity on behalf of whom a contribution has been received by licensor and subsequently incorporated within the work. - grant of copyright license. subject to the terms and conditions of this license, each contributor hereby grants to you a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute the work and such derivative works in source or object form. - grant of patent license. subject to the terms and conditions of this license, each contributor hereby grants to you a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable except as stated in this section patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the work, where such license applies only to those patent claims licensable by such contributor that are necessarily infringed by their contribution s alone or by combination of their contribution s with the work to which such contribution s was submitted. if you institute patent litigation against any entity including a cross-claim or counterclaim in a lawsuit alleging that the work or a contribution incorporated within the work constitutes direct or contributory patent infringement, then any patent licenses granted to you under this license for that work shall terminate as of the date such litigation is filed. - redistribution. you may reproduce and distribute copies of the work or derivative works thereof in any medium, with or without modifications, and in source or object form, provided that you meet the following conditions: a you must give any other recipients of the work or derivative works a copy of this license; and b you must cause any modified files to carry prominent notices stating that you changed the files; and c you must retain, in the source form of any derivative works that you distribute, all copyright, patent, trademark, and attribution notices from the source form of the work, excluding those notices that do not pertain to any part of the derivative works; and d if the work includes a \"notice\" text file as part of its distribution, then any derivative works that you distribute must include a readable copy of the attribution notices contained within such notice file, excluding those notices that do not pertain to any part of the derivative works, in at least one of the following places: within a notice text file distributed as part of the derivative works; within the source form or documentation, if provided along with the derivative works; or, within a display generated by the derivative works, if and wherever such third-party notices normally appear. the contents of the notice file are for informational purposes only and do not modify the license. you may add your own attribution notices within derivative works that you distribute, alongside or as an addendum to the notice text from the work, provided that such additional attribution notices cannot be construed as modifying the license. you may add your own copyright statement to your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of your modifications, or for any such derivative works as a whole, provided your use, reproduction, and distribution of the work otherwise complies with the conditions stated in this license. - submission of contributions. unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you to the licensor shall be under the terms and conditions of this license, without any additional terms or conditions. notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with licensor regarding such contributions. - trademarks. this license does not grant permission to use the trade names, trademarks, service marks, or product names of the licensor, except as required for reasonable and customary use in describing the origin of the work and reproducing the content of the notice file. - disclaimer of warranty. unless required by applicable law or agreed to in writing, licensor provides the work and each contributor provides its contributions on an \"as is\" basis, without warranties or conditions of any kind, either express or implied, including, without limitation, any warranties or conditions of title, non-infringement, merchantability, or fitness for a particular purpose. you are solely responsible for determining the appropriateness of using or redistributing the work and assume any risks associated with your exercise of permissions under this license. - limitation of liability. in no event and under no legal theory, whether in tort including negligence , contract, or otherwise, unless required by applicable law such as deliberate and grossly negligent acts or agreed to in writing, shall any contributor be liable to you for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this license or out of the use or inability to use the work including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses , even if such contributor has been advised of the possibility of such damages. - accepting warranty or additional liability. while redistributing the work or derivative works thereof, you may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this license. however, in accepting such obligations, you may act only on your own behalf and on your sole responsibility, not on behalf of any other contributor, and only if you agree to indemnify, defend, and hold each contributor harmless for any liability incurred by, or claims asserted against, such contributor by reason of your accepting any such warranty or additional liability.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "Apache-2.0"
+              },
+              {
+                "filename": "LICENSE-MIT",
+                "content": "Copyright (c) 2016 The Rust Project Developers\n\nPermission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE.\n",
+                "content_hash": "46cdc03462b9af57968df67b450cc4372ac41f53",
+                "content_normalized": "permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files the \"software\" , to deal in the software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the software, and to permit persons to whom the software is furnished to do so, subject to the following conditions: the above copyright notice and this permission notice shall be included in all copies or substantial portions of the software. the software is provided \"as is\", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. in no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "MIT"
+              },
+              {
+                "filename": "Cargo.toml",
+                "content": "# THIS FILE IS AUTOMATICALLY GENERATED BY CARGO\n#\n# When uploading crates to the registry Cargo will automatically\n# \"normalize\" Cargo.toml files for maximal compatibility\n# with all versions of Cargo and also rewrite `path` dependencies\n# to registry (e.g. crates.io) dependencies\n#\n# If you believe there's an error in this file please file an\n# issue against the rust-lang/cargo repository. If you're\n# editing this file be aware that the upstream Cargo.toml\n# will likely look very different (and much more reasonable)\n\n[package]\nname = \"quote\"\nversion = \"0.6.4\"\nauthors = [\"David Tolnay <dtolnay@gmail.com>\"]\ninclude = [\"Cargo.toml\", \"src/**/*.rs\", \"tests/**/*.rs\", \"README.md\", \"LICENSE-APACHE\", \"LICENSE-MIT\"]\ndescription = \"Quasi-quoting macro quote!(...)\"\ndocumentation = \"https://docs.rs/quote/\"\nreadme = \"README.md\"\nkeywords = [\"syn\"]\nlicense = \"MIT/Apache-2.0\"\nrepository = \"https://github.com/dtolnay/quote\"\n[dependencies.proc-macro2]\nversion = \"0.4.4\"\ndefault-features = false\n\n[features]\ndefault = [\"proc-macro\"]\nproc-macro = [\"proc-macro2/proc-macro\"]\n",
+                "content_hash": null,
+                "content_normalized": null,
+                "matcher": {
+                  "name": "cargo",
+                  "confidence": 90
+                },
+                "matched_license": "NOASSERTION"
+              }
+            ]
+          }
+        }
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-APACHE",
+          "token": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+        },
+        {
+          "path": "LICENSE-MIT",
+          "token": "c9a75f18b9ab2927829a208fc6aa2cf4e63b8420887ba29cdb265d6619ae82d5"
+        },
+        {
+          "path": "Cargo.toml",
+          "token": "a02686a992d472d3cc92326977fb38432dd6ccdcc65189c52fdef6f34ddb5338"
+        }
+      ]
+    }
+  },
+  "scancode": {
+    "3.2.2": {
+      "_metadata": {
+        "type": "scancode",
+        "url": "cd:/crate/cratesio/-/quote/0.6.4/tool/fossology",
+        "fetchedAt": "2019-03-13T03:42:02.252Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:scancode:3.2.2",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:quote:revision:0.6.4:tool:fossology",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "3.2.2",
+        "toolVersion": "3.0.2",
+        "contentType": "application/json",
+        "releaseDate": "2018-07-22T18:07:39.239122+00:00",
+        "processedAt": "2019-03-13T03:42:24.509Z"
+      },
+      "content": {
+        "headers": [
+          {
+            "tool_name": "scancode-toolkit",
+            "tool_version": "3.0.2",
+            "options": {
+              "input": "/tmp/cd-HlmEDw/crate/quote-0.6.4",
+              "--classify": true,
+              "--copyright": true,
+              "--email": true,
+              "--generated": true,
+              "--info": true,
+              "--is-license-text": true,
+              "--json-pp": "/tmp/cd-fAdUuK",
+              "--license": true,
+              "--license-clarity-score": true,
+              "--license-diag": true,
+              "--license-text": true,
+              "--package": true,
+              "--processes": "2",
+              "--strip-root": true,
+              "--summary": true,
+              "--summary-key-files": true,
+              "--timeout": "1000.0",
+              "--url": true
+            },
+            "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+            "start_timestamp": "2019-03-13T034204.876857",
+            "end_timestamp": "2019-03-13T034223.180733",
+            "message": null,
+            "errors": [],
+            "extra_data": {
+              "files_count": 9
+            }
+          }
+        ],
+        "summary": {
+          "license_expressions": [
+            {
+              "value": "mit",
+              "count": 6
+            },
+            {
+              "value": null,
+              "count": 4
+            },
+            {
+              "value": "apache-2.0",
+              "count": 4
+            },
+            {
+              "value": "apache-2.0 OR mit",
+              "count": 2
+            },
+            {
+              "value": "free-unknown",
+              "count": 1
+            },
+            {
+              "value": "unknown",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 8
+            },
+            {
+              "value": "Copyright (c) The Rust Project",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 8
+            },
+            {
+              "value": "The Rust Project",
+              "count": 1
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 7
+            },
+            {
+              "value": "David Tolnay <dtolnay@gmail.com>",
+              "count": 2
+            }
+          ],
+          "programming_language": [
+            {
+              "value": null,
+              "count": 4
+            },
+            {
+              "value": "Rust",
+              "count": 4
+            },
+            {
+              "value": "Objective-C",
+              "count": 1
+            }
+          ],
+          "packages": []
+        },
+        "license_clarity_score": {
+          "score": 30,
+          "has_declared_license_in_key_files": true,
+          "file_level_license_and_copyright_coverage": 0,
+          "has_consistent_key_and_file_level_licenses": false,
+          "is_using_only_spdx_licenses": false,
+          "has_full_text_for_all_licenses": false
+        },
+        "summary_of_key_files": {
+          "license_expressions": [
+            {
+              "value": "apache-2.0",
+              "count": 4
+            },
+            {
+              "value": "mit",
+              "count": 4
+            },
+            {
+              "value": "free-unknown",
+              "count": 1
+            },
+            {
+              "value": "unknown",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 2
+            },
+            {
+              "value": "Copyright (c) The Rust Project",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 2
+            },
+            {
+              "value": "The Rust Project",
+              "count": 1
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 3
+            }
+          ],
+          "programming_language": [
+            {
+              "value": null,
+              "count": 2
+            },
+            {
+              "value": "Objective-C",
+              "count": 1
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": "Cargo.toml",
+            "type": "file",
+            "name": "Cargo.toml",
+            "base_name": "Cargo",
+            "extension": ".toml",
+            "size": 1068,
+            "date": "1970-01-01",
+            "sha1": "aa1aa2b801f0210b0b79f4d4dfe7a717a005dfb8",
+            "md5": "b36e076979cc697d7f5f8602e7bf48f8",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 17,
+                "end_line": 17,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT\"]"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 27,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 22,
+                "end_line": 22,
+                "matched_rule": {
+                  "identifier": "apache-2.0_or_mit4.RULE",
+                  "license_expression": "apache-2.0 OR mit",
+                  "licenses": [
+                    "apache-2.0",
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "license = \"MIT/Apache-2.0\""
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 22,
+                "end_line": 22,
+                "matched_rule": {
+                  "identifier": "apache-2.0_or_mit4.RULE",
+                  "license_expression": "apache-2.0 OR mit",
+                  "licenses": [
+                    "apache-2.0",
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "license = \"MIT/Apache-2.0\""
+              }
+            ],
+            "license_expressions": [
+              "mit",
+              "apache-2.0 OR mit"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "David Tolnay <dtolnay@gmail.com>",
+                "start_line": 16,
+                "end_line": 18
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "dtolnay@gmail.com",
+                "start_line": 16,
+                "end_line": 16
+              }
+            ],
+            "urls": [
+              {
+                "url": "https://docs.rs/quote/",
+                "start_line": 19,
+                "end_line": 19
+              },
+              {
+                "url": "https://github.com/dtolnay/quote",
+                "start_line": 23,
+                "end_line": 23
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml.orig",
+            "type": "file",
+            "name": "Cargo.toml.orig",
+            "base_name": "Cargo.toml",
+            "extension": ".orig",
+            "size": 747,
+            "date": "2018-07-22",
+            "sha1": "0fb532d4e9329c097bee636e72c3c7bf0fbc322f",
+            "md5": "f14b8708a62f2dcc66a940044c3712fb",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 27,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "apache-2.0_or_mit4.RULE",
+                  "license_expression": "apache-2.0 OR mit",
+                  "licenses": [
+                    "apache-2.0",
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "license = \"MIT/Apache-2.0\""
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "apache-2.0_or_mit4.RULE",
+                  "license_expression": "apache-2.0 OR mit",
+                  "licenses": [
+                    "apache-2.0",
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "license = \"MIT/Apache-2.0\""
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 11,
+                "end_line": 11,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT\"]"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0 OR mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "David Tolnay <dtolnay@gmail.com>",
+                "start_line": 4,
+                "end_line": 6
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "dtolnay@gmail.com",
+                "start_line": 4,
+                "end_line": 4
+              }
+            ],
+            "urls": [
+              {
+                "url": "https://github.com/dtolnay/quote",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://docs.rs/quote/",
+                "start_line": 8,
+                "end_line": 8
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-APACHE",
+            "type": "file",
+            "name": "LICENSE-APACHE",
+            "base_name": "LICENSE-APACHE",
+            "extension": "",
+            "size": 10847,
+            "date": "2016-09-03",
+            "sha1": "5798832c31663cedc1618d18544d445da0295229",
+            "md5": "1836efb2eb779966696f473ee8540542",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 100,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 1,
+                "end_line": 201,
+                "matched_rule": {
+                  "identifier": "apache-2.0.LICENSE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "1-hash",
+                  "rule_length": 1608,
+                  "matched_length": 1608,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License."
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://www.apache.org/licenses/",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 195,
+                "end_line": 195
+              }
+            ],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": true,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-MIT",
+            "type": "file",
+            "name": "LICENSE-MIT",
+            "base_name": "LICENSE-MIT",
+            "extension": "",
+            "size": 1071,
+            "date": "2016-09-03",
+            "sha1": "9a2b6b4ad55ec42cf19fc686c74668d3a6303ae7",
+            "md5": "0b29d505d9225d1f0815cbdcf602b901",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 100,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 3,
+                "end_line": 25,
+                "matched_rule": {
+                  "identifier": "mit.LICENSE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 163,
+                  "matched_length": 163,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Permission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE."
+              }
+            ],
+            "license_expressions": [
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright (c) 2016 The Rust Project",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "README.md",
+            "type": "file",
+            "name": "README.md",
+            "base_name": "README",
+            "extension": ".md",
+            "size": 5550,
+            "date": "2018-05-21",
+            "sha1": "1423e115c1e0353c62b4e9c8efc4f8180f911178",
+            "md5": "eab0f1246db3df7544065b7c577ba38f",
+            "mime_type": "text/x-c",
+            "file_type": "C source, UTF-8 Unicode text",
+            "programming_language": "Objective-C",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "unknown",
+                "score": 11,
+                "name": "Unknown license detected but not recognized",
+                "short_name": "unknown",
+                "category": "Unstated License",
+                "is_exception": false,
+                "owner": "Unspecified",
+                "homepage_url": "",
+                "text_url": "",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:unknown",
+                "spdx_license_key": "",
+                "spdx_url": "",
+                "start_line": 136,
+                "end_line": 136,
+                "matched_rule": {
+                  "identifier": "unknown_28.RULE",
+                  "license_expression": "unknown",
+                  "licenses": [
+                    "unknown"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 11
+                },
+                "matched_text": "Licensed under"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 27,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 138,
+                "end_line": 138,
+                "matched_rule": {
+                  "identifier": "apache-2.0_48.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "Apache License, Version 2.0 (["
+              },
+              {
+                "key": "apache-2.0",
+                "score": 44,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 138,
+                "end_line": 138,
+                "matched_rule": {
+                  "identifier": "apache-2.0_25.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 8,
+                  "matched_length": 8,
+                  "match_coverage": 100,
+                  "rule_relevance": 44
+                },
+                "matched_text": "http://www.apache.org/licenses/LICENSE-2.0)"
+              },
+              {
+                "key": "mit",
+                "score": 80,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 139,
+                "end_line": 139,
+                "matched_rule": {
+                  "identifier": "mit_14.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 80
+                },
+                "matched_text": "MIT license (["
+              },
+              {
+                "key": "mit",
+                "score": 22,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 139,
+                "end_line": 139,
+                "matched_rule": {
+                  "identifier": "mit_154.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 4,
+                  "matched_length": 4,
+                  "match_coverage": 100,
+                  "rule_relevance": 22
+                },
+                "matched_text": "LICENSE-MIT](LICENSE-MIT)"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 139,
+                "end_line": 139,
+                "matched_rule": {
+                  "identifier": "mit_82.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "http://opensource.org/licenses/MIT)"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 146,
+                "end_line": 146,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0"
+              },
+              {
+                "key": "free-unknown",
+                "score": 11,
+                "name": "Free unknown license detected but not recognized",
+                "short_name": "Free unknown",
+                "category": "Unstated License",
+                "is_exception": false,
+                "owner": "Unspecified",
+                "homepage_url": "",
+                "text_url": "",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:free-unknown",
+                "spdx_license_key": "",
+                "spdx_url": "",
+                "start_line": 147,
+                "end_line": 147,
+                "matched_rule": {
+                  "identifier": "free-unknown_31.RULE",
+                  "license_expression": "free-unknown",
+                  "licenses": [
+                    "free-unknown"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 11
+                },
+                "matched_text": "dual licensed"
+              }
+            ],
+            "license_expressions": [
+              "unknown",
+              "apache-2.0",
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit",
+              "apache-2.0",
+              "free-unknown"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://api.travis-ci.org/dtolnay/quote.svg?branch=master",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://travis-ci.org/dtolnay/quote",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://img.shields.io/crates/v/quote.svg",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://crates.io/crates/quote",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://img.shields.io/badge/api-rustdoc-blue.svg",
+                "start_line": 6,
+                "end_line": 6
+              },
+              {
+                "url": "https://docs.rs/quote",
+                "start_line": 6,
+                "end_line": 6
+              },
+              {
+                "url": "https://docs.rs/quote/0.6/quote/macro.quote.html",
+                "start_line": 11,
+                "end_line": 11
+              },
+              {
+                "url": "https://github.com/dtolnay/quote/releases",
+                "start_line": 34,
+                "end_line": 34
+              },
+              {
+                "url": "https://docs.rs/proc-macro2/0.4/proc_macro2/struct.TokenStream.html",
+                "start_line": 54,
+                "end_line": 54
+              },
+              {
+                "url": "https://docs.rs/quote/0.6/quote/trait.ToTokens.html",
+                "start_line": 60,
+                "end_line": 60
+              },
+              {
+                "url": "https://github.com/dtolnay/syn",
+                "start_line": 61,
+                "end_line": 61
+              },
+              {
+                "url": "https://docs.rs/proc-macro2/0.4/proc_macro2/struct.Span.html#method.call_site",
+                "start_line": 109,
+                "end_line": 109
+              },
+              {
+                "url": "https://docs.rs/quote/0.6/quote/macro.quote_spanned.html",
+                "start_line": 114,
+                "end_line": 114
+              },
+              {
+                "url": "https://github.com/dtolnay/quote/issues/7",
+                "start_line": 123,
+                "end_line": 123
+              },
+              {
+                "url": "https://github.com/dtolnay/quote/issues/8",
+                "start_line": 124,
+                "end_line": 124
+              },
+              {
+                "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 138,
+                "end_line": 138
+              },
+              {
+                "url": "http://opensource.org/licenses/MIT",
+                "start_line": 139,
+                "end_line": 139
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": true,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src",
+            "type": "directory",
+            "name": "src",
+            "base_name": "src",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 3,
+            "dirs_count": 0,
+            "size_count": 24279,
+            "scan_errors": []
+          },
+          {
+            "path": "src/ext.rs",
+            "type": "file",
+            "name": "ext.rs",
+            "base_name": "ext",
+            "extension": ".rs",
+            "size": 2856,
+            "date": "2018-05-17",
+            "sha1": "5caeb8b25737f6a43fd3a78b97cafa6890266aba",
+            "md5": "36673057a94e6e23bc45a001a2f18ea0",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/lib.rs",
+            "type": "file",
+            "name": "lib.rs",
+            "base_name": "lib",
+            "extension": ".rs",
+            "size": 16583,
+            "date": "2018-07-22",
+            "sha1": "ce8f375964eaa14cec0e6255f0be1752913d871b",
+            "md5": "047d504385ca7043c15fcc9f8c20b1be",
+            "mime_type": "text/x-c",
+            "file_type": "C source, UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://serde.rs/",
+                "start_line": 48,
+                "end_line": 48
+              },
+              {
+                "url": "https://docs.rs/quote/0.6.4",
+                "start_line": 95,
+                "end_line": 95
+              },
+              {
+                "url": "https://docs.rs/proc-macro2/0.4/proc_macro2/struct.TokenStream.html",
+                "start_line": 129,
+                "end_line": 129
+              },
+              {
+                "url": "https://github.com/dtolnay/syn",
+                "start_line": 141,
+                "end_line": 141
+              },
+              {
+                "url": "https://docs.rs/proc-macro2/0.4/proc_macro2/struct.Span.html#method.call_site",
+                "start_line": 160,
+                "end_line": 160
+              },
+              {
+                "url": "https://docs.rs/proc-macro2/0.4/proc_macro2/struct.Span.html",
+                "start_line": 220,
+                "end_line": 220
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/marker/trait.Sync.html",
+                "start_line": 264,
+                "end_line": 264
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/to_tokens.rs",
+            "type": "file",
+            "name": "to_tokens.rs",
+            "base_name": "to_tokens",
+            "extension": ".rs",
+            "size": 4840,
+            "date": "2018-06-03",
+            "sha1": "f8605b297ea0270a0d2f37037f2434cc221af0c8",
+            "md5": "74fdaa5bfdb35736473fcc4c5c513c3f",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests",
+            "type": "directory",
+            "name": "tests",
+            "base_name": "tests",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 1,
+            "dirs_count": 0,
+            "size_count": 6969,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test.rs",
+            "type": "file",
+            "name": "test.rs",
+            "base_name": "test",
+            "extension": ".rs",
+            "size": 6969,
+            "date": "2018-05-21",
+            "sha1": "23ed488bbc53132e9c7df99e6b74371065d10a1b",
+            "md5": "a1802d97cb7f9e1afdc71bbef99832b9",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/business/evidence/crate-quote-1.0.9.json
+++ b/test/business/evidence/crate-quote-1.0.9.json
@@ -1,0 +1,2534 @@
+{
+  "clearlydefined": {
+    "1.2.0": {
+      "_metadata": {
+        "type": "crate",
+        "url": "cd:/crate/cratesio/-/quote/1.0.9",
+        "fetchedAt": "2021-02-20T00:00:38.079Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:quote:revision:1.0.9:tool:clearlydefined:1.2.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:quote:revision:1.0.9:tool:clearlydefined",
+            "type": "collection"
+          },
+          "licensee": {
+            "href": "urn:crate:cratesio:-:quote:revision:1.0.9:tool:licensee",
+            "type": "collection"
+          },
+          "scancode": {
+            "href": "urn:crate:cratesio:-:quote:revision:1.0.9:tool:scancode",
+            "type": "collection"
+          },
+          "source": {
+            "href": "urn:git:github:dtolnay:quote:revision:68ebadbc1b4242531c5a78fbba01c648bd58c8e7",
+            "type": "resource"
+          }
+        },
+        "schemaVersion": "1.2.0",
+        "toolVersion": "1.0.0"
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-APACHE",
+          "token": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+        },
+        {
+          "path": "LICENSE-MIT",
+          "token": "c9a75f18b9ab2927829a208fc6aa2cf4e63b8420887ba29cdb265d6619ae82d5"
+        }
+      ],
+      "summaryInfo": {
+        "k": 119,
+        "count": 22,
+        "hashes": {
+          "sha1": "7e27d33619123ef5f370d3ed0b59a6180249823d",
+          "sha256": "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+        }
+      },
+      "files": [
+        {
+          "path": ".cargo_vcs_info.json",
+          "hashes": {
+            "sha1": "bcd5c9e40cb4069cf5023e66134ef0e97552d51f",
+            "sha256": "7edadcf89b60be70a7fc8e8455696813ff3b5c61a9f8527f2a7c0ba582056c4e"
+          }
+        },
+        {
+          "path": "Cargo.toml",
+          "hashes": {
+            "sha1": "a1bd63d8e34f21541e189762ec95c727c3df155e",
+            "sha256": "d1e6bb8b4ac54b84f367a4e1b46e7dca3b1a744017d8f7fa2f4c11a8730e657a"
+          }
+        },
+        {
+          "path": "Cargo.toml.orig",
+          "hashes": {
+            "sha1": "81889a27c92ed001ef7fd11946e135b9ed2f24c8",
+            "sha256": "86fcc2807586064b7abbcd12ce4d8fcbf458a2139dc6d1425421eb8432e1f96b"
+          }
+        },
+        {
+          "path": "LICENSE-APACHE",
+          "hashes": {
+            "sha1": "5798832c31663cedc1618d18544d445da0295229",
+            "sha256": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+          }
+        },
+        {
+          "path": "LICENSE-MIT",
+          "hashes": {
+            "sha1": "9a2b6b4ad55ec42cf19fc686c74668d3a6303ae7",
+            "sha256": "c9a75f18b9ab2927829a208fc6aa2cf4e63b8420887ba29cdb265d6619ae82d5"
+          }
+        },
+        {
+          "path": "README.md",
+          "hashes": {
+            "sha1": "f4532b28162e5566d5b62255dd866b66d64d9d23",
+            "sha256": "9209682116de84bb9cc7be6ccf44478b46b909c7857f9e186d90bcff522af864"
+          }
+        },
+        {
+          "path": "src/ext.rs",
+          "hashes": {
+            "sha1": "f280494b1a6e3abe5de7be48effc8aec025870cc",
+            "sha256": "a9fed3a1a4c9d3f2de717ba808af99291b995db2cbf8067f4b6927c39cc62bc6"
+          }
+        },
+        {
+          "path": "src/format.rs",
+          "hashes": {
+            "sha1": "be502e1863fcd06af55e5ab351121753f8b8242a",
+            "sha256": "a9c3e3a333c6dacf6e330d02b4c726862e273df1c2c6be6da199049cd1e521db"
+          }
+        },
+        {
+          "path": "src/ident_fragment.rs",
+          "hashes": {
+            "sha1": "31739ab5021eda8fb8fbb28dc89c4932daff9fac",
+            "sha256": "e66a63f6e9020f2639a71f120d627bc6cfd60081a6caf8a1d735b59ee2413d29"
+          }
+        },
+        {
+          "path": "src/lib.rs",
+          "hashes": {
+            "sha1": "67725e74a9edcf8f0c0a701e5c823573670d56d8",
+            "sha256": "2500b1955d139e5b467df046cda4f2837fb1edace838aa190020752ab79314c4"
+          }
+        },
+        {
+          "path": "src/runtime.rs",
+          "hashes": {
+            "sha1": "ec06709fda918dc06a959960f907f14b7f3e19a5",
+            "sha256": "f2d1fa6084764d98f98b96344cf675886a79b46a845c592e604f96bbde9aca07"
+          }
+        },
+        {
+          "path": "src/spanned.rs",
+          "hashes": {
+            "sha1": "073a4baaefb0d7975aa17c3d4abe747d8775d3ca",
+            "sha256": "adc0ed742ad17327c375879472d435cea168c208c303f53eb93cb2c0f10f3650"
+          }
+        },
+        {
+          "path": "src/to_tokens.rs",
+          "hashes": {
+            "sha1": "38907071bb30c9f84293bd4f1aaf32ce82c700d1",
+            "sha256": "e589c1643479a9003d4dd1d9fa63714042b106f1b16d8ea3903cfe2f73a020f5"
+          }
+        },
+        {
+          "path": "tests/compiletest.rs",
+          "hashes": {
+            "sha1": "dd4cae466417bc6d64d31c8be5b0425d1f117d76",
+            "sha256": "0a52a44786aea1c299c695bf948b2ed2081e4cc344e5c2cadceab4eb03d0010d"
+          }
+        },
+        {
+          "path": "tests/test.rs",
+          "hashes": {
+            "sha1": "5277660db814d801aeaacabda1a8a31f7e2cb7c9",
+            "sha256": "6eb200350fa78405d4fd920ecf71d226e258c61aa88f850750efa99e065f06d6"
+          }
+        },
+        {
+          "path": "tests/ui/does-not-have-iter-interpolated-dup.rs",
+          "hashes": {
+            "sha1": "762ca8eff76c7aa2c7167c8643d495aef3677aaa",
+            "sha256": "ad13eea21d4cdd2ab6c082f633392e1ff20fb0d1af5f2177041e0bf7f30da695"
+          }
+        },
+        {
+          "path": "tests/ui/does-not-have-iter-interpolated.rs",
+          "hashes": {
+            "sha1": "59ae43cdd13aec3f959cecb3d71a22d9f8d5f961",
+            "sha256": "83a5b3f240651adcbe4b6e51076d76d653ad439b37442cf4054f1fd3c073f3b7"
+          }
+        },
+        {
+          "path": "tests/ui/does-not-have-iter-separated.rs",
+          "hashes": {
+            "sha1": "cff3286cb5f558e2fc42580c579161c1a21ef26d",
+            "sha256": "fe413c48331d5e3a7ae5fef6a5892a90c72f610d54595879eb49d0a94154ba3f"
+          }
+        },
+        {
+          "path": "tests/ui/does-not-have-iter.rs",
+          "hashes": {
+            "sha1": "6f5435da5068ddb1d42dbb9bf712f5107553fab0",
+            "sha256": "09dc9499d861b63cebb0848b855b78e2dc9497bfde37ba6339f3625ae009a62f"
+          }
+        },
+        {
+          "path": "tests/ui/not-quotable.rs",
+          "hashes": {
+            "sha1": "4233d8b23de4bc52dd8f4c2d4812b96d38f8b652",
+            "sha256": "5759d0884943417609f28faadc70254a3e2fd3d9bd6ff7297a3fb70a77fafd8a"
+          }
+        },
+        {
+          "path": "tests/ui/not-repeatable.rs",
+          "hashes": {
+            "sha1": "526d7f3875490f86d3a2592b8ac2099668083f13",
+            "sha256": "a4b115c04e4e41049a05f5b69450503fbffeba031218b4189cb931839f7f9a9c"
+          }
+        },
+        {
+          "path": "tests/ui/wrong-type-span.rs",
+          "hashes": {
+            "sha1": "aae20d36be040ecc5c5b7d43964d9bde727ce016",
+            "sha256": "5f310cb7fde3ef51bad01e7f286d244e3b6e67396cd2ea7eab77275c9d902699"
+          }
+        }
+      ],
+      "manifest": {
+        "id": "quote",
+        "name": "quote",
+        "updated_at": "2021-02-12T06:50:01.443101+00:00",
+        "versions": [
+          338641,
+          316952,
+          249756,
+          242484,
+          240881,
+          236401,
+          218275,
+          170236,
+          169922,
+          169200,
+          162385,
+          143924,
+          129093,
+          116896,
+          114976,
+          104920,
+          104918,
+          103619,
+          102399,
+          100822,
+          94579,
+          93669,
+          93621,
+          93609,
+          89818,
+          87127,
+          87126,
+          76815,
+          76799,
+          76779,
+          47123,
+          46487,
+          45869,
+          42741,
+          42675,
+          38562,
+          38480,
+          38422,
+          38421,
+          38419,
+          36663,
+          36601,
+          35513,
+          35512,
+          35511,
+          35427,
+          35405,
+          35377,
+          35119,
+          35095,
+          35015,
+          34770,
+          34363,
+          33834,
+          33819,
+          33112,
+          33026
+        ],
+        "keywords": [
+          "syn"
+        ],
+        "categories": [
+          "development-tools::procedural-macro-helpers"
+        ],
+        "badges": [],
+        "created_at": "2016-09-03T05:42:05.484129+00:00",
+        "downloads": 44367650,
+        "recent_downloads": 7447279,
+        "max_version": "1.0.9",
+        "newest_version": "1.0.9",
+        "max_stable_version": "1.0.9",
+        "description": "Quasi-quoting macro quote!(...)",
+        "homepage": null,
+        "documentation": "https://docs.rs/quote/",
+        "repository": "https://github.com/dtolnay/quote",
+        "links": {
+          "version_downloads": "/api/v1/crates/quote/downloads",
+          "versions": null,
+          "owners": "/api/v1/crates/quote/owners",
+          "owner_team": "/api/v1/crates/quote/owner_team",
+          "owner_user": "/api/v1/crates/quote/owner_user",
+          "reverse_dependencies": "/api/v1/crates/quote/reverse_dependencies"
+        },
+        "exact_match": false
+      },
+      "registryData": {
+        "id": 338641,
+        "crate": "quote",
+        "num": "1.0.9",
+        "dl_path": "/api/v1/crates/quote/1.0.9/download",
+        "readme_path": "/api/v1/crates/quote/1.0.9/readme",
+        "updated_at": "2021-02-12T06:50:01.443101+00:00",
+        "created_at": "2021-02-12T06:50:01.443101+00:00",
+        "downloads": 391948,
+        "features": {
+          "default": [
+            "proc-macro"
+          ],
+          "proc-macro": [
+            "proc-macro2/proc-macro"
+          ]
+        },
+        "yanked": false,
+        "license": "MIT OR Apache-2.0",
+        "links": {
+          "dependencies": "/api/v1/crates/quote/1.0.9/dependencies",
+          "version_downloads": "/api/v1/crates/quote/1.0.9/downloads",
+          "authors": "/api/v1/crates/quote/1.0.9/authors"
+        },
+        "crate_size": 25042,
+        "published_by": {
+          "id": 3618,
+          "login": "dtolnay",
+          "name": "David Tolnay",
+          "avatar": "https://avatars2.githubusercontent.com/u/1940490?v=4",
+          "url": "https://github.com/dtolnay"
+        },
+        "audit_actions": [
+          {
+            "action": "publish",
+            "user": {
+              "id": 3618,
+              "login": "dtolnay",
+              "name": "David Tolnay",
+              "avatar": "https://avatars2.githubusercontent.com/u/1940490?v=4",
+              "url": "https://github.com/dtolnay"
+            },
+            "time": "2021-02-12T06:50:01.443101+00:00"
+          }
+        ]
+      },
+      "sourceInfo": {
+        "type": "git",
+        "provider": "github",
+        "namespace": "dtolnay",
+        "name": "quote",
+        "revision": "68ebadbc1b4242531c5a78fbba01c648bd58c8e7",
+        "url": null,
+        "path": null
+      }
+    }
+  },
+  "licensee": {
+    "9.13.0": {
+      "_metadata": {
+        "type": "licensee",
+        "url": "cd:/crate/cratesio/-/quote/1.0.9",
+        "fetchedAt": "2021-02-20T00:00:42.207Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:quote:revision:1.0.9:tool:licensee:9.13.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:quote:revision:1.0.9:tool:licensee",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "9.13.0",
+        "toolVersion": "9.11.0",
+        "processedAt": "2021-02-20T00:00:44.481Z"
+      },
+      "licensee": {
+        "version": "9.11.0",
+        "parameters": [
+          "--json",
+          "--no-readme"
+        ],
+        "output": {
+          "contentType": "application/json",
+          "content": {
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "spdx_id": "Apache-2.0",
+                "meta": {
+                  "title": "Apache License 2.0",
+                  "source": "https://spdx.org/licenses/Apache-2.0.html",
+                  "description": "A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.",
+                  "using": [
+                    {
+                      "Kubernetes": "https://github.com/kubernetes/kubernetes/blob/master/LICENSE"
+                    },
+                    {
+                      "PDF.js": "https://github.com/mozilla/pdf.js/blob/master/LICENSE"
+                    },
+                    {
+                      "Swift": "https://github.com/apple/swift/blob/master/LICENSE.txt"
+                    }
+                  ],
+                  "featured": true,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": "The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix."
+                },
+                "url": "http://choosealicense.com/licenses/apache-2.0/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "patent-use",
+                      "label": "Patent use",
+                      "description": "This license provides an express grant of patent rights from contributors."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    },
+                    {
+                      "tag": "document-changes",
+                      "label": "State changes",
+                      "description": "Changes made to the code must be documented."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "trademark-use",
+                      "label": "Trademark use",
+                      "description": "This license explicitly states that it does NOT grant trademark rights, even though licenses without such a statement probably do not grant any implicit trademark rights."
+                    },
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "mit",
+                "spdx_id": "MIT",
+                "meta": {
+                  "title": "MIT License",
+                  "source": "https://spdx.org/licenses/MIT.html",
+                  "description": "A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.",
+                  "using": [
+                    {
+                      "Babel": "https://github.com/babel/babel/blob/master/LICENSE"
+                    },
+                    {
+                      ".NET Core": "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+                    },
+                    {
+                      "Rails": "https://github.com/rails/rails/blob/master/MIT-LICENSE"
+                    }
+                  ],
+                  "featured": true,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": null
+                },
+                "url": "http://choosealicense.com/licenses/mit/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [
+                  {
+                    "name": "year",
+                    "description": "The current year"
+                  },
+                  {
+                    "name": "fullname",
+                    "description": "The full name or username of the repository owner"
+                  }
+                ],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "other",
+                "spdx_id": "NOASSERTION",
+                "meta": {
+                  "title": null,
+                  "source": null,
+                  "description": null,
+                  "how": null,
+                  "using": null,
+                  "featured": false,
+                  "hidden": true,
+                  "nickname": null,
+                  "note": null
+                },
+                "url": "http://choosealicense.com/licenses/other/",
+                "rules": {
+                  "permissions": [],
+                  "conditions": [],
+                  "limitations": []
+                },
+                "fields": [],
+                "other": true,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              }
+            ],
+            "matched_files": [
+              {
+                "filename": "LICENSE-APACHE",
+                "content": "                              Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
+                "content_hash": "ab3901051663cb8ee5dea9ebdff406ad136910e3",
+                "content_normalized": "terms and conditions for use, reproduction, and distribution - definitions. \"license\" shall mean the terms and conditions for use, reproduction, and distribution as defined by sections 1 through 9 of this document. \"licensor\" shall mean the copyright holder or entity authorized by the copyright holder that is granting the license. \"legal entity\" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. for the purposes of this definition, \"control\" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity. \"you\" (or \"your\") shall mean an individual or legal entity exercising permissions granted by this license. \"source\" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files. \"object\" form shall mean any form resulting from mechanical transformation or translation of a source form, including but not limited to compiled object code, generated documentation, and conversions to other media types. \"work\" shall mean the work of authorship, whether in source or object form, made available under the license, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the appendix below). \"derivative works\" shall mean any work, whether in source or object form, that is based on (or derived from) the work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. for the purposes of this license, derivative works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the work and derivative works thereof. \"contribution\" shall mean any work of authorship, including the original version of the work and any modifications or additions to that work or derivative works thereof, that is intentionally submitted to licensor for inclusion in the work by the copyright holder or by an individual or legal entity authorized to submit on behalf of the copyright holder. for the purposes of this definition, \"submitted\" means any form of electronic, verbal, or written communication sent to the licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the licensor for the purpose of discussing and improving the work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright holder as \"not a contribution.\" \"contributor\" shall mean licensor and any individual or legal entity on behalf of whom a contribution has been received by licensor and subsequently incorporated within the work. - grant of copyright license. subject to the terms and conditions of this license, each contributor hereby grants to you a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute the work and such derivative works in source or object form. - grant of patent license. subject to the terms and conditions of this license, each contributor hereby grants to you a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the work, where such license applies only to those patent claims licensable by such contributor that are necessarily infringed by their contribution(s) alone or by combination of their contribution(s) with the work to which such contribution(s) was submitted. if you institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the work or a contribution incorporated within the work constitutes direct or contributory patent infringement, then any patent licenses granted to you under this license for that work shall terminate as of the date such litigation is filed. - redistribution. you may reproduce and distribute copies of the work or derivative works thereof in any medium, with or without modifications, and in source or object form, provided that you meet the following conditions: * you must give any other recipients of the work or derivative works a copy of this license; and * you must cause any modified files to carry prominent notices stating that you changed the files; and * you must retain, in the source form of any derivative works that you distribute, all copyright, patent, trademark, and attribution notices from the source form of the work, excluding those notices that do not pertain to any part of the derivative works; and * if the work includes a \"notice\" text file as part of its distribution, then any derivative works that you distribute must include a readable copy of the attribution notices contained within such notice file, excluding those notices that do not pertain to any part of the derivative works, in at least one of the following places: within a notice text file distributed as part of the derivative works; within the source form or documentation, if provided along with the derivative works; or, within a display generated by the derivative works, if and wherever such third-party notices normally appear. the contents of the notice file are for informational purposes only and do not modify the license. you may add your own attribution notices within derivative works that you distribute, alongside or as an addendum to the notice text from the work, provided that such additional attribution notices cannot be construed as modifying the license. you may add your own copyright statement to your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of your modifications, or for any such derivative works as a whole, provided your use, reproduction, and distribution of the work otherwise complies with the conditions stated in this license. - submission of contributions. unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you to the licensor shall be under the terms and conditions of this license, without any additional terms or conditions. notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with licensor regarding such contributions. - trademarks. this license does not grant permission to use the trade names, trademarks, service marks, or product names of the licensor, except as required for reasonable and customary use in describing the origin of the work and reproducing the content of the notice file. - disclaimer of warranty. unless required by applicable law or agreed to in writing, licensor provides the work (and each contributor provides its contributions) on an \"as is\" basis, without warranties or conditions of any kind, either express or implied, including, without limitation, any warranties or conditions of title, non-infringement, merchantability, or fitness for a particular purpose. you are solely responsible for determining the appropriateness of using or redistributing the work and assume any risks associated with your exercise of permissions under this license. - limitation of liability. in no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any contributor be liable to you for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this license or out of the use or inability to use the work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such contributor has been advised of the possibility of such damages. - accepting warranty or additional liability. while redistributing the work or derivative works thereof, you may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this license. however, in accepting such obligations, you may act only on your own behalf and on your sole responsibility, not on behalf of any other contributor, and only if you agree to indemnify, defend, and hold each contributor harmless for any liability incurred by, or claims asserted against, such contributor by reason of your accepting any such warranty or additional liability.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "Apache-2.0"
+              },
+              {
+                "filename": "LICENSE-MIT",
+                "content": "Copyright (c) 2016 The Rust Project Developers\n\nPermission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE.\n",
+                "content_hash": "d64f3bb4282a97b37454b5bb96a8a264a3363dc3",
+                "content_normalized": "permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"software\"), to deal in the software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the software, and to permit persons to whom the software is furnished to do so, subject to the following conditions: the above copyright notice and this permission notice shall be included in all copies or substantial portions of the software. the software is provided \"as is\", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. in no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "MIT"
+              },
+              {
+                "filename": "Cargo.toml",
+                "content": "# THIS FILE IS AUTOMATICALLY GENERATED BY CARGO\n#\n# When uploading crates to the registry Cargo will automatically\n# \"normalize\" Cargo.toml files for maximal compatibility\n# with all versions of Cargo and also rewrite `path` dependencies\n# to registry (e.g., crates.io) dependencies\n#\n# If you believe there's an error in this file please file an\n# issue against the rust-lang/cargo repository. If you're\n# editing this file be aware that the upstream Cargo.toml\n# will likely look very different (and much more reasonable)\n\n[package]\nedition = \"2018\"\nname = \"quote\"\nversion = \"1.0.9\"\nauthors = [\"David Tolnay <dtolnay@gmail.com>\"]\ninclude = [\"Cargo.toml\", \"src/**/*.rs\", \"tests/**/*.rs\", \"README.md\", \"LICENSE-APACHE\", \"LICENSE-MIT\"]\ndescription = \"Quasi-quoting macro quote!(...)\"\ndocumentation = \"https://docs.rs/quote/\"\nreadme = \"README.md\"\nkeywords = [\"syn\"]\ncategories = [\"development-tools::procedural-macro-helpers\"]\nlicense = \"MIT OR Apache-2.0\"\nrepository = \"https://github.com/dtolnay/quote\"\n[package.metadata.docs.rs]\ntargets = [\"x86_64-unknown-linux-gnu\"]\n[dependencies.proc-macro2]\nversion = \"1.0.20\"\ndefault-features = false\n[dev-dependencies.rustversion]\nversion = \"1.0\"\n\n[dev-dependencies.trybuild]\nversion = \"1.0.19\"\nfeatures = [\"diff\"]\n\n[features]\ndefault = [\"proc-macro\"]\nproc-macro = [\"proc-macro2/proc-macro\"]\n",
+                "content_hash": null,
+                "content_normalized": null,
+                "matcher": {
+                  "name": "cargo",
+                  "confidence": 90
+                },
+                "matched_license": "NOASSERTION"
+              }
+            ]
+          }
+        }
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-APACHE",
+          "token": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+        },
+        {
+          "path": "LICENSE-MIT",
+          "token": "c9a75f18b9ab2927829a208fc6aa2cf4e63b8420887ba29cdb265d6619ae82d5"
+        },
+        {
+          "path": "Cargo.toml",
+          "token": "d1e6bb8b4ac54b84f367a4e1b46e7dca3b1a744017d8f7fa2f4c11a8730e657a"
+        }
+      ]
+    }
+  },
+  "scancode": {
+    "3.2.2": {
+      "_metadata": {
+        "type": "scancode",
+        "url": "cd:/crate/cratesio/-/quote/1.0.9",
+        "fetchedAt": "2021-02-20T00:00:41.438Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:quote:revision:1.0.9:tool:scancode:3.2.2",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:quote:revision:1.0.9:tool:scancode",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "3.2.2",
+        "toolVersion": "3.0.2",
+        "contentType": "application/json",
+        "releaseDate": "2021-02-12T06:50:01.443101+00:00",
+        "processedAt": "2021-02-20T00:01:17.047Z"
+      },
+      "content": {
+        "headers": [
+          {
+            "tool_name": "scancode-toolkit",
+            "tool_version": "3.0.2",
+            "options": {
+              "input": "/tmp/cd-PqVeL2/crate/quote-1.0.9",
+              "--classify": true,
+              "--copyright": true,
+              "--email": true,
+              "--generated": true,
+              "--info": true,
+              "--is-license-text": true,
+              "--json-pp": "/tmp/cd-fERobt",
+              "--license": true,
+              "--license-clarity-score": true,
+              "--license-diag": true,
+              "--license-text": true,
+              "--package": true,
+              "--processes": "2",
+              "--strip-root": true,
+              "--summary": true,
+              "--summary-key-files": true,
+              "--timeout": "1000.0",
+              "--url": true
+            },
+            "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+            "start_timestamp": "2021-02-20T000045.354711",
+            "end_timestamp": "2021-02-20T000114.339539",
+            "message": null,
+            "errors": [],
+            "extra_data": {
+              "files_count": 22
+            }
+          }
+        ],
+        "summary": {
+          "license_expressions": [
+            {
+              "value": null,
+              "count": 17
+            },
+            {
+              "value": "mit",
+              "count": 7
+            },
+            {
+              "value": "apache-2.0",
+              "count": 5
+            },
+            {
+              "value": "free-unknown",
+              "count": 1
+            },
+            {
+              "value": "unknown",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 21
+            },
+            {
+              "value": "Copyright (c) The Rust Project",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 21
+            },
+            {
+              "value": "The Rust Project",
+              "count": 1
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 20
+            },
+            {
+              "value": "David Tolnay <dtolnay@gmail.com>",
+              "count": 2
+            }
+          ],
+          "programming_language": [
+            {
+              "value": "Rust",
+              "count": 16
+            },
+            {
+              "value": null,
+              "count": 6
+            }
+          ],
+          "packages": []
+        },
+        "license_clarity_score": {
+          "score": 30,
+          "has_declared_license_in_key_files": true,
+          "file_level_license_and_copyright_coverage": 0,
+          "has_consistent_key_and_file_level_licenses": false,
+          "is_using_only_spdx_licenses": false,
+          "has_full_text_for_all_licenses": false
+        },
+        "summary_of_key_files": {
+          "license_expressions": [
+            {
+              "value": "apache-2.0",
+              "count": 3
+            },
+            {
+              "value": "mit",
+              "count": 3
+            },
+            {
+              "value": "free-unknown",
+              "count": 1
+            },
+            {
+              "value": "unknown",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 2
+            },
+            {
+              "value": "Copyright (c) The Rust Project",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 2
+            },
+            {
+              "value": "The Rust Project",
+              "count": 1
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 3
+            }
+          ],
+          "programming_language": [
+            {
+              "value": null,
+              "count": 3
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": ".cargo_vcs_info.json",
+            "type": "file",
+            "name": ".cargo_vcs_info.json",
+            "base_name": ".cargo_vcs_info",
+            "extension": ".json",
+            "size": 74,
+            "date": "1970-01-01",
+            "sha1": "bcd5c9e40cb4069cf5023e66134ef0e97552d51f",
+            "md5": "09f40d8410c9f9283e73ea4393af2be9",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml",
+            "type": "file",
+            "name": "Cargo.toml",
+            "base_name": "Cargo",
+            "extension": ".toml",
+            "size": 1332,
+            "date": "1970-01-01",
+            "sha1": "a1bd63d8e34f21541e189762ec95c727c3df155e",
+            "md5": "9498d7fd322639cf1035ca5ed3c6a5ac",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 18,
+                "end_line": 18,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT\"]"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 24,
+                "end_line": 24,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "license = \"MIT"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 24,
+                "end_line": 24,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0\""
+              }
+            ],
+            "license_expressions": [
+              "mit",
+              "mit",
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "David Tolnay <dtolnay@gmail.com>",
+                "start_line": 17,
+                "end_line": 19
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "dtolnay@gmail.com",
+                "start_line": 17,
+                "end_line": 17
+              }
+            ],
+            "urls": [
+              {
+                "url": "https://docs.rs/quote/",
+                "start_line": 20,
+                "end_line": 20
+              },
+              {
+                "url": "https://github.com/dtolnay/quote",
+                "start_line": 25,
+                "end_line": 25
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml.orig",
+            "type": "file",
+            "name": "Cargo.toml.orig",
+            "base_name": "Cargo.toml",
+            "extension": ".orig",
+            "size": 991,
+            "date": "1970-01-01",
+            "sha1": "81889a27c92ed001ef7fd11946e135b9ed2f24c8",
+            "md5": "b953309c133f4035dec461c050238a38",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "license = \"MIT"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0\""
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 12,
+                "end_line": 12,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT\"]"
+              }
+            ],
+            "license_expressions": [
+              "mit",
+              "apache-2.0",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "David Tolnay <dtolnay@gmail.com>",
+                "start_line": 4,
+                "end_line": 6
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "dtolnay@gmail.com",
+                "start_line": 4,
+                "end_line": 4
+              }
+            ],
+            "urls": [
+              {
+                "url": "https://github.com/dtolnay/quote",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://docs.rs/quote/",
+                "start_line": 8,
+                "end_line": 8
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-APACHE",
+            "type": "file",
+            "name": "LICENSE-APACHE",
+            "base_name": "LICENSE-APACHE",
+            "extension": "",
+            "size": 10847,
+            "date": "1970-01-01",
+            "sha1": "5798832c31663cedc1618d18544d445da0295229",
+            "md5": "1836efb2eb779966696f473ee8540542",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 100,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 1,
+                "end_line": 201,
+                "matched_rule": {
+                  "identifier": "apache-2.0.LICENSE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "1-hash",
+                  "rule_length": 1608,
+                  "matched_length": 1608,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License."
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://www.apache.org/licenses/",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 195,
+                "end_line": 195
+              }
+            ],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": true,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-MIT",
+            "type": "file",
+            "name": "LICENSE-MIT",
+            "base_name": "LICENSE-MIT",
+            "extension": "",
+            "size": 1071,
+            "date": "1970-01-01",
+            "sha1": "9a2b6b4ad55ec42cf19fc686c74668d3a6303ae7",
+            "md5": "0b29d505d9225d1f0815cbdcf602b901",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 100,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 3,
+                "end_line": 25,
+                "matched_rule": {
+                  "identifier": "mit.LICENSE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 163,
+                  "matched_length": 163,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Permission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE."
+              }
+            ],
+            "license_expressions": [
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright (c) 2016 The Rust Project",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "README.md",
+            "type": "file",
+            "name": "README.md",
+            "base_name": "README",
+            "extension": ".md",
+            "size": 10056,
+            "date": "1970-01-01",
+            "sha1": "f4532b28162e5566d5b62255dd866b66d64d9d23",
+            "md5": "a18509b5d43fdba76c70c3368c40cb96",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text, with very long lines",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "unknown",
+                "score": 11,
+                "name": "Unknown license detected but not recognized",
+                "short_name": "unknown",
+                "category": "Unstated License",
+                "is_exception": false,
+                "owner": "Unspecified",
+                "homepage_url": "",
+                "text_url": "",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:unknown",
+                "spdx_license_key": "",
+                "spdx_url": "",
+                "start_line": 251,
+                "end_line": 251,
+                "matched_rule": {
+                  "identifier": "unknown_28.RULE",
+                  "license_expression": "unknown",
+                  "licenses": [
+                    "unknown"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 11
+                },
+                "matched_text": "Licensed under"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 27,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 251,
+                "end_line": 252,
+                "matched_rule": {
+                  "identifier": "apache-2.0_48.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "Apache License, Version\n2.0</"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 252,
+                "end_line": 252,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT\">"
+              },
+              {
+                "key": "mit",
+                "score": 80,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 252,
+                "end_line": 252,
+                "matched_rule": {
+                  "identifier": "mit_14.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 80
+                },
+                "matched_text": "MIT license</"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 259,
+                "end_line": 259,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0"
+              },
+              {
+                "key": "free-unknown",
+                "score": 11,
+                "name": "Free unknown license detected but not recognized",
+                "short_name": "Free unknown",
+                "category": "Unstated License",
+                "is_exception": false,
+                "owner": "Unspecified",
+                "homepage_url": "",
+                "text_url": "",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:free-unknown",
+                "spdx_license_key": "",
+                "spdx_url": "",
+                "start_line": 260,
+                "end_line": 260,
+                "matched_rule": {
+                  "identifier": "free-unknown_31.RULE",
+                  "license_expression": "free-unknown",
+                  "licenses": [
+                    "free-unknown"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 11
+                },
+                "matched_text": "dual licensed"
+              }
+            ],
+            "license_expressions": [
+              "unknown",
+              "apache-2.0",
+              "mit",
+              "mit",
+              "apache-2.0",
+              "free-unknown"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://img.shields.io/badge/github-dtolnay/quote-8da0cb?style=for-the-badge&labelColor=555555&logo=github",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://github.com/dtolnay/quote",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://img.shields.io/crates/v/quote.svg?style=for-the-badge&color=fc8d62&logo=rust",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://crates.io/crates/quote",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://img.shields.io/badge/docs.rs-quote-66c2a5?style=for-the-badge&labelColor=555555&logoColor=white&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K",
+                "start_line": 6,
+                "end_line": 6
+              },
+              {
+                "url": "https://docs.rs/quote",
+                "start_line": 6,
+                "end_line": 6
+              },
+              {
+                "url": "https://img.shields.io/github/workflow/status/dtolnay/quote/CI/master?style=for-the-badge",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://github.com/dtolnay/quote/actions?query=branch:master",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://docs.rs/quote/1.0/quote/macro.quote.html",
+                "start_line": 12,
+                "end_line": 12
+              },
+              {
+                "url": "https://github.com/dtolnay/quote/releases",
+                "start_line": 38,
+                "end_line": 38
+              },
+              {
+                "url": "https://docs.rs/proc-macro2/1.0/proc_macro2/struct.TokenStream.html",
+                "start_line": 48,
+                "end_line": 48
+              },
+              {
+                "url": "https://docs.rs/quote/1.0/quote/trait.ToTokens.html",
+                "start_line": 54,
+                "end_line": 54
+              },
+              {
+                "url": "https://github.com/dtolnay/syn",
+                "start_line": 55,
+                "end_line": 55
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/convert/trait.From.html",
+                "start_line": 118,
+                "end_line": 118
+              },
+              {
+                "url": "https://docs.rs/proc-macro2/1.0/proc_macro2/struct.Span.html#method.call_site",
+                "start_line": 224,
+                "end_line": 224
+              },
+              {
+                "url": "https://docs.rs/quote/1.0/quote/macro.quote_spanned.html",
+                "start_line": 229,
+                "end_line": 229
+              },
+              {
+                "url": "https://github.com/rust-lang/rustfmt",
+                "start_line": 244,
+                "end_line": 244
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": true,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src",
+            "type": "directory",
+            "name": "src",
+            "base_name": "src",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 7,
+            "dirs_count": 0,
+            "size_count": 69046,
+            "scan_errors": []
+          },
+          {
+            "path": "src/ext.rs",
+            "type": "file",
+            "name": "ext.rs",
+            "base_name": "ext",
+            "extension": ".rs",
+            "size": 2740,
+            "date": "1970-01-01",
+            "sha1": "f280494b1a6e3abe5de7be48effc8aec025870cc",
+            "md5": "10effccef92589e96de505587b24a614",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/format.rs",
+            "type": "file",
+            "name": "format.rs",
+            "base_name": "format",
+            "extension": ".rs",
+            "size": 4700,
+            "date": "1970-01-01",
+            "sha1": "be502e1863fcd06af55e5ab351121753f8b8242a",
+            "md5": "26647f77acac45c4207136b9c1c847ed",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/ident_fragment.rs",
+            "type": "file",
+            "name": "ident_fragment.rs",
+            "base_name": "ident_fragment",
+            "extension": ".rs",
+            "size": 2248,
+            "date": "1970-01-01",
+            "sha1": "31739ab5021eda8fb8fbb28dc89c4932daff9fac",
+            "md5": "fc082740330acf0544ab3be0b2920ee2",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/lib.rs",
+            "type": "file",
+            "name": "lib.rs",
+            "base_name": "lib",
+            "extension": ".rs",
+            "size": 39020,
+            "date": "1970-01-01",
+            "sha1": "67725e74a9edcf8f0c0a701e5c823573670d56d8",
+            "md5": "1a064d4827949d1b64999508463b1d53",
+            "mime_type": "text/x-c",
+            "file_type": "C source, UTF-8 Unicode text, with very long lines",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/dtolnay/quote",
+                "start_line": 1,
+                "end_line": 1
+              },
+              {
+                "url": "https://crates.io/crates/quote",
+                "start_line": 1,
+                "end_line": 1
+              },
+              {
+                "url": "https://docs.rs/quote",
+                "start_line": 1,
+                "end_line": 1
+              },
+              {
+                "url": "https://img.shields.io/badge/github-8da0cb?style=for-the-badge&labelColor=555555&logo=github",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "https://img.shields.io/badge/crates.io-fc8d62?style=for-the-badge&labelColor=555555&logo=rust",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logoColor=white&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://serde.rs/",
+                "start_line": 48,
+                "end_line": 48
+              },
+              {
+                "url": "https://docs.rs/quote/1.0.9",
+                "start_line": 84,
+                "end_line": 84
+              },
+              {
+                "url": "https://docs.rs/proc-macro2/1.0/proc_macro2/struct.TokenStream.html",
+                "start_line": 124,
+                "end_line": 124
+              },
+              {
+                "url": "https://github.com/dtolnay/syn",
+                "start_line": 138,
+                "end_line": 138
+              },
+              {
+                "url": "https://docs.rs/proc-macro2/1.0/proc_macro2/struct.Span.html#method.call_site",
+                "start_line": 159,
+                "end_line": 159
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/convert/trait.From.html",
+                "start_line": 185,
+                "end_line": 185
+              },
+              {
+                "url": "https://docs.rs/syn/1.0/syn/struct.Index.html",
+                "start_line": 427,
+                "end_line": 427
+              },
+              {
+                "url": "https://docs.rs/proc-macro2/1.0/proc_macro2/struct.Span.html",
+                "start_line": 501,
+                "end_line": 501
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/marker/trait.Sync.html",
+                "start_line": 544,
+                "end_line": 544
+              },
+              {
+                "url": "https://github.com/dtolnay/quote/issues/130",
+                "start_line": 772,
+                "end_line": 772
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/runtime.rs",
+            "type": "file",
+            "name": "runtime.rs",
+            "base_name": "runtime",
+            "extension": ".rs",
+            "size": 13862,
+            "date": "1970-01-01",
+            "sha1": "ec06709fda918dc06a959960f907f14b7f3e19a5",
+            "md5": "1b8065b863899380fee08deb0570cfc8",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/spanned.rs",
+            "type": "file",
+            "name": "spanned.rs",
+            "base_name": "spanned",
+            "extension": ".rs",
+            "size": 1064,
+            "date": "1970-01-01",
+            "sha1": "073a4baaefb0d7975aa17c3d4abe747d8775d3ca",
+            "md5": "e2c93e5eae5913f84e358f87ef960f51",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/rust/issues/43081",
+                "start_line": 24,
+                "end_line": 24
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/to_tokens.rs",
+            "type": "file",
+            "name": "to_tokens.rs",
+            "base_name": "to_tokens",
+            "extension": ".rs",
+            "size": 5412,
+            "date": "1970-01-01",
+            "sha1": "38907071bb30c9f84293bd4f1aaf32ce82c700d1",
+            "md5": "424c8dab18cd712f0fc6a62301f92c1f",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests",
+            "type": "directory",
+            "name": "tests",
+            "base_name": "tests",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 9,
+            "dirs_count": 1,
+            "size_count": 11902,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/compiletest.rs",
+            "type": "file",
+            "name": "compiletest.rs",
+            "base_name": "compiletest",
+            "extension": ".rs",
+            "size": 140,
+            "date": "1970-01-01",
+            "sha1": "dd4cae466417bc6d64d31c8be5b0425d1f117d76",
+            "md5": "4052cbaafd7be320632dd211b150324c",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test.rs",
+            "type": "file",
+            "name": "test.rs",
+            "base_name": "test",
+            "extension": ".rs",
+            "size": 10912,
+            "date": "1970-01-01",
+            "sha1": "5277660db814d801aeaacabda1a8a31f7e2cb7c9",
+            "md5": "605cec6eaab25af9095cf01e660f3463",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/dtolnay/quote/issues/130",
+                "start_line": 441,
+                "end_line": 441
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/ui",
+            "type": "directory",
+            "name": "ui",
+            "base_name": "ui",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 7,
+            "dirs_count": 0,
+            "size_count": 850,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/ui/does-not-have-iter-interpolated-dup.rs",
+            "type": "file",
+            "name": "does-not-have-iter-interpolated-dup.rs",
+            "base_name": "does-not-have-iter-interpolated-dup",
+            "extension": ".rs",
+            "size": 209,
+            "date": "1970-01-01",
+            "sha1": "762ca8eff76c7aa2c7167c8643d495aef3677aaa",
+            "md5": "4af5b8637b260f967ebb6209b35f7b6b",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/ui/does-not-have-iter-interpolated.rs",
+            "type": "file",
+            "name": "does-not-have-iter-interpolated.rs",
+            "base_name": "does-not-have-iter-interpolated",
+            "extension": ".rs",
+            "size": 201,
+            "date": "1970-01-01",
+            "sha1": "59ae43cdd13aec3f959cecb3d71a22d9f8d5f961",
+            "md5": "f499a5d30f5c374a38fd0e0bb19d812c",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/ui/does-not-have-iter-separated.rs",
+            "type": "file",
+            "name": "does-not-have-iter-separated.rs",
+            "base_name": "does-not-have-iter-separated",
+            "extension": ".rs",
+            "size": 55,
+            "date": "1970-01-01",
+            "sha1": "cff3286cb5f558e2fc42580c579161c1a21ef26d",
+            "md5": "22fa0e7d2d543677ff07bd695a8e8ebe",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/ui/does-not-have-iter.rs",
+            "type": "file",
+            "name": "does-not-have-iter.rs",
+            "base_name": "does-not-have-iter",
+            "extension": ".rs",
+            "size": 54,
+            "date": "1970-01-01",
+            "sha1": "6f5435da5068ddb1d42dbb9bf712f5107553fab0",
+            "md5": "697f359b4f316a6c6742eabc3b020795",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/ui/not-quotable.rs",
+            "type": "file",
+            "name": "not-quotable.rs",
+            "base_name": "not-quotable",
+            "extension": ".rs",
+            "size": 119,
+            "date": "1970-01-01",
+            "sha1": "4233d8b23de4bc52dd8f4c2d4812b96d38f8b652",
+            "md5": "e21a4dceebc62a96b53806ef0c866f92",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/ui/not-repeatable.rs",
+            "type": "file",
+            "name": "not-repeatable.rs",
+            "base_name": "not-repeatable",
+            "extension": ".rs",
+            "size": 106,
+            "date": "1970-01-01",
+            "sha1": "526d7f3875490f86d3a2592b8ac2099668083f13",
+            "md5": "f45895fa35d3a198e35b8ac162c333a9",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/ui/wrong-type-span.rs",
+            "type": "file",
+            "name": "wrong-type-span.rs",
+            "base_name": "wrong-type-span",
+            "extension": ".rs",
+            "size": 106,
+            "date": "1970-01-01",
+            "sha1": "aae20d36be040ecc5c5b7d43964d9bde727ce016",
+            "md5": "41213ca216ab40c504d51a632b2bb935",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/business/evidence/crate-rand-0.8.2.json
+++ b/test/business/evidence/crate-rand-0.8.2.json
@@ -1,0 +1,6404 @@
+{
+  "clearlydefined": {
+    "1.2.0": {
+      "_metadata": {
+        "type": "crate",
+        "url": "cd:/crate/cratesio/-/rand/0.8.3",
+        "fetchedAt": "2021-01-29T16:36:40.196Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:rand:revision:0.8.3:tool:clearlydefined:1.2.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:rand:revision:0.8.3:tool:clearlydefined",
+            "type": "collection"
+          },
+          "licensee": {
+            "href": "urn:crate:cratesio:-:rand:revision:0.8.3:tool:licensee",
+            "type": "collection"
+          },
+          "scancode": {
+            "href": "urn:crate:cratesio:-:rand:revision:0.8.3:tool:scancode",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "1.2.0",
+        "toolVersion": "1.0.0"
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-APACHE",
+          "token": "aaff376532ea30a0cd5330b9502ad4a4c8bf769c539c87ffe78819d188a18ebf"
+        },
+        {
+          "path": "LICENSE-MIT",
+          "token": "209fbbe0ad52d9235e37badf9cadfe4dbdc87203179c0899e738b39ade42177b"
+        }
+      ],
+      "summaryInfo": {
+        "k": 356,
+        "count": 33,
+        "hashes": {
+          "sha1": "14a0fece98e71d67b0dfae263d2bcf816b84b907",
+          "sha256": "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+        }
+      },
+      "files": [
+        {
+          "path": ".cargo_vcs_info.json",
+          "hashes": {
+            "sha1": "306ddd6832babf3feb98cf6891af675b72e8020f",
+            "sha256": "4d27f6bed9fc0a31c054d32f88cf1a9da28f7943578d1b5e86f3604a4dc82f23"
+          }
+        },
+        {
+          "path": "CHANGELOG.md",
+          "hashes": {
+            "sha1": "192ed3855dfcbda89a866885ff8d8d86e6a95c11",
+            "sha256": "163f660fdd260ee2aade895b64c86f6cecf1974d4c46f67496828095876f30a3"
+          }
+        },
+        {
+          "path": "COPYRIGHT",
+          "hashes": {
+            "sha1": "f14afa20edce530124d39cd56312c7781c19b267",
+            "sha256": "90eb64f0279b0d9432accfa6023ff803bc4965212383697eee27a0f426d5f8d5"
+          }
+        },
+        {
+          "path": "Cargo.lock",
+          "hashes": {
+            "sha1": "225d1b6dd2d07ea3c61e9f62eac7726f12c7f509",
+            "sha256": "24336b1ee91200de8c16cd04f9ec2bf082d8ab0da54f8ad6de7b0825d8bcc403"
+          }
+        },
+        {
+          "path": "Cargo.toml",
+          "hashes": {
+            "sha1": "e59c734f509ddb1f602b0f413bd5aaae44ab3f76",
+            "sha256": "001ce77abe9a414eb711cbe40932b9ee88822e63613798ca3976909951bf4c5f"
+          }
+        },
+        {
+          "path": "Cargo.toml.orig",
+          "hashes": {
+            "sha1": "9f18d7eae0a53bea82d8fb10bb1f1b7b831bbb31",
+            "sha256": "fbb0cf79e9202eb9ddae4bc604ce1d037b01fea86e6178e44e2633ff25785df0"
+          }
+        },
+        {
+          "path": "LICENSE-APACHE",
+          "hashes": {
+            "sha1": "e9b475b5dccf14bd66d72dd12a04db75eaad1a9e",
+            "sha256": "aaff376532ea30a0cd5330b9502ad4a4c8bf769c539c87ffe78819d188a18ebf"
+          }
+        },
+        {
+          "path": "LICENSE-MIT",
+          "hashes": {
+            "sha1": "d74ad13f1402c35008f22bc588a6b8199ed164d3",
+            "sha256": "209fbbe0ad52d9235e37badf9cadfe4dbdc87203179c0899e738b39ade42177b"
+          }
+        },
+        {
+          "path": "README.md",
+          "hashes": {
+            "sha1": "8a9c43485f697ec93f229ba2fde1b130ce1a94da",
+            "sha256": "779a810c27e3b55bcb1341228340590515851052906c2af288780b8702016deb"
+          }
+        },
+        {
+          "path": "src/distributions/bernoulli.rs",
+          "hashes": {
+            "sha1": "767f1f55ba3cae24e3ff916dff6cf60c0a9d5fb9",
+            "sha256": "ceaefa810de9e65de9b9bb98985092f01c76166f83c48476b2d2261ed612f49e"
+          }
+        },
+        {
+          "path": "src/distributions/float.rs",
+          "hashes": {
+            "sha1": "0a9c59eb3485e6a09b72bebc2a585b070c3edad5",
+            "sha256": "e5c22bb31a2297ed554553b671084d9a41f110d414b52eaa24fd6e7759bccfc7"
+          }
+        },
+        {
+          "path": "src/distributions/integer.rs",
+          "hashes": {
+            "sha1": "05f5f4cf805acaee8644ff6abccb41d0693ef340",
+            "sha256": "16948664d86a506ed8a401d602238e08ae6f74744b4a656167f8c2a70f7455bb"
+          }
+        },
+        {
+          "path": "src/distributions/mod.rs",
+          "hashes": {
+            "sha1": "aa83850d175acfc35eec0332ae7747255e301f0e",
+            "sha256": "8fcee0cf3434343a7cb3a6b0be03191d202cbc6375e8516700411513831c5775"
+          }
+        },
+        {
+          "path": "src/distributions/other.rs",
+          "hashes": {
+            "sha1": "90b6a1f54731db7726fc96c3740b215d552c2458",
+            "sha256": "e99827bdfe6da505b837dcd6dfb831a02d8b57e0c5cdaacbd086184c07f6ebc1"
+          }
+        },
+        {
+          "path": "src/distributions/uniform.rs",
+          "hashes": {
+            "sha1": "261b02e1a719f39b5a7213c4a8c2088e58fa1790",
+            "sha256": "ab6bfd4a4e7df146d501fa56dffaf9f91cfe10e1f4ac4cbc8920b583a1005da1"
+          }
+        },
+        {
+          "path": "src/distributions/utils.rs",
+          "hashes": {
+            "sha1": "f6766b5517011a372220771c22cd22803c85e931",
+            "sha256": "97bd9e385c3aa24acb2765f0190983c46f34dcd436eec6ced69a7124d1faf41f"
+          }
+        },
+        {
+          "path": "src/distributions/weighted.rs",
+          "hashes": {
+            "sha1": "e0a21b836a6626cbb9bd9f55122c5efa22984abf",
+            "sha256": "049ed1ce8dcb66ebfa34bdfebea6c355732b099c564e047c7151e0c4e8fb3114"
+          }
+        },
+        {
+          "path": "src/distributions/weighted_index.rs",
+          "hashes": {
+            "sha1": "e240ba387e11673f82fd95782a42f13d42bbff36",
+            "sha256": "f44fe6231c192205515797a759456b5add0b8edd687e89186dcdc200028a965b"
+          }
+        },
+        {
+          "path": "src/lib.rs",
+          "hashes": {
+            "sha1": "44b2c086c8c08d14225fcfe8d354567fd8f64b10",
+            "sha256": "4a1daba8371978292f85c52aba3cb357e68c46ef9b56b33e6e7e33d62308bb28"
+          }
+        },
+        {
+          "path": "src/prelude.rs",
+          "hashes": {
+            "sha1": "0b2fd921f741e73e3f0c7638ceee2d2aa2dea937",
+            "sha256": "2f2132d74ce9f70513224baad3b161b1585a639f9136a254cdb0e7f8ffceb25b"
+          }
+        },
+        {
+          "path": "src/rng.rs",
+          "hashes": {
+            "sha1": "ad8fc141e342ab72ce827d6acaadda725c542c0d",
+            "sha256": "50196ee1cad553e7793537de033eb7745a75aafec65e06a46594a4bcadf1a85b"
+          }
+        },
+        {
+          "path": "src/rngs/adapter/mod.rs",
+          "hashes": {
+            "sha1": "41426d1297e2da1c88e953bcb7ce429ce00250a4",
+            "sha256": "1f21d310f3626c7f2d94770e47782db0e71995e1c15363a6d5623f5785b5f14f"
+          }
+        },
+        {
+          "path": "src/rngs/adapter/read.rs",
+          "hashes": {
+            "sha1": "438e6dab2f2aa6251fb9228d98fb574a5aade8f0",
+            "sha256": "f67300fb9d855355d138a198af70438618335ec39d5d0a4973afbdb54c0cbba6"
+          }
+        },
+        {
+          "path": "src/rngs/adapter/reseeding.rs",
+          "hashes": {
+            "sha1": "be5c1b45c03b1924e5d494ff0112137a4fc0c014",
+            "sha256": "59ce72e2a5586ab06c4f29792d46edb4d22de462c5a77476d3492ac3c9a7195e"
+          }
+        },
+        {
+          "path": "src/rngs/mock.rs",
+          "hashes": {
+            "sha1": "876ed6114bf1d8df3e75d4e835a6b05de8fb48a8",
+            "sha256": "0074abe04cf84b1263218f50140931fa4188f4e0a43fe3205556a00e4c36d1e9"
+          }
+        },
+        {
+          "path": "src/rngs/mod.rs",
+          "hashes": {
+            "sha1": "c8b9c1079aa56d76ace61797ee0f2e75e53c9f90",
+            "sha256": "a6dec3d19e1726ba05f130ab9b20719d79177b8c1584cdd7b5f37b9996315ed3"
+          }
+        },
+        {
+          "path": "src/rngs/small.rs",
+          "hashes": {
+            "sha1": "cd04db45de1314700fd057e90ba744a60061890d",
+            "sha256": "a8e61c6e0bad62f06db1325e3b93eff1d4aa9e82cf0316fbfd02da2ef5b85b83"
+          }
+        },
+        {
+          "path": "src/rngs/std.rs",
+          "hashes": {
+            "sha1": "87908f87bc5a42d26e5fcaabb729d1d6ebf4051d",
+            "sha256": "0fe31f4a9b3f440801965d777b455b066516044b0c83cb69547c17cbd21bf57e"
+          }
+        },
+        {
+          "path": "src/rngs/thread.rs",
+          "hashes": {
+            "sha1": "c9e192f174213fccfded8b6459655d107d38c00d",
+            "sha256": "3249717e00a4cc944829c6ffde289053ae08bc6159dc90a2d397bf583c2cd8ad"
+          }
+        },
+        {
+          "path": "src/rngs/xoshiro128plusplus.rs",
+          "hashes": {
+            "sha1": "5ae88ea9dd0eaa23dda2ff312cf095944d8e6c97",
+            "sha256": "deca2450a2d5ea826ca6f47cccb9ee06daeac38799a30a107b78c5dae78ae30c"
+          }
+        },
+        {
+          "path": "src/rngs/xoshiro256plusplus.rs",
+          "hashes": {
+            "sha1": "32cf284da477446a0eb2f3bbf7c40b3ae9f7236d",
+            "sha256": "429c1fdf5013589e253932198352ac9ce72870b32b08402a8f5d8d6aec31b6cb"
+          }
+        },
+        {
+          "path": "src/seq/index.rs",
+          "hashes": {
+            "sha1": "90443fd13ef17d6f320491ab2d4ddf45a3c47341",
+            "sha256": "04ecf55d9ddc19df16f140107828855061798f9ad2833b1c033c9018b8109f7c"
+          }
+        },
+        {
+          "path": "src/seq/mod.rs",
+          "hashes": {
+            "sha1": "ac21abf968955cea3e917581b6709a1e6245cb83",
+            "sha256": "44ff77a2a31ac578ca36b825624f3cff1a48557e84967ee602bc7bc557a3ea31"
+          }
+        }
+      ],
+      "manifest": {
+        "id": "rand",
+        "name": "rand",
+        "updated_at": "2021-01-26T08:50:46.191427+00:00",
+        "versions": [
+          331918,
+          326822,
+          322376,
+          316445,
+          202916,
+          176558,
+          176021,
+          158945,
+          158711,
+          155960,
+          154971,
+          130460,
+          127212,
+          125555,
+          125521,
+          119212,
+          117808,
+          115893,
+          113343,
+          130165,
+          102932,
+          99538,
+          98022,
+          97193,
+          95831,
+          93664,
+          92908,
+          89893,
+          86584,
+          130166,
+          127355,
+          127151,
+          104133,
+          76564,
+          74803,
+          73853,
+          130167,
+          79903,
+          78200,
+          76563,
+          75606,
+          70485,
+          67607,
+          60891,
+          38564,
+          22300,
+          20439,
+          17884,
+          15268,
+          14687,
+          13851,
+          9238,
+          7843,
+          7771,
+          7710,
+          7648,
+          7248,
+          7239,
+          7237,
+          6964,
+          6704,
+          6029,
+          5937,
+          5252,
+          4371,
+          4362
+        ],
+        "keywords": [
+          "rng",
+          "random"
+        ],
+        "categories": [
+          "no-std",
+          "algorithms"
+        ],
+        "badges": [],
+        "created_at": "2015-02-03T06:17:14.147783+00:00",
+        "downloads": 53039996,
+        "recent_downloads": 7188123,
+        "max_version": "0.8.3",
+        "newest_version": "0.8.3",
+        "max_stable_version": "0.8.3",
+        "description": "Random number generators and other randomness functionality.\n",
+        "homepage": "https://rust-random.github.io/book",
+        "documentation": "https://docs.rs/rand",
+        "repository": "https://github.com/rust-random/rand",
+        "links": {
+          "version_downloads": "/api/v1/crates/rand/downloads",
+          "versions": null,
+          "owners": "/api/v1/crates/rand/owners",
+          "owner_team": "/api/v1/crates/rand/owner_team",
+          "owner_user": "/api/v1/crates/rand/owner_user",
+          "reverse_dependencies": "/api/v1/crates/rand/reverse_dependencies"
+        },
+        "exact_match": false
+      },
+      "registryData": {
+        "id": 331918,
+        "crate": "rand",
+        "num": "0.8.3",
+        "dl_path": "/api/v1/crates/rand/0.8.3/download",
+        "readme_path": "/api/v1/crates/rand/0.8.3/readme",
+        "updated_at": "2021-01-26T08:50:46.191427+00:00",
+        "created_at": "2021-01-26T08:50:46.191427+00:00",
+        "downloads": 80335,
+        "features": {
+          "alloc": [
+            "rand_core/alloc"
+          ],
+          "default": [
+            "std",
+            "std_rng"
+          ],
+          "getrandom": [
+            "rand_core/getrandom"
+          ],
+          "nightly": [],
+          "serde1": [
+            "serde"
+          ],
+          "simd_support": [
+            "packed_simd"
+          ],
+          "small_rng": [],
+          "std": [
+            "rand_core/std",
+            "rand_chacha/std",
+            "alloc",
+            "getrandom",
+            "libc"
+          ],
+          "std_rng": [
+            "rand_chacha",
+            "rand_hc"
+          ]
+        },
+        "yanked": false,
+        "license": "MIT OR Apache-2.0",
+        "links": {
+          "dependencies": "/api/v1/crates/rand/0.8.3/dependencies",
+          "version_downloads": "/api/v1/crates/rand/0.8.3/downloads",
+          "authors": "/api/v1/crates/rand/0.8.3/authors"
+        },
+        "crate_size": 84493,
+        "published_by": {
+          "id": 1234,
+          "login": "dhardy",
+          "name": "Diggory Hardy",
+          "avatar": "https://avatars1.githubusercontent.com/u/134893?v=4",
+          "url": "https://github.com/dhardy"
+        },
+        "audit_actions": [
+          {
+            "action": "publish",
+            "user": {
+              "id": 1234,
+              "login": "dhardy",
+              "name": "Diggory Hardy",
+              "avatar": "https://avatars1.githubusercontent.com/u/134893?v=4",
+              "url": "https://github.com/dhardy"
+            },
+            "time": "2021-01-26T08:50:46.191427+00:00"
+          }
+        ]
+      }
+    }
+  },
+  "scancode": {
+    "3.2.2": {
+      "_metadata": {
+        "type": "scancode",
+        "url": "cd:/crate/cratesio/-/rand/0.8.3",
+        "fetchedAt": "2021-01-29T16:36:41.274Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:rand:revision:0.8.3:tool:scancode:3.2.2",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:rand:revision:0.8.3:tool:scancode",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "3.2.2",
+        "toolVersion": "3.0.2",
+        "contentType": "application/json",
+        "releaseDate": "2021-01-26T08:50:46.191427+00:00",
+        "processedAt": "2021-01-29T16:37:27.394Z"
+      },
+      "content": {
+        "headers": [
+          {
+            "tool_name": "scancode-toolkit",
+            "tool_version": "3.0.2",
+            "options": {
+              "input": "/tmp/cd-ct4m29/crate/rand-0.8.3",
+              "--classify": true,
+              "--copyright": true,
+              "--email": true,
+              "--generated": true,
+              "--info": true,
+              "--is-license-text": true,
+              "--json-pp": "/tmp/cd-T6PMVE",
+              "--license": true,
+              "--license-clarity-score": true,
+              "--license-diag": true,
+              "--license-text": true,
+              "--package": true,
+              "--processes": "2",
+              "--strip-root": true,
+              "--summary": true,
+              "--summary-key-files": true,
+              "--timeout": "1000.0",
+              "--url": true
+            },
+            "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+            "start_timestamp": "2021-01-29T163644.825340",
+            "end_timestamp": "2021-01-29T163725.285480",
+            "message": null,
+            "errors": [],
+            "extra_data": {
+              "files_count": 33
+            }
+          }
+        ],
+        "summary": {
+          "license_expressions": [
+            {
+              "value": "mit",
+              "count": 61
+            },
+            {
+              "value": "apache-2.0",
+              "count": 24
+            },
+            {
+              "value": "mit OR apache-2.0",
+              "count": 5
+            },
+            {
+              "value": null,
+              "count": 3
+            },
+            {
+              "value": "apache-2.0 OR mit",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": "Copyright",
+              "count": 24
+            },
+            {
+              "value": null,
+              "count": 8
+            },
+            {
+              "value": "Copyright (c) The Rust Project",
+              "count": 7
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 26
+            },
+            {
+              "value": "The Rust Project",
+              "count": 7
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 31
+            },
+            {
+              "value": "The Rand Project Developers', The Rust Project",
+              "count": 2
+            }
+          ],
+          "programming_language": [
+            {
+              "value": "Rust",
+              "count": 24
+            },
+            {
+              "value": null,
+              "count": 7
+            },
+            {
+              "value": "Objective-C",
+              "count": 2
+            }
+          ],
+          "packages": []
+        },
+        "license_clarity_score": {
+          "score": 64,
+          "has_declared_license_in_key_files": true,
+          "file_level_license_and_copyright_coverage": 0.17,
+          "has_consistent_key_and_file_level_licenses": true,
+          "is_using_only_spdx_licenses": true,
+          "has_full_text_for_all_licenses": false
+        },
+        "summary_of_key_files": {
+          "license_expressions": [
+            {
+              "value": "apache-2.0",
+              "count": 3
+            },
+            {
+              "value": "mit",
+              "count": 3
+            },
+            {
+              "value": "apache-2.0 OR mit",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 3
+            },
+            {
+              "value": "Copyright (c) The Rust Project",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 3
+            },
+            {
+              "value": "The Rust Project",
+              "count": 1
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 4
+            }
+          ],
+          "programming_language": [
+            {
+              "value": null,
+              "count": 3
+            },
+            {
+              "value": "Objective-C",
+              "count": 1
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": ".cargo_vcs_info.json",
+            "type": "file",
+            "name": ".cargo_vcs_info.json",
+            "base_name": ".cargo_vcs_info",
+            "extension": ".json",
+            "size": 74,
+            "date": "1970-01-01",
+            "sha1": "306ddd6832babf3feb98cf6891af675b72e8020f",
+            "md5": "9dc7581a698d4b3562e19fe05c8d8ac0",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.lock",
+            "type": "file",
+            "name": "Cargo.lock",
+            "base_name": "Cargo",
+            "extension": ".lock",
+            "size": 4868,
+            "date": "1970-01-01",
+            "sha1": "225d1b6dd2d07ea3c61e9f62eac7726f12c7f509",
+            "md5": "ae99b8f23c9a8361edfdf098dbb00136",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/crates.io-index",
+                "start_line": 6,
+                "end_line": 6
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml",
+            "type": "file",
+            "name": "Cargo.toml",
+            "base_name": "Cargo",
+            "extension": ".toml",
+            "size": 2284,
+            "date": "1970-01-01",
+            "sha1": "e59c734f509ddb1f602b0f413bd5aaae44ab3f76",
+            "md5": "66a3b58708328c21b47e523df1ca11da",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 26,
+                "end_line": 26,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "license = \"MIT"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 26,
+                "end_line": 26,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0\""
+              }
+            ],
+            "license_expressions": [
+              "mit",
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "The Rand Project Developers', The Rust Project",
+                "start_line": 17,
+                "end_line": 20
+              }
+            ],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://rust-random.github.io/book",
+                "start_line": 21,
+                "end_line": 21
+              },
+              {
+                "url": "https://docs.rs/rand",
+                "start_line": 22,
+                "end_line": 22
+              },
+              {
+                "url": "https://github.com/rust-random/rand",
+                "start_line": 27,
+                "end_line": 27
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml.orig",
+            "type": "file",
+            "name": "Cargo.toml.orig",
+            "base_name": "Cargo.toml",
+            "extension": ".orig",
+            "size": 2814,
+            "date": "1970-01-01",
+            "sha1": "9f18d7eae0a53bea82d8fb10bb1f1b7b831bbb31",
+            "md5": "7de287ce7b0651fd734850173f56e61a",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "license = \"MIT"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0\""
+              }
+            ],
+            "license_expressions": [
+              "mit",
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "The Rand Project Developers', The Rust Project",
+                "start_line": 4,
+                "end_line": 6
+              }
+            ],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-random/rand",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://docs.rs/rand",
+                "start_line": 8,
+                "end_line": 8
+              },
+              {
+                "url": "https://rust-random.github.io/book",
+                "start_line": 9,
+                "end_line": 9
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "CHANGELOG.md",
+            "type": "file",
+            "name": "CHANGELOG.md",
+            "base_name": "CHANGELOG",
+            "extension": ".md",
+            "size": 23327,
+            "date": "1970-01-01",
+            "sha1": "192ed3855dfcbda89a866885ff8d8d86e6a95c11",
+            "md5": "81ce8ef4fb9862fff254a7d06bb42800",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Objective-C",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://keepachangelog.com/en/1.0.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://semver.org/spec/v2.0.0.html",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://rust-random.github.io/book/update.html",
+                "start_line": 9,
+                "end_line": 9
+              },
+              {
+                "url": "https://docs.rs/getrandom/latest",
+                "start_line": 29,
+                "end_line": 29
+              },
+              {
+                "url": "https://github.com/rust-random/getrandom",
+                "start_line": 138,
+                "end_line": 138
+              },
+              {
+                "url": "https://github.com/rust-lang-nursery/rand",
+                "start_line": 202,
+                "end_line": 202
+              },
+              {
+                "url": "https://github.com/rust-random/rand",
+                "start_line": 203,
+                "end_line": 203
+              },
+              {
+                "url": "https://rust-random.github.io/book",
+                "start_line": 204,
+                "end_line": 204
+              },
+              {
+                "url": "https://github.com/rust-random/book",
+                "start_line": 205,
+                "end_line": 205
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "COPYRIGHT",
+            "type": "file",
+            "name": "COPYRIGHT",
+            "base_name": "COPYRIGHT",
+            "extension": "",
+            "size": 569,
+            "date": "1970-01-01",
+            "sha1": "f14afa20edce530124d39cd56312c7781c19b267",
+            "md5": "86438b2332d07437f7ddc2fe9fe4edd2",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 97.83,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 6,
+                "end_line": 9,
+                "matched_rule": {
+                  "identifier": "apache-2.0_or_mit7.RULE",
+                  "license_expression": "apache-2.0 OR mit",
+                  "licenses": [
+                    "apache-2.0",
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 45,
+                  "matched_length": 45,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Except as otherwise noted (below and/or in individual files), [Rand] is\nlicensed under the Apache License, Version 2.0 <LICENSE-APACHE> or\n<http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n<LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option."
+              },
+              {
+                "key": "mit",
+                "score": 97.83,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 9,
+                "matched_rule": {
+                  "identifier": "apache-2.0_or_mit7.RULE",
+                  "license_expression": "apache-2.0 OR mit",
+                  "licenses": [
+                    "apache-2.0",
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 45,
+                  "matched_length": 45,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Except as otherwise noted (below and/or in individual files), [Rand] is\nlicensed under the Apache License, Version 2.0 <LICENSE-APACHE> or\n<http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n<LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option."
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0 OR mit"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 8,
+                "end_line": 8
+              },
+              {
+                "url": "http://opensource.org/licenses/MIT",
+                "start_line": 9,
+                "end_line": 9
+              }
+            ],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-APACHE",
+            "type": "file",
+            "name": "LICENSE-APACHE",
+            "base_name": "LICENSE-APACHE",
+            "extension": "",
+            "size": 10849,
+            "date": "1970-01-01",
+            "sha1": "e9b475b5dccf14bd66d72dd12a04db75eaad1a9e",
+            "md5": "9ee8a33d3852b5a3d70f661d27bf3cc5",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 27,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 1,
+                "end_line": 2,
+                "matched_rule": {
+                  "identifier": "apache-2.0_48.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "Apache License\n                        Version 2.0,"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 44,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 191,
+                "end_line": 191,
+                "matched_rule": {
+                  "identifier": "apache-2.0_63.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 12,
+                  "matched_length": 8,
+                  "match_coverage": 66.67,
+                  "rule_relevance": 66
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 ("
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 195,
+                "end_line": 195
+              }
+            ],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-MIT",
+            "type": "file",
+            "name": "LICENSE-MIT",
+            "base_name": "LICENSE-MIT",
+            "extension": "",
+            "size": 1117,
+            "date": "1970-01-01",
+            "sha1": "d74ad13f1402c35008f22bc588a6b8199ed164d3",
+            "md5": "08cf50287469d314ddbee33f572260a7",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 100,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 26,
+                "matched_rule": {
+                  "identifier": "mit.LICENSE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 163,
+                  "matched_length": 163,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Permission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE."
+              }
+            ],
+            "license_expressions": [
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 2
+              },
+              {
+                "value": "Copyright (c) 2014 The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "README.md",
+            "type": "file",
+            "name": "README.md",
+            "base_name": "README",
+            "extension": ".md",
+            "size": 7079,
+            "date": "1970-01-01",
+            "sha1": "8a9c43485f697ec93f229ba2fde1b130ce1a94da",
+            "md5": "a3682aa960802bdac05f955267df07df",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Objective-C",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 39.11,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 144,
+                "end_line": 144,
+                "matched_rule": {
+                  "identifier": "mit_4.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 8,
+                  "matched_length": 8,
+                  "match_coverage": 100,
+                  "rule_relevance": 44
+                },
+                "matched_text": "distributed under the terms of [both] the MIT license"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 27,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 145,
+                "end_line": 145,
+                "matched_rule": {
+                  "identifier": "apache-2.0_48.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "Apache License (Version 2.0)."
+              },
+              {
+                "key": "mit",
+                "score": 22,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 147,
+                "end_line": 147,
+                "matched_rule": {
+                  "identifier": "mit_154.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 4,
+                  "matched_length": 4,
+                  "match_coverage": 100,
+                  "rule_relevance": 22
+                },
+                "matched_text": "LICENSE-MIT](LICENSE-MIT),"
+              }
+            ],
+            "license_expressions": [
+              "mit",
+              "apache-2.0",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-random/rand/workflows/Tests/badge.svg?event=push",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "https://github.com/rust-random/rand/actions",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "https://img.shields.io/crates/v/rand.svg",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://crates.io/crates/rand",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://img.shields.io/badge/book-master-yellow.svg",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://rust-random.github.io/book",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://img.shields.io/badge/api-master-yellow.svg",
+                "start_line": 6,
+                "end_line": 6
+              },
+              {
+                "url": "https://rust-random.github.io/rand/rand",
+                "start_line": 6,
+                "end_line": 6
+              },
+              {
+                "url": "https://docs.rs/rand/badge.svg",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://docs.rs/rand",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://img.shields.io/badge/rustc-1.36+-lightgray.svg",
+                "start_line": 8,
+                "end_line": 8
+              },
+              {
+                "url": "https://github.com/rust-random/rand#rust-version-requirements",
+                "start_line": 8,
+                "end_line": 8
+              },
+              {
+                "url": "https://docs.rs/rand/*/rand/trait.Rng.html",
+                "start_line": 12,
+                "end_line": 12
+              },
+              {
+                "url": "https://docs.rs/rand/*/rand/seq/trait.SliceRandom.html",
+                "start_line": 13,
+                "end_line": 13
+              },
+              {
+                "url": "https://docs.rs/rand/*/rand/seq/trait.IteratorRandom.html",
+                "start_line": 14,
+                "end_line": 14
+              },
+              {
+                "url": "https://crates.io/crates/getrandom",
+                "start_line": 15,
+                "end_line": 15
+              },
+              {
+                "url": "https://docs.rs/rand/*/rand/fn.thread_rng.html",
+                "start_line": 16,
+                "end_line": 16
+              },
+              {
+                "url": "https://crates.io/crates/rand_core",
+                "start_line": 17,
+                "end_line": 17
+              },
+              {
+                "url": "https://rust-random.github.io/book/crates.html",
+                "start_line": 18,
+                "end_line": 18
+              },
+              {
+                "url": "https://rust-random.github.io/book/guide-rngs.html#cryptographically-secure-pseudo-random-number-generators-csprngs",
+                "start_line": 19,
+                "end_line": 19
+              },
+              {
+                "url": "https://rust-random.github.io/book/guide-rngs.html#basic-pseudo-random-number-generators-prngs",
+                "start_line": 20,
+                "end_line": 20
+              },
+              {
+                "url": "https://docs.rs/rand/*/rand/distributions/index.html",
+                "start_line": 21,
+                "end_line": 21
+              },
+              {
+                "url": "https://docs.rs/rand_distr",
+                "start_line": 23,
+                "end_line": 23
+              },
+              {
+                "url": "https://docs.rs/statrs/0.13.0/statrs",
+                "start_line": 24,
+                "end_line": 24
+              },
+              {
+                "url": "https://rust-random.github.io/book/portability.html",
+                "start_line": 25,
+                "end_line": 25
+              },
+              {
+                "url": "https://crates.io/crates/fastrand",
+                "start_line": 35,
+                "end_line": 35
+              },
+              {
+                "url": "https://crates.io/crates/oorandom",
+                "start_line": 36,
+                "end_line": 36
+              },
+              {
+                "url": "https://rust-random.github.io/rand",
+                "start_line": 44,
+                "end_line": 44
+              },
+              {
+                "url": "https://rust-random.github.io/book/update.html",
+                "start_line": 76,
+                "end_line": 76
+              },
+              {
+                "url": "https://semver.org/",
+                "start_line": 79,
+                "end_line": 79
+              },
+              {
+                "url": "https://github.com/dtolnay/semver-trick",
+                "start_line": 84,
+                "end_line": 84
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": true,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src",
+            "type": "directory",
+            "name": "src",
+            "base_name": "src",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 24,
+            "dirs_count": 4,
+            "size_count": 286528,
+            "scan_errors": []
+          },
+          {
+            "path": "src/lib.rs",
+            "type": "file",
+            "name": "lib.rs",
+            "base_name": "lib",
+            "extension": ".rs",
+            "size": 6744,
+            "date": "1970-01-01",
+            "sha1": "44b2c086c8c08d14225fcfe8d354567fd8f64b10",
+            "md5": "ad22a59105b8b5ff725c8fbad64c61a8",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 2
+              },
+              {
+                "value": "Copyright 2013-2017 The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6
+              },
+              {
+                "url": "https://rust-random.github.io/book",
+                "start_line": 41,
+                "end_line": 41
+              },
+              {
+                "url": "https://www.rust-lang.org/favicon.ico",
+                "start_line": 45,
+                "end_line": 45
+              },
+              {
+                "url": "https://rust-random.github.io/rand/",
+                "start_line": 46,
+                "end_line": 46
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/prelude.rs",
+            "type": "file",
+            "name": "prelude.rs",
+            "base_name": "prelude",
+            "extension": ".rs",
+            "size": 1284,
+            "date": "1970-01-01",
+            "sha1": "0b2fd921f741e73e3f0c7638ceee2d2aa2dea937",
+            "md5": "71df077fc92f534bf530d19ddb8873f5",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 95.83,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 3,
+                "end_line": 7,
+                "matched_rule": {
+                  "identifier": "mit_or_apache-2.0_2.RULE",
+                  "license_expression": "mit OR apache-2.0",
+                  "licenses": [
+                    "mit",
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 48,
+                  "matched_length": 46,
+                  "match_coverage": 95.83,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// [https]://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or [https]://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+              },
+              {
+                "key": "apache-2.0",
+                "score": 95.83,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 7,
+                "matched_rule": {
+                  "identifier": "mit_or_apache-2.0_2.RULE",
+                  "license_expression": "mit OR apache-2.0",
+                  "licenses": [
+                    "mit",
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 48,
+                  "matched_length": 46,
+                  "match_coverage": 95.83,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// [https]://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or [https]://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+              }
+            ],
+            "license_expressions": [
+              "mit OR apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rng.rs",
+            "type": "file",
+            "name": "rng.rs",
+            "base_name": "rng",
+            "extension": ".rs",
+            "size": 18381,
+            "date": "1970-01-01",
+            "sha1": "ad8fc141e342ab72ce827d6acaadda725c542c0d",
+            "md5": "6a509a43e62f7f47ff40d5624d53d1da",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 2
+              },
+              {
+                "value": "Copyright 2013-2017 The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6
+              },
+              {
+                "url": "https://rust-random.github.io/book/portability.html",
+                "start_line": 311,
+                "end_line": 311
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/distributions",
+            "type": "directory",
+            "name": "distributions",
+            "base_name": "distributions",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 9,
+            "dirs_count": 0,
+            "size_count": 145547,
+            "scan_errors": []
+          },
+          {
+            "path": "src/distributions/bernoulli.rs",
+            "type": "file",
+            "name": "bernoulli.rs",
+            "base_name": "bernoulli",
+            "extension": ".rs",
+            "size": 7328,
+            "date": "1970-01-01",
+            "sha1": "767f1f55ba3cae24e3ff916dff6cf60c0a9d5fb9",
+            "md5": "6c11d2fcbd846ae6b91d21c51b94206c",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/distributions/float.rs",
+            "type": "file",
+            "name": "float.rs",
+            "base_name": "float",
+            "extension": ".rs",
+            "size": 12583,
+            "date": "1970-01-01",
+            "sha1": "0a9c59eb3485e6a09b72bebc2a585b070c3edad5",
+            "md5": "2b334c526b6fde2894da54b388a06b13",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/distributions/integer.rs",
+            "type": "file",
+            "name": "integer.rs",
+            "base_name": "integer",
+            "extension": ".rs",
+            "size": 9047,
+            "date": "1970-01-01",
+            "sha1": "05f5f4cf805acaee8644ff6abccb41d0693ef340",
+            "md5": "c49938a0fd62738e8ece437aa8eaf086",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 95.83,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 3,
+                "end_line": 7,
+                "matched_rule": {
+                  "identifier": "mit_or_apache-2.0_2.RULE",
+                  "license_expression": "mit OR apache-2.0",
+                  "licenses": [
+                    "mit",
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 48,
+                  "matched_length": 46,
+                  "match_coverage": 95.83,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// [https]://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or [https]://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+              },
+              {
+                "key": "apache-2.0",
+                "score": 95.83,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 7,
+                "matched_rule": {
+                  "identifier": "mit_or_apache-2.0_2.RULE",
+                  "license_expression": "mit OR apache-2.0",
+                  "licenses": [
+                    "mit",
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 48,
+                  "matched_length": 46,
+                  "match_coverage": 95.83,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// [https]://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or [https]://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+              }
+            ],
+            "license_expressions": [
+              "mit OR apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/distributions/mod.rs",
+            "type": "file",
+            "name": "mod.rs",
+            "base_name": "mod",
+            "extension": ".rs",
+            "size": 13585,
+            "date": "1970-01-01",
+            "sha1": "aa83850d175acfc35eec0332ae7747255e301f0e",
+            "md5": "952bf7da18a5d2fbd5b17e518df976f9",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 44.31,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_175.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 13,
+                  "matched_length": 8,
+                  "match_coverage": 61.54,
+                  "rule_relevance": 72
+                },
+                "matched_text": "the MIT license\n// <[LICENSE]-[MIT] [or] https://opensource.org/licenses/MIT>,"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 2
+              },
+              {
+                "value": "Copyright 2013-2017 The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6
+              },
+              {
+                "url": "https://en.wikipedia.org/wiki/Probability_distribution",
+                "start_line": 88,
+                "end_line": 88
+              },
+              {
+                "url": "https://crates.io/crates/rand_distr",
+                "start_line": 89,
+                "end_line": 89
+              },
+              {
+                "url": "https://crates.io/crates/statrs",
+                "start_line": 90,
+                "end_line": 90
+              },
+              {
+                "url": "https://rust-random.github.io/book/portability.html",
+                "start_line": 141,
+                "end_line": 141
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/distributions/other.rs",
+            "type": "file",
+            "name": "other.rs",
+            "base_name": "other",
+            "extension": ".rs",
+            "size": 9923,
+            "date": "1970-01-01",
+            "sha1": "90b6a1f54731db7726fc96c3740b215d552c2458",
+            "md5": "b153495266f8810e1761fd0a8c0c73f6",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://en.wikipedia.org/wiki/Password_strength",
+                "start_line": 55,
+                "end_line": 55
+              },
+              {
+                "url": "https://en.wikipedia.org/wiki/Diceware",
+                "start_line": 56,
+                "end_line": 56
+              },
+              {
+                "url": "https://github.com/rust-lang/rust/issues/24066",
+                "start_line": 186,
+                "end_line": 186
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/distributions/uniform.rs",
+            "type": "file",
+            "name": "uniform.rs",
+            "base_name": "uniform",
+            "extension": ".rs",
+            "size": 61828,
+            "date": "1970-01-01",
+            "sha1": "261b02e1a719f39b5a7213c4a8c2088e58fa1790",
+            "md5": "256685a351d0f767d5cfd06bf5f93f57",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright 2017 The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/distributions/utils.rs",
+            "type": "file",
+            "name": "utils.rs",
+            "base_name": "utils",
+            "extension": ".rs",
+            "size": 13599,
+            "date": "1970-01-01",
+            "sha1": "f6766b5517011a372220771c22cd22803c85e931",
+            "md5": "d159bbb0de6aeca0f6fd94e7c6b2ca03",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/distributions/weighted.rs",
+            "type": "file",
+            "name": "weighted.rs",
+            "base_name": "weighted",
+            "extension": ".rs",
+            "size": 1578,
+            "date": "1970-01-01",
+            "sha1": "e0a21b836a6626cbb9bd9f55122c5efa22984abf",
+            "md5": "679d3746cdfb933d4f59da04743e7971",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/distributions/weighted_index.rs",
+            "type": "file",
+            "name": "weighted_index.rs",
+            "base_name": "weighted_index",
+            "extension": ".rs",
+            "size": 16076,
+            "date": "1970-01-01",
+            "sha1": "e240ba387e11673f82fd95782a42f13d42bbff36",
+            "md5": "d3c8c2734df1a4c5f9e8aaa203bef17b",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://docs.rs/rand_distr/*/rand_distr/weighted_alias/index.html",
+                "start_line": 35,
+                "end_line": 35
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs",
+            "type": "directory",
+            "name": "rngs",
+            "base_name": "rngs",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 10,
+            "dirs_count": 1,
+            "size_count": 45622,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/mock.rs",
+            "type": "file",
+            "name": "mock.rs",
+            "base_name": "mock",
+            "extension": ".rs",
+            "size": 2309,
+            "date": "1970-01-01",
+            "sha1": "876ed6114bf1d8df3e75d4e835a6b05de8fb48a8",
+            "md5": "e3d24bd9f6f3763ce0cde476ec9ab732",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/mod.rs",
+            "type": "file",
+            "name": "mod.rs",
+            "base_name": "mod",
+            "extension": ".rs",
+            "size": 5961,
+            "date": "1970-01-01",
+            "sha1": "c8b9c1079aa56d76ace61797ee0f2e75e53c9f90",
+            "md5": "900c31e9ea917ec8cccff19755abd787",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://github.com/rust-random/rand/issues/699",
+                "start_line": 78,
+                "end_line": 78
+              },
+              {
+                "url": "https://crates.io/crates/rdrand",
+                "start_line": 92,
+                "end_line": 92
+              },
+              {
+                "url": "https://crates.io/crates/rand_jitter",
+                "start_line": 93,
+                "end_line": 93
+              },
+              {
+                "url": "https://crates.io/crates/rand_chacha",
+                "start_line": 94,
+                "end_line": 94
+              },
+              {
+                "url": "https://crates.io/crates/rand_pcg",
+                "start_line": 95,
+                "end_line": 95
+              },
+              {
+                "url": "https://crates.io/crates/rand_xoshiro",
+                "start_line": 96,
+                "end_line": 96
+              },
+              {
+                "url": "https://crates.io/keywords/rng",
+                "start_line": 97,
+                "end_line": 97
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/small.rs",
+            "type": "file",
+            "name": "small.rs",
+            "base_name": "small",
+            "extension": ".rs",
+            "size": 4312,
+            "date": "1970-01-01",
+            "sha1": "cd04db45de1314700fd057e90ba744a60061890d",
+            "md5": "526ecd6ffa771a07b56d27e1290aaf3f",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://rust-random.github.io/book/guide-rngs.html",
+                "start_line": 36,
+                "end_line": 36
+              },
+              {
+                "url": "https://crates.io/crates/rand_chacha",
+                "start_line": 77,
+                "end_line": 77
+              },
+              {
+                "url": "https://crates.io/crates/rand_xoshiro",
+                "start_line": 78,
+                "end_line": 78
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/std.rs",
+            "type": "file",
+            "name": "std.rs",
+            "base_name": "std",
+            "extension": ".rs",
+            "size": 3241,
+            "date": "1970-01-01",
+            "sha1": "87908f87bc5a42d26e5fcaabb729d1d6ebf4051d",
+            "md5": "a5ecc3f9edf6dad1b2d25f6425af4a3e",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://crates.io/crates/rand_chacha",
+                "start_line": 34,
+                "end_line": 34
+              },
+              {
+                "url": "https://github.com/rust-random/rand/issues/932",
+                "start_line": 35,
+                "end_line": 35
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/thread.rs",
+            "type": "file",
+            "name": "thread.rs",
+            "base_name": "thread",
+            "extension": ".rs",
+            "size": 5391,
+            "date": "1970-01-01",
+            "sha1": "c9e192f174213fccfded8b6459655d107d38c00d",
+            "md5": "026e84179598573dea144868bb968906",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/xoshiro128plusplus.rs",
+            "type": "file",
+            "name": "xoshiro128plusplus.rs",
+            "base_name": "xoshiro128plusplus",
+            "extension": ".rs",
+            "size": 3647,
+            "date": "1970-01-01",
+            "sha1": "5ae88ea9dd0eaa23dda2ff312cf095944d8e6c97",
+            "md5": "1c613f68c2182f79a04727d9dbff549c",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 95.83,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 3,
+                "end_line": 7,
+                "matched_rule": {
+                  "identifier": "mit_or_apache-2.0_2.RULE",
+                  "license_expression": "mit OR apache-2.0",
+                  "licenses": [
+                    "mit",
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 48,
+                  "matched_length": 46,
+                  "match_coverage": 95.83,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// [https]://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or [https]://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+              },
+              {
+                "key": "apache-2.0",
+                "score": 95.83,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 7,
+                "matched_rule": {
+                  "identifier": "mit_or_apache-2.0_2.RULE",
+                  "license_expression": "mit OR apache-2.0",
+                  "licenses": [
+                    "mit",
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 48,
+                  "matched_length": 46,
+                  "match_coverage": 95.83,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// [https]://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or [https]://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+              }
+            ],
+            "license_expressions": [
+              "mit OR apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "http://xoshiro.di.unimi.it/xoshiro128plusplus.c",
+                "start_line": 20,
+                "end_line": 20
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/xoshiro256plusplus.rs",
+            "type": "file",
+            "name": "xoshiro256plusplus.rs",
+            "base_name": "xoshiro256plusplus",
+            "extension": ".rs",
+            "size": 3892,
+            "date": "1970-01-01",
+            "sha1": "32cf284da477446a0eb2f3bbf7c40b3ae9f7236d",
+            "md5": "65567b9cfaaaf8f015263614e98fb6b7",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 95.83,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 3,
+                "end_line": 7,
+                "matched_rule": {
+                  "identifier": "mit_or_apache-2.0_2.RULE",
+                  "license_expression": "mit OR apache-2.0",
+                  "licenses": [
+                    "mit",
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 48,
+                  "matched_length": 46,
+                  "match_coverage": 95.83,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// [https]://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or [https]://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+              },
+              {
+                "key": "apache-2.0",
+                "score": 95.83,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 7,
+                "matched_rule": {
+                  "identifier": "mit_or_apache-2.0_2.RULE",
+                  "license_expression": "mit OR apache-2.0",
+                  "licenses": [
+                    "mit",
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 48,
+                  "matched_length": 46,
+                  "match_coverage": 95.83,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// [https]://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or [https]://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+              }
+            ],
+            "license_expressions": [
+              "mit OR apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "http://xoshiro.di.unimi.it/xoshiro256plusplus.c",
+                "start_line": 20,
+                "end_line": 20
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/adapter",
+            "type": "directory",
+            "name": "adapter",
+            "base_name": "adapter",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 3,
+            "dirs_count": 0,
+            "size_count": 16869,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/adapter/mod.rs",
+            "type": "file",
+            "name": "mod.rs",
+            "base_name": "mod",
+            "extension": ".rs",
+            "size": 501,
+            "date": "1970-01-01",
+            "sha1": "41426d1297e2da1c88e953bcb7ce429ce00250a4",
+            "md5": "c68094b9d2fd5729dfa9a7bd36862a58",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 95.83,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 3,
+                "end_line": 7,
+                "matched_rule": {
+                  "identifier": "mit_or_apache-2.0_2.RULE",
+                  "license_expression": "mit OR apache-2.0",
+                  "licenses": [
+                    "mit",
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 48,
+                  "matched_length": 46,
+                  "match_coverage": 95.83,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// [https]://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or [https]://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+              },
+              {
+                "key": "apache-2.0",
+                "score": 95.83,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 7,
+                "matched_rule": {
+                  "identifier": "mit_or_apache-2.0_2.RULE",
+                  "license_expression": "mit OR apache-2.0",
+                  "licenses": [
+                    "mit",
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 48,
+                  "matched_length": 46,
+                  "match_coverage": 95.83,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// [https]://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or [https]://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+              }
+            ],
+            "license_expressions": [
+              "mit OR apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/adapter/read.rs",
+            "type": "file",
+            "name": "read.rs",
+            "base_name": "read",
+            "extension": ".rs",
+            "size": 4225,
+            "date": "1970-01-01",
+            "sha1": "438e6dab2f2aa6251fb9228d98fb574a5aade8f0",
+            "md5": "54c970ff550dd4f73d5c124f82c71b2f",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 2
+              },
+              {
+                "value": "Copyright 2013 The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/rngs/adapter/reseeding.rs",
+            "type": "file",
+            "name": "reseeding.rs",
+            "base_name": "reseeding",
+            "extension": ".rs",
+            "size": 12143,
+            "date": "1970-01-01",
+            "sha1": "be5c1b45c03b1924e5d494ff0112137a4fc0c014",
+            "md5": "2d51212823bfa0a1d65c30c244e6fd0b",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 2
+              },
+              {
+                "value": "Copyright 2013 The Rust Project",
+                "start_line": 1,
+                "end_line": 2
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 6,
+                "end_line": 6
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/seq",
+            "type": "directory",
+            "name": "seq",
+            "base_name": "seq",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 2,
+            "dirs_count": 0,
+            "size_count": 68950,
+            "scan_errors": []
+          },
+          {
+            "path": "src/seq/index.rs",
+            "type": "file",
+            "name": "index.rs",
+            "base_name": "index",
+            "extension": ".rs",
+            "size": 22550,
+            "date": "1970-01-01",
+            "sha1": "90443fd13ef17d6f320491ab2d4ddf45a3c47341",
+            "md5": "cd2b8d7bc3535e61c7d838257cc47df1",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 82.33,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "apache-2.0_123.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 15,
+                  "matched_length": 13,
+                  "match_coverage": 86.67,
+                  "rule_relevance": 95
+                },
+                "matched_text": "Licensed under the Apache License, [Version] [2].[0] <[LICENSE]-[APACHE] [or]\n// https://www.apache.org/licenses/LICENSE-2.0>"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://github.com/rust-random/rand/pull/479",
+                "start_line": 236,
+                "end_line": 236
+              },
+              {
+                "url": "https://doi.org/10.1016/j.ipl.2005.11.003",
+                "start_line": 302,
+                "end_line": 302
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/seq/mod.rs",
+            "type": "file",
+            "name": "mod.rs",
+            "base_name": "mod",
+            "extension": ".rs",
+            "size": 46400,
+            "date": "1970-01-01",
+            "sha1": "ac21abf968955cea3e917581b6709a1e6245cb83",
+            "md5": "c3cce6b632e77a6a63ddd476bd1f239f",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 49.5,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 3,
+                "end_line": 3,
+                "matched_rule": {
+                  "identifier": "apache-2.0_81.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 10,
+                  "matched_length": 9,
+                  "match_coverage": 90,
+                  "rule_relevance": 55
+                },
+                "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-"
+              },
+              {
+                "key": "mit",
+                "score": 16,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 4,
+                "end_line": 4,
+                "matched_rule": {
+                  "identifier": "mit_27.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 16
+                },
+                "matched_text": "the MIT license"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT>,"
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "Copyright 2018",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://github.com/rust-lang/rust/issues/77404",
+                "start_line": 382,
+                "end_line": 382
+              },
+              {
+                "url": "https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm",
+                "start_line": 599,
+                "end_line": 599
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/business/evidence/crate-regex-1.5.3.json
+++ b/test/business/evidence/crate-regex-1.5.3.json
@@ -1,0 +1,6264 @@
+{
+  "clearlydefined": {
+    "1.2.0": {
+      "_metadata": {
+        "type": "crate",
+        "url": "cd:/crate/cratesio/-/regex/1.5.3",
+        "fetchedAt": "2021-05-02T02:46:00.890Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:regex:revision:1.5.3:tool:clearlydefined:1.2.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:regex:revision:1.5.3:tool:clearlydefined",
+            "type": "collection"
+          },
+          "licensee": {
+            "href": "urn:crate:cratesio:-:regex:revision:1.5.3:tool:licensee",
+            "type": "collection"
+          },
+          "scancode": {
+            "href": "urn:crate:cratesio:-:regex:revision:1.5.3:tool:scancode",
+            "type": "collection"
+          },
+          "source": {
+            "href": "urn:git:github:rust-lang:regex:revision:26c8d8e4612f836b111dd694c9ad800dae104468",
+            "type": "resource"
+          }
+        },
+        "schemaVersion": "1.2.0",
+        "toolVersion": "1.0.0"
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-APACHE",
+          "token": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+        },
+        {
+          "path": "LICENSE-MIT",
+          "token": "6485b8ed310d3f0340bf1ad1f47645069ce4069dcc6bb46c7d5c6faf41de1fdb"
+        },
+        {
+          "path": "src/testdata/LICENSE",
+          "token": "58cf078acc03da3e280a938c2bd9943f554fc9b6ced89ad93ba35ca436872899"
+        }
+      ],
+      "summaryInfo": {
+        "k": 939,
+        "count": 84,
+        "hashes": {
+          "sha1": "7c9eb5a1bad88a576b2fa4ee0778054026948a13",
+          "sha256": "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
+        }
+      },
+      "files": [
+        {
+          "path": ".cargo_vcs_info.json",
+          "hashes": {
+            "sha1": "c6108fa93ea6059c5b97c318d0982c615012c632",
+            "sha256": "24d70243e30073029ae87f2b33f58f13ad961c60bdb5b9f4b308d1e8ae80f8da"
+          }
+        },
+        {
+          "path": ".gitignore",
+          "hashes": {
+            "sha1": "5b5664b0fc5fbb74486d8b64033f240f83d1e6c4",
+            "sha256": "cd353900829f8aaea6a9bcf3e1fcabc48bcacee513bd78cead6c17593ed7fa74"
+          }
+        },
+        {
+          "path": "CHANGELOG.md",
+          "hashes": {
+            "sha1": "8b997ec5af3fd33b890eb50937383a68d9de8b38",
+            "sha256": "d26fb27c65c228a9791b9bf9b5f0d0de92e8469f5e06238e0d664a721e2ae298"
+          }
+        },
+        {
+          "path": "Cargo.lock",
+          "hashes": {
+            "sha1": "a8699e010c9db2000c80e7e97e51962afdf07e84",
+            "sha256": "477233fccb66b013fd099e467c5eb8a36cdfe4bc3c27082140b2c2aa90060406"
+          }
+        },
+        {
+          "path": "Cargo.toml",
+          "hashes": {
+            "sha1": "b07141b5e27d535ad7e8acd0b81d762cb4537c87",
+            "sha256": "e7d4b8f4c64431d8f31fd3bd1d3fa5ce6e4a85170035964e0d64afca379ffc65"
+          }
+        },
+        {
+          "path": "Cargo.toml.orig",
+          "hashes": {
+            "sha1": "88d6f53837b51db7a1f140b046ff646f4488b312",
+            "sha256": "bd75b831253a4b95d5fda8bfba2da85783c2574d42b5a0c0e2fb4b038f88fb23"
+          }
+        },
+        {
+          "path": "HACKING.md",
+          "hashes": {
+            "sha1": "cc0709c914a2d4bfaeb434cf8cf77e0e532f2646",
+            "sha256": "17818f7a17723608f6bdbe6388ad0a913d4f96f76a16649aaf4e274b1fa0ea97"
+          }
+        },
+        {
+          "path": "LICENSE-APACHE",
+          "hashes": {
+            "sha1": "5798832c31663cedc1618d18544d445da0295229",
+            "sha256": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+          }
+        },
+        {
+          "path": "LICENSE-MIT",
+          "hashes": {
+            "sha1": "9f3c36d2b7d381d9cf382a00166f3fbd06783636",
+            "sha256": "6485b8ed310d3f0340bf1ad1f47645069ce4069dcc6bb46c7d5c6faf41de1fdb"
+          }
+        },
+        {
+          "path": "PERFORMANCE.md",
+          "hashes": {
+            "sha1": "8df261024386414895b3fc724d881526f73963cc",
+            "sha256": "961b7b457076caa2591bb0a744e014e93f41a5823d0a62d7eb94cfe869600e04"
+          }
+        },
+        {
+          "path": "README.md",
+          "hashes": {
+            "sha1": "5eb97556aa4471d0ec412e08770fd7e02a40ff79",
+            "sha256": "54c37b83071ff16e93157deb2e633a82b4bc2ca509e15ceb3021be787727dfa8"
+          }
+        },
+        {
+          "path": "UNICODE.md",
+          "hashes": {
+            "sha1": "673be359a1e5d0b4c688fc231ade12a5bf540e3c",
+            "sha256": "a8a8399540eed000d19420135a527f400247a04572e44d124c786b870f518776"
+          }
+        },
+        {
+          "path": "examples/regexdna-input.txt",
+          "hashes": {
+            "sha1": "02fcdd8ce1c10a024f5f56d74e12abf5776d6acb",
+            "sha256": "156a49710bb3e1ed4bc2bbb0af0f383b747b3d0281453cfff39c296124c598f8"
+          }
+        },
+        {
+          "path": "examples/regexdna-output.txt",
+          "hashes": {
+            "sha1": "432c22ec703378d047762ec6674fddbb37141f95",
+            "sha256": "35e85b19b70a893d752fd43e54e1e9da08bac43559191cea85b33387c24c4cc1"
+          }
+        },
+        {
+          "path": "examples/shootout-regex-dna-bytes.rs",
+          "hashes": {
+            "sha1": "5531123c4f4bfb2194a1301a2d77a2302be8d35a",
+            "sha256": "fa2daedb4e0a05f64f33f4af62fbb0176db998e3676f8637ab684b725367a7b4"
+          }
+        },
+        {
+          "path": "examples/shootout-regex-dna-cheat.rs",
+          "hashes": {
+            "sha1": "d3356abdcdb7bd7737360b592f9703a6c8661ec1",
+            "sha256": "1f871a6eaaf8372299fa3c762051112fa89a14235b03f734fc50ebd51ecaee72"
+          }
+        },
+        {
+          "path": "examples/shootout-regex-dna-replace.rs",
+          "hashes": {
+            "sha1": "0f7fac4e7d4a3e4f44df49a1f1ca38f05f05e586",
+            "sha256": "32ffdf13ac6c4ce3fc32116a048e9cc682aa34cdb8e5beaf565a22addbdcd9ab"
+          }
+        },
+        {
+          "path": "examples/shootout-regex-dna-single-cheat.rs",
+          "hashes": {
+            "sha1": "54773da206e058e80d95c81245976330ccf53a0f",
+            "sha256": "809f75bf1e1917a53623eb6f1a3ce3b7d2ed98a6a1dbc0bd4853bec49a0c6f94"
+          }
+        },
+        {
+          "path": "examples/shootout-regex-dna-single.rs",
+          "hashes": {
+            "sha1": "1ca372884f811be0be7ff494f01588be9f411a82",
+            "sha256": "1ab14f5703cd4be2e75a2e792e0ba1d322b9e4b14535d396805a4316d577f5bb"
+          }
+        },
+        {
+          "path": "examples/shootout-regex-dna.rs",
+          "hashes": {
+            "sha1": "87ddf491ed3fa7c64130175892de4441706f9cb7",
+            "sha256": "20ea46ab63f91e3ac6a64e997eadd436a9cbc2f1bdade28e4512052f0e25bc34"
+          }
+        },
+        {
+          "path": "rustfmt.toml",
+          "hashes": {
+            "sha1": "558a7c72e415544f0b8790cd8c752690d0bc05c6",
+            "sha256": "1ca600239a27401c4a43f363cf3f38183a212affc1f31bff3ae93234bbaec228"
+          }
+        },
+        {
+          "path": "src/backtrack.rs",
+          "hashes": {
+            "sha1": "0ce4af66cbbf5eb7b4ec3e895ccd9e8a1e0e5619",
+            "sha256": "9018950f86564184a5dafd869a6c2cb3c4538ff302adbeccac33015f6e88f904"
+          }
+        },
+        {
+          "path": "src/compile.rs",
+          "hashes": {
+            "sha1": "994606f5444b3bd24cff12abf22e89df5c92b1cb",
+            "sha256": "84251b11081db43b712a887d424b79bdcd4738865e7df4d8667250cec553bac3"
+          }
+        },
+        {
+          "path": "src/dfa.rs",
+          "hashes": {
+            "sha1": "17171b41c83ac19a67ed7664228c3af45609a247",
+            "sha256": "380580f54b0cee80c1a26caee3b4b76ad06ac63afdf8a8d351368a458454517d"
+          }
+        },
+        {
+          "path": "src/error.rs",
+          "hashes": {
+            "sha1": "848b397b1379cd7054b1c052eb6dcfba3751fad0",
+            "sha256": "71c85db839514f26ee024a689061743ea94a34eb7a3291e6c2b69b45a9682d09"
+          }
+        },
+        {
+          "path": "src/exec.rs",
+          "hashes": {
+            "sha1": "35084b1e0e7a1bcd2c6516596dbfaaca9cbd5cf6",
+            "sha256": "2203bee6ebe03fd67ab011c057ebb10d9913afb6c2db59fb10c6ea219f70689a"
+          }
+        },
+        {
+          "path": "src/expand.rs",
+          "hashes": {
+            "sha1": "45c3c35a3d6ab2d5030c92d598bc2898b0187509",
+            "sha256": "ccba4798bd48ce40c34e91318f12258f46d8382e178a2c2b31c0d03b1ab51c5b"
+          }
+        },
+        {
+          "path": "src/find_byte.rs",
+          "hashes": {
+            "sha1": "a395097fa0fa7f55e3c8ab7799b7b6a26f524488",
+            "sha256": "b387247b77e3269f057c3399aefe5a815032c3af918c876f80eb4b282e4eb95e"
+          }
+        },
+        {
+          "path": "src/freqs.rs",
+          "hashes": {
+            "sha1": "8a63c576ee115d36a87415461f0d315690ddb980",
+            "sha256": "255555f3d95b08a5bb3bc2f38d5a06cc100a39c0f0127fe4f50c33afa1cadc65"
+          }
+        },
+        {
+          "path": "src/input.rs",
+          "hashes": {
+            "sha1": "293cb8a3eec498c9eb8c0bf7c836498ebb99e9c9",
+            "sha256": "69595d1ea8d35351f5065ffdbf5965427d2e3fb5160a37008fa7e21d0eaa7720"
+          }
+        },
+        {
+          "path": "src/lib.rs",
+          "hashes": {
+            "sha1": "5f96c5a2b3e1f32a387659cdce33e80e5322349a",
+            "sha256": "20bc28509e1853faea9581d43b21bc3ab144bb776e47fda4560082c4673854a6"
+          }
+        },
+        {
+          "path": "src/literal/imp.rs",
+          "hashes": {
+            "sha1": "ee7ca8c60eb1dc6342f6a831d9d7aec74b144b53",
+            "sha256": "5f73e0bcbee70c11041deca5ae84a8d30995963f452b29dd2fe5ab46d4978c12"
+          }
+        },
+        {
+          "path": "src/literal/mod.rs",
+          "hashes": {
+            "sha1": "f498786b8dd7091f42ce6f8856b5d431d507233f",
+            "sha256": "533f1d68af088e9485170145e27518368e541a0337fdb44f63249ebf97310300"
+          }
+        },
+        {
+          "path": "src/pattern.rs",
+          "hashes": {
+            "sha1": "abbbc722428eaca4d456c2159e9a03f0c50c49b4",
+            "sha256": "e6124b403c18344675aa341faf9ae2f592193ef89f1c4a5e1cee135b8b34dd21"
+          }
+        },
+        {
+          "path": "src/pikevm.rs",
+          "hashes": {
+            "sha1": "e4ccc6a75ee3ac71147044874e1ef036d7e0231e",
+            "sha256": "83423e5a94ea36e99dc6f69891ab200c1d0dadd3389ee296a816ec8d68bf556f"
+          }
+        },
+        {
+          "path": "src/pool.rs",
+          "hashes": {
+            "sha1": "bc4d6328566e5bf40bc499d54824d206807b67a7",
+            "sha256": "942e991ae31ef349bd76efd78b2a712c01166dec965bf93742977ed0870d5a10"
+          }
+        },
+        {
+          "path": "src/prog.rs",
+          "hashes": {
+            "sha1": "1a5193ae480732beb6d7b582f648ea6712e6bbb8",
+            "sha256": "78a02dcc1fc7b1d4f37a4a4eeb075eb5cc84aea1736e4de3a2cc7449a9ce5103"
+          }
+        },
+        {
+          "path": "src/re_builder.rs",
+          "hashes": {
+            "sha1": "7af2b6681b26f79e186ee3003554833532014464",
+            "sha256": "943344bf6e2fc90902ee04b11b741c32418ac6814b21b7982cc0a3a817713f3e"
+          }
+        },
+        {
+          "path": "src/re_bytes.rs",
+          "hashes": {
+            "sha1": "65cdd8fb0bdd9ee1d88aef5498f26a640cff1ea1",
+            "sha256": "c19bf2df00024e91f6f2b68be2d8971e847d6f16d7b949a04d2569736b1cdadb"
+          }
+        },
+        {
+          "path": "src/re_set.rs",
+          "hashes": {
+            "sha1": "3d3f5923a87a9ff626f449bd1a9943b32bb7b6d2",
+            "sha256": "a0cb76fafe7e33ea8c7b65aae53fa3432fc1651be186218b2284cb3c002ea966"
+          }
+        },
+        {
+          "path": "src/re_trait.rs",
+          "hashes": {
+            "sha1": "9beabe1741eff38b56d0c1c6108d2b2db52c4854",
+            "sha256": "1c209fe30392b957f1bdcacdb900f222fc761a2e1634ab1c3f4ee97f315a0c22"
+          }
+        },
+        {
+          "path": "src/re_unicode.rs",
+          "hashes": {
+            "sha1": "6049a24a6f11dfa56e1559b7ffd6081294e3a993",
+            "sha256": "1b25aa974065211a269e70b3636aef91e31f9ad7e395150c22e30317172169f8"
+          }
+        },
+        {
+          "path": "src/sparse.rs",
+          "hashes": {
+            "sha1": "458ec7e85c3621e160228c53534b4c68d143c7cc",
+            "sha256": "0da3ddb7972109869248a764dbb10254555f4bb51c375e89fb3fab9cafa47320"
+          }
+        },
+        {
+          "path": "src/testdata/LICENSE",
+          "hashes": {
+            "sha1": "553e82bef8637312393c95bc62e23e8f81fd9e47",
+            "sha256": "58cf078acc03da3e280a938c2bd9943f554fc9b6ced89ad93ba35ca436872899"
+          }
+        },
+        {
+          "path": "src/testdata/README",
+          "hashes": {
+            "sha1": "01f8233ffcdab4cd03c4a2a05a155f6d6eae3290",
+            "sha256": "45f869e37f798905c773bfbe0ef19a5fb7e585cbf0b7c21b5b5a784e8cec3c14"
+          }
+        },
+        {
+          "path": "src/testdata/basic.dat",
+          "hashes": {
+            "sha1": "bf772321e16a4806ee201346e4285d9658695a4a",
+            "sha256": "b5b33aa89d48a61cd67cb1fbfd8f70e62c83e30b86256f9f915a5190dd38ff06"
+          }
+        },
+        {
+          "path": "src/testdata/nullsubexpr.dat",
+          "hashes": {
+            "sha1": "9631512e2ad27414672e44f3bfc040d0f83cf686",
+            "sha256": "496ac0278eec3b6d9170faace14554569032dd3d909618364d9326156de39ecf"
+          }
+        },
+        {
+          "path": "src/testdata/repetition.dat",
+          "hashes": {
+            "sha1": "7115777cd017589c96cebe2456e28a3827da0a2a",
+            "sha256": "1f7959063015b284b18a4a2c1c8b416d438a2d6c4b1a362da43406b865f50e69"
+          }
+        },
+        {
+          "path": "src/utf8.rs",
+          "hashes": {
+            "sha1": "b9d2f2f89997c4d2671437ee055bf5a3bd248f8e",
+            "sha256": "708615a4859110cc9766b342a9c1da6c5c4a8a04ad239046b2725385db977efe"
+          }
+        },
+        {
+          "path": "test",
+          "hashes": {
+            "sha1": "d2e9ca45ca440a6a8e8ad05134949a6d2349afc4",
+            "sha256": "0d62fdca7da12fc19ea5306b5de1d83e68d9365a029c043d524334da138b0304"
+          }
+        },
+        {
+          "path": "tests/api.rs",
+          "hashes": {
+            "sha1": "28ee18875c468cb7cf27a6e735750f07e5235d99",
+            "sha256": "7b2a0ef75e99b9776094967bd66e9cdeaa8e11359f5f0a12bd08ef0e8d0c11fc"
+          }
+        },
+        {
+          "path": "tests/api_str.rs",
+          "hashes": {
+            "sha1": "f50036ff5054be66c0697660eb0bc8619e6b9dbc",
+            "sha256": "2ae38c04e7e8fac008b609a820d0b1561ba75f39b0edc0987d6d3d06132da77f"
+          }
+        },
+        {
+          "path": "tests/bytes.rs",
+          "hashes": {
+            "sha1": "2868995c1c7f9a0fbdce42f4a7e6f737f5e29fa4",
+            "sha256": "edc50f526c5fee43df89d639ef18b237e4eb91e9d533bfc43f3cbab7417d38ba"
+          }
+        },
+        {
+          "path": "tests/consistent.rs",
+          "hashes": {
+            "sha1": "932b495a6cde0c50a740b9c32366ceb46defe2bb",
+            "sha256": "d69435154c09478076497216e43081a835ac65147181a4fbddad7bff469605b2"
+          }
+        },
+        {
+          "path": "tests/crates_regex.rs",
+          "hashes": {
+            "sha1": "c2ea44c1bea699bf5710873fbcefc983e7db648b",
+            "sha256": "91a59d470e0700b4bcb3ff735d06799f3107b8ef4875a2e9904607b164be0326"
+          }
+        },
+        {
+          "path": "tests/crazy.rs",
+          "hashes": {
+            "sha1": "129615cc2d9640aeb07cadf043855af4f1b64b93",
+            "sha256": "c0d56380dff19bdd5d7a3eb731d0e2dc564e169a1b73c81e1879b1e87f5f5f77"
+          }
+        },
+        {
+          "path": "tests/flags.rs",
+          "hashes": {
+            "sha1": "60d870b1aa441c62cfc48d3a3dd554a8b2fee507",
+            "sha256": "05caace2c81a99d2168037f3a38035d4dffe9f85ef3ebd7ef18b1bc6612f1ea8"
+          }
+        },
+        {
+          "path": "tests/fowler.rs",
+          "hashes": {
+            "sha1": "cd4bed571684b4542ad028ff6e5f7e8d4c3b60b1",
+            "sha256": "d78cf914de40b1e125cc92b65ccb444d462586bd07b5e05de4e4a1b5de16aa76"
+          }
+        },
+        {
+          "path": "tests/macros.rs",
+          "hashes": {
+            "sha1": "9dbdd1065e0e97edc1a1a07a6a1b5760e830c33f",
+            "sha256": "6db70c16fc90df13e6b30d2b606f8b6dd4dc976697967f6ee001b15aab6d0b19"
+          }
+        },
+        {
+          "path": "tests/macros_bytes.rs",
+          "hashes": {
+            "sha1": "1b9f2a9bfbd5ff06d5b6d3de57d212b66e69ff4c",
+            "sha256": "a049f528a93173a1bb176cd46932dce1880679f4a1752e099be920f0e4546fd0"
+          }
+        },
+        {
+          "path": "tests/macros_str.rs",
+          "hashes": {
+            "sha1": "59d2b598cd7b7e8b5b18a8ee6f5a46a0d10caa93",
+            "sha256": "e585b1461374c45a2eca44ca045bc3c1fe984b2b4212e432b0c695b420e708b7"
+          }
+        },
+        {
+          "path": "tests/misc.rs",
+          "hashes": {
+            "sha1": "b5d590ef3de94e2445dd7fd7ddb87b50faa20ad3",
+            "sha256": "395f52793fa022e4cdda78675b6a6fba1a3106b4b99c834c39f7801574054bd1"
+          }
+        },
+        {
+          "path": "tests/multiline.rs",
+          "hashes": {
+            "sha1": "c08bc71c9748bd62971d1cf20395099e93314050",
+            "sha256": "1b1a3326ed976437c1357f01d81833ece7ea244f38826246eab55cacd5d0862a"
+          }
+        },
+        {
+          "path": "tests/noparse.rs",
+          "hashes": {
+            "sha1": "310ae03fac7684f446d4f2368e6380cc1dc6daab",
+            "sha256": "12b6be0eff3d80779d33c6459396c74c0f6ebf4ddc9f1d33c3e747ea9e3bf268"
+          }
+        },
+        {
+          "path": "tests/regression.rs",
+          "hashes": {
+            "sha1": "f2a03e99b05fc586295615006a8c5febfe927f19",
+            "sha256": "4d4aecf57ce5accf73fe8818267e8d45c9a15896d40093a5b5e1a09007a121a1"
+          }
+        },
+        {
+          "path": "tests/regression_fuzz.rs",
+          "hashes": {
+            "sha1": "af9600e2249bc0e9e5a51480c34346507b34fefa",
+            "sha256": "a504ec563e0d23bd2039493b7b1767fe1f831d7d668f6f4b2ecd124fc7899bcd"
+          }
+        },
+        {
+          "path": "tests/replace.rs",
+          "hashes": {
+            "sha1": "1ef541a4e4165691418ff1e30ba986a64208a8a5",
+            "sha256": "0efa042c0d531911e8ac41ce98a6b60236cbf40954102c59f9f6dea78d9d74dd"
+          }
+        },
+        {
+          "path": "tests/searcher.rs",
+          "hashes": {
+            "sha1": "e7ceb209b2d556ea94eada036ecf25692b702164",
+            "sha256": "ce35e47b0a276a7e8c9060c6a0b225ffba163aebc61fbc15555a6897fa0e552c"
+          }
+        },
+        {
+          "path": "tests/set.rs",
+          "hashes": {
+            "sha1": "c0d70fd37a36275897b808833a512b8a54ddbae4",
+            "sha256": "f1e2af6baeeaed3cc99ed347ff516fe7b2eb0027ef64b891502e1486598eaf8a"
+          }
+        },
+        {
+          "path": "tests/shortest_match.rs",
+          "hashes": {
+            "sha1": "04387f3ad627444f1bfdcc2d9ab9c8a2b8916192",
+            "sha256": "a2c94390c0d61bc24796b4c1288c924e90c8c9c6156fdebb858175177a194a42"
+          }
+        },
+        {
+          "path": "tests/suffix_reverse.rs",
+          "hashes": {
+            "sha1": "2408f57b62224bff2ba09a54875ea9672204939e",
+            "sha256": "b95f89397404871227d9efe6df23b9ded147f183db81597e608f693955c668b5"
+          }
+        },
+        {
+          "path": "tests/test_backtrack.rs",
+          "hashes": {
+            "sha1": "7bdab4e10a7ad6d9e9c003ce1cf856007d8ede7a",
+            "sha256": "b70c5e5f1241efd76dd9f9dd4a4df8a7b38113bd407d1f5f56867f1176177a59"
+          }
+        },
+        {
+          "path": "tests/test_backtrack_bytes.rs",
+          "hashes": {
+            "sha1": "1c20c7c3436d1fa02db9561078e85576653b16a5",
+            "sha256": "b8a111d4b4109c8bba7e2afb650572c495a14d357fb1f743c1076fb001f704b5"
+          }
+        },
+        {
+          "path": "tests/test_backtrack_utf8bytes.rs",
+          "hashes": {
+            "sha1": "ec0689437246dd8cbf7dd8bd0fbfb42252d19542",
+            "sha256": "c0c279785d18beac2b4e178e7bf6c14ed235d65f00ca467cfd9c333d79487649"
+          }
+        },
+        {
+          "path": "tests/test_crates_regex.rs",
+          "hashes": {
+            "sha1": "a8a031a12ec6469856c92e225e698e8c138912b1",
+            "sha256": "fd9525c2eef0e2f8cb7f787bc2b721bcd0b5d84f3bca49adfe48d657a99c721a"
+          }
+        },
+        {
+          "path": "tests/test_default.rs",
+          "hashes": {
+            "sha1": "fdcb3fb3f4f24cab29403b61ce91f6431beffb02",
+            "sha256": "9dadd426a991683e601d3e52b1f6a551d531a23408ea791e5446eae83a3e8b6c"
+          }
+        },
+        {
+          "path": "tests/test_default_bytes.rs",
+          "hashes": {
+            "sha1": "95ff26130a8cb3a223424c7a3323792b9307bb47",
+            "sha256": "831d3e6bfb882feb15f700e30304bd34328f888fb4c15c7169371e25024ce9a7"
+          }
+        },
+        {
+          "path": "tests/test_nfa.rs",
+          "hashes": {
+            "sha1": "a83b98f631fbbfbf0b609bee3b4d30770284ecd8",
+            "sha256": "f119fc43a018249c39c813d57096b0654ff69f337345f2bbd9b0e61cc9137285"
+          }
+        },
+        {
+          "path": "tests/test_nfa_bytes.rs",
+          "hashes": {
+            "sha1": "d1d1f5c60a254aaa2afe825ed81a4bfebc56144a",
+            "sha256": "89eae3bef6a1d0bcea6b5de5be35ad72f613f2ceb8b58fe82a6c6ef2ccdc07d0"
+          }
+        },
+        {
+          "path": "tests/test_nfa_utf8bytes.rs",
+          "hashes": {
+            "sha1": "999d5295a5212cdabaebb20ecb36ac83215652c2",
+            "sha256": "7d830b4aa401887d7cf098b62fed4cd8017ef8b61f625c7c9a2159a6b4cfeb71"
+          }
+        },
+        {
+          "path": "tests/unicode.rs",
+          "hashes": {
+            "sha1": "da5038d8ba955495a6ca95c0171c891dc7a132ea",
+            "sha256": "4bf85f5c3d547fa8b5623194a09b6413067499dfbe7c1d29d8b50bf1cddacf6b"
+          }
+        },
+        {
+          "path": "tests/word_boundary.rs",
+          "hashes": {
+            "sha1": "4bb48b2eb2d5d4767327c280b87683090ea0ab96",
+            "sha256": "7081317ddcec1e82dd4a2090a571c6abf2ff4bbfa8cd10395e1eb3f386157fae"
+          }
+        },
+        {
+          "path": "tests/word_boundary_ascii.rs",
+          "hashes": {
+            "sha1": "9b586ecdf6ef6dafe24bb954688c15547a7a05ff",
+            "sha256": "cd0be5b5b485de0ba7994b42e2864585556c3d2d8bf5eab05b58931d9aaf4b87"
+          }
+        },
+        {
+          "path": "tests/word_boundary_unicode.rs",
+          "hashes": {
+            "sha1": "d21c987013ae8dd41ea9c84ce372a708e33464b2",
+            "sha256": "75dbcc35d3abc0f9795c2ea99e216dc227b0a5b58e9ca5eef767815ff0513921"
+          }
+        }
+      ],
+      "manifest": {
+        "id": "regex",
+        "name": "regex",
+        "updated_at": "2021-05-02T00:31:11.663737+00:00",
+        "versions": [
+          373509,
+          373311,
+          373224,
+          373221,
+          370062,
+          352143,
+          350923,
+          324638,
+          300878,
+          293184,
+          292466,
+          246551,
+          246433,
+          232375,
+          224372,
+          220447,
+          208168,
+          202679,
+          202614,
+          173864,
+          173680,
+          167241,
+          164199,
+          161393,
+          160301,
+          155416,
+          145248,
+          142627,
+          142437,
+          142295,
+          136321,
+          136316,
+          120267,
+          116490,
+          107037,
+          105483,
+          105246,
+          100302,
+          97154,
+          91039,
+          91023,
+          85135,
+          84520,
+          84414,
+          83837,
+          80368,
+          75963,
+          75940,
+          72797,
+          53983,
+          41445,
+          41312,
+          36790,
+          36749,
+          36747,
+          33882,
+          33804,
+          33179,
+          33090,
+          29799,
+          29797,
+          27414,
+          27332,
+          26342,
+          26095,
+          26003,
+          25640,
+          25261,
+          25259,
+          25146,
+          24922,
+          24761,
+          24687,
+          24629,
+          23960,
+          23906,
+          23844,
+          23077,
+          22823,
+          22761,
+          22601,
+          22444,
+          21167,
+          20874,
+          20266,
+          20265,
+          19609,
+          18787,
+          18785,
+          13169,
+          12711,
+          12621,
+          12021,
+          11986,
+          11888,
+          11842,
+          11829,
+          10945,
+          10857,
+          10856,
+          9293,
+          9068,
+          8851,
+          8491,
+          7848,
+          7847,
+          7413,
+          7358,
+          7294,
+          7062,
+          6420,
+          6216,
+          6003,
+          5935,
+          5790,
+          5258,
+          4600,
+          4373,
+          4208,
+          3999,
+          2588,
+          2416,
+          2224,
+          2144,
+          2013,
+          1895,
+          1563,
+          1363,
+          1321,
+          1178,
+          1100
+        ],
+        "keywords": [],
+        "categories": [
+          "text-processing"
+        ],
+        "badges": [],
+        "created_at": "2014-12-13T22:10:11.303311+00:00",
+        "downloads": 37338914,
+        "recent_downloads": 6140650,
+        "max_version": "1.5.3",
+        "newest_version": "1.5.3",
+        "max_stable_version": "1.5.3",
+        "description": "An implementation of regular expressions for Rust. This implementation uses\nfinite automata and guarantees linear time matching on all inputs.\n",
+        "homepage": "https://github.com/rust-lang/regex",
+        "documentation": "https://docs.rs/regex",
+        "repository": "https://github.com/rust-lang/regex",
+        "links": {
+          "version_downloads": "/api/v1/crates/regex/downloads",
+          "versions": null,
+          "owners": "/api/v1/crates/regex/owners",
+          "owner_team": "/api/v1/crates/regex/owner_team",
+          "owner_user": "/api/v1/crates/regex/owner_user",
+          "reverse_dependencies": "/api/v1/crates/regex/reverse_dependencies"
+        },
+        "exact_match": false
+      },
+      "registryData": {
+        "id": 373509,
+        "crate": "regex",
+        "num": "1.5.3",
+        "dl_path": "/api/v1/crates/regex/1.5.3/download",
+        "readme_path": "/api/v1/crates/regex/1.5.3/readme",
+        "updated_at": "2021-05-02T00:31:11.663737+00:00",
+        "created_at": "2021-05-02T00:31:11.663737+00:00",
+        "downloads": 1595,
+        "features": {
+          "default": [
+            "std",
+            "perf",
+            "unicode",
+            "regex-syntax/default"
+          ],
+          "pattern": [],
+          "perf": [
+            "perf-cache",
+            "perf-dfa",
+            "perf-inline",
+            "perf-literal"
+          ],
+          "perf-cache": [],
+          "perf-dfa": [],
+          "perf-inline": [],
+          "perf-literal": [
+            "aho-corasick",
+            "memchr"
+          ],
+          "std": [],
+          "unicode": [
+            "unicode-age",
+            "unicode-bool",
+            "unicode-case",
+            "unicode-gencat",
+            "unicode-perl",
+            "unicode-script",
+            "unicode-segment",
+            "regex-syntax/unicode"
+          ],
+          "unicode-age": [
+            "regex-syntax/unicode-age"
+          ],
+          "unicode-bool": [
+            "regex-syntax/unicode-bool"
+          ],
+          "unicode-case": [
+            "regex-syntax/unicode-case"
+          ],
+          "unicode-gencat": [
+            "regex-syntax/unicode-gencat"
+          ],
+          "unicode-perl": [
+            "regex-syntax/unicode-perl"
+          ],
+          "unicode-script": [
+            "regex-syntax/unicode-script"
+          ],
+          "unicode-segment": [
+            "regex-syntax/unicode-segment"
+          ],
+          "unstable": [
+            "pattern"
+          ],
+          "use_std": [
+            "std"
+          ]
+        },
+        "yanked": false,
+        "license": "MIT OR Apache-2.0",
+        "links": {
+          "dependencies": "/api/v1/crates/regex/1.5.3/dependencies",
+          "version_downloads": "/api/v1/crates/regex/1.5.3/downloads",
+          "authors": "/api/v1/crates/regex/1.5.3/authors"
+        },
+        "crate_size": 236506,
+        "published_by": {
+          "id": 189,
+          "login": "BurntSushi",
+          "name": "Andrew Gallant",
+          "avatar": "https://avatars3.githubusercontent.com/u/456674?v=4",
+          "url": "https://github.com/BurntSushi"
+        },
+        "audit_actions": [
+          {
+            "action": "publish",
+            "user": {
+              "id": 189,
+              "login": "BurntSushi",
+              "name": "Andrew Gallant",
+              "avatar": "https://avatars3.githubusercontent.com/u/456674?v=4",
+              "url": "https://github.com/BurntSushi"
+            },
+            "time": "2021-05-02T00:31:11.663737+00:00"
+          }
+        ]
+      },
+      "sourceInfo": {
+        "type": "git",
+        "provider": "github",
+        "namespace": "rust-lang",
+        "name": "regex",
+        "revision": "26c8d8e4612f836b111dd694c9ad800dae104468",
+        "url": null,
+        "path": null
+      }
+    }
+  },
+  "licensee": {
+    "9.13.0": {
+      "_metadata": {
+        "type": "licensee",
+        "url": "cd:/crate/cratesio/-/regex/1.5.3",
+        "fetchedAt": "2021-05-02T02:46:03.097Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:regex:revision:1.5.3:tool:licensee:9.13.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:regex:revision:1.5.3:tool:licensee",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "9.13.0",
+        "toolVersion": "9.11.0",
+        "processedAt": "2021-05-02T02:46:04.832Z"
+      },
+      "licensee": {
+        "version": "9.11.0",
+        "parameters": [
+          "--json",
+          "--no-readme"
+        ],
+        "output": {
+          "contentType": "application/json",
+          "content": {
+            "licenses": [
+              {
+                "key": "mit",
+                "spdx_id": "MIT",
+                "meta": {
+                  "title": "MIT License",
+                  "source": "https://spdx.org/licenses/MIT.html",
+                  "description": "A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.",
+                  "using": [
+                    {
+                      "Babel": "https://github.com/babel/babel/blob/master/LICENSE"
+                    },
+                    {
+                      ".NET Core": "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+                    },
+                    {
+                      "Rails": "https://github.com/rails/rails/blob/master/MIT-LICENSE"
+                    }
+                  ],
+                  "featured": true,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": null
+                },
+                "url": "http://choosealicense.com/licenses/mit/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [
+                  {
+                    "name": "year",
+                    "description": "The current year"
+                  },
+                  {
+                    "name": "fullname",
+                    "description": "The full name or username of the repository owner"
+                  }
+                ],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "apache-2.0",
+                "spdx_id": "Apache-2.0",
+                "meta": {
+                  "title": "Apache License 2.0",
+                  "source": "https://spdx.org/licenses/Apache-2.0.html",
+                  "description": "A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.",
+                  "using": [
+                    {
+                      "Kubernetes": "https://github.com/kubernetes/kubernetes/blob/master/LICENSE"
+                    },
+                    {
+                      "PDF.js": "https://github.com/mozilla/pdf.js/blob/master/LICENSE"
+                    },
+                    {
+                      "Swift": "https://github.com/apple/swift/blob/master/LICENSE.txt"
+                    }
+                  ],
+                  "featured": true,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": "The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix."
+                },
+                "url": "http://choosealicense.com/licenses/apache-2.0/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "patent-use",
+                      "label": "Patent use",
+                      "description": "This license provides an express grant of patent rights from contributors."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    },
+                    {
+                      "tag": "document-changes",
+                      "label": "State changes",
+                      "description": "Changes made to the code must be documented."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "trademark-use",
+                      "label": "Trademark use",
+                      "description": "This license explicitly states that it does NOT grant trademark rights, even though licenses without such a statement probably do not grant any implicit trademark rights."
+                    },
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "other",
+                "spdx_id": "NOASSERTION",
+                "meta": {
+                  "title": null,
+                  "source": null,
+                  "description": null,
+                  "how": null,
+                  "using": null,
+                  "featured": false,
+                  "hidden": true,
+                  "nickname": null,
+                  "note": null
+                },
+                "url": "http://choosealicense.com/licenses/other/",
+                "rules": {
+                  "permissions": [],
+                  "conditions": [],
+                  "limitations": []
+                },
+                "fields": [],
+                "other": true,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              }
+            ],
+            "matched_files": [
+              {
+                "filename": "LICENSE-MIT",
+                "content": "Copyright (c) 2014 The Rust Project Developers\n\nPermission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE.\n",
+                "content_hash": "d64f3bb4282a97b37454b5bb96a8a264a3363dc3",
+                "content_normalized": "permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"software\"), to deal in the software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the software, and to permit persons to whom the software is furnished to do so, subject to the following conditions: the above copyright notice and this permission notice shall be included in all copies or substantial portions of the software. the software is provided \"as is\", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. in no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "MIT"
+              },
+              {
+                "filename": "LICENSE-APACHE",
+                "content": "                              Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
+                "content_hash": "ab3901051663cb8ee5dea9ebdff406ad136910e3",
+                "content_normalized": "terms and conditions for use, reproduction, and distribution - definitions. \"license\" shall mean the terms and conditions for use, reproduction, and distribution as defined by sections 1 through 9 of this document. \"licensor\" shall mean the copyright holder or entity authorized by the copyright holder that is granting the license. \"legal entity\" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. for the purposes of this definition, \"control\" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity. \"you\" (or \"your\") shall mean an individual or legal entity exercising permissions granted by this license. \"source\" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files. \"object\" form shall mean any form resulting from mechanical transformation or translation of a source form, including but not limited to compiled object code, generated documentation, and conversions to other media types. \"work\" shall mean the work of authorship, whether in source or object form, made available under the license, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the appendix below). \"derivative works\" shall mean any work, whether in source or object form, that is based on (or derived from) the work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. for the purposes of this license, derivative works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the work and derivative works thereof. \"contribution\" shall mean any work of authorship, including the original version of the work and any modifications or additions to that work or derivative works thereof, that is intentionally submitted to licensor for inclusion in the work by the copyright holder or by an individual or legal entity authorized to submit on behalf of the copyright holder. for the purposes of this definition, \"submitted\" means any form of electronic, verbal, or written communication sent to the licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the licensor for the purpose of discussing and improving the work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright holder as \"not a contribution.\" \"contributor\" shall mean licensor and any individual or legal entity on behalf of whom a contribution has been received by licensor and subsequently incorporated within the work. - grant of copyright license. subject to the terms and conditions of this license, each contributor hereby grants to you a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute the work and such derivative works in source or object form. - grant of patent license. subject to the terms and conditions of this license, each contributor hereby grants to you a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the work, where such license applies only to those patent claims licensable by such contributor that are necessarily infringed by their contribution(s) alone or by combination of their contribution(s) with the work to which such contribution(s) was submitted. if you institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the work or a contribution incorporated within the work constitutes direct or contributory patent infringement, then any patent licenses granted to you under this license for that work shall terminate as of the date such litigation is filed. - redistribution. you may reproduce and distribute copies of the work or derivative works thereof in any medium, with or without modifications, and in source or object form, provided that you meet the following conditions: * you must give any other recipients of the work or derivative works a copy of this license; and * you must cause any modified files to carry prominent notices stating that you changed the files; and * you must retain, in the source form of any derivative works that you distribute, all copyright, patent, trademark, and attribution notices from the source form of the work, excluding those notices that do not pertain to any part of the derivative works; and * if the work includes a \"notice\" text file as part of its distribution, then any derivative works that you distribute must include a readable copy of the attribution notices contained within such notice file, excluding those notices that do not pertain to any part of the derivative works, in at least one of the following places: within a notice text file distributed as part of the derivative works; within the source form or documentation, if provided along with the derivative works; or, within a display generated by the derivative works, if and wherever such third-party notices normally appear. the contents of the notice file are for informational purposes only and do not modify the license. you may add your own attribution notices within derivative works that you distribute, alongside or as an addendum to the notice text from the work, provided that such additional attribution notices cannot be construed as modifying the license. you may add your own copyright statement to your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of your modifications, or for any such derivative works as a whole, provided your use, reproduction, and distribution of the work otherwise complies with the conditions stated in this license. - submission of contributions. unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you to the licensor shall be under the terms and conditions of this license, without any additional terms or conditions. notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with licensor regarding such contributions. - trademarks. this license does not grant permission to use the trade names, trademarks, service marks, or product names of the licensor, except as required for reasonable and customary use in describing the origin of the work and reproducing the content of the notice file. - disclaimer of warranty. unless required by applicable law or agreed to in writing, licensor provides the work (and each contributor provides its contributions) on an \"as is\" basis, without warranties or conditions of any kind, either express or implied, including, without limitation, any warranties or conditions of title, non-infringement, merchantability, or fitness for a particular purpose. you are solely responsible for determining the appropriateness of using or redistributing the work and assume any risks associated with your exercise of permissions under this license. - limitation of liability. in no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any contributor be liable to you for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this license or out of the use or inability to use the work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such contributor has been advised of the possibility of such damages. - accepting warranty or additional liability. while redistributing the work or derivative works thereof, you may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this license. however, in accepting such obligations, you may act only on your own behalf and on your sole responsibility, not on behalf of any other contributor, and only if you agree to indemnify, defend, and hold each contributor harmless for any liability incurred by, or claims asserted against, such contributor by reason of your accepting any such warranty or additional liability.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "Apache-2.0"
+              },
+              {
+                "filename": "Cargo.toml",
+                "content": "# THIS FILE IS AUTOMATICALLY GENERATED BY CARGO\n#\n# When uploading crates to the registry Cargo will automatically\n# \"normalize\" Cargo.toml files for maximal compatibility\n# with all versions of Cargo and also rewrite `path` dependencies\n# to registry (e.g., crates.io) dependencies\n#\n# If you believe there's an error in this file please file an\n# issue against the rust-lang/cargo repository. If you're\n# editing this file be aware that the upstream Cargo.toml\n# will likely look very different (and much more reasonable)\n\n[package]\nedition = \"2018\"\nname = \"regex\"\nversion = \"1.5.3\"\nauthors = [\"The Rust Project Developers\"]\nexclude = [\"/scripts/*\", \"/.github/*\"]\nautotests = false\ndescription = \"An implementation of regular expressions for Rust. This implementation uses\\nfinite automata and guarantees linear time matching on all inputs.\\n\"\nhomepage = \"https://github.com/rust-lang/regex\"\ndocumentation = \"https://docs.rs/regex\"\nreadme = \"README.md\"\ncategories = [\"text-processing\"]\nlicense = \"MIT OR Apache-2.0\"\nrepository = \"https://github.com/rust-lang/regex\"\n[profile.bench]\ndebug = true\n\n[profile.release]\ndebug = true\n\n[profile.test]\ndebug = true\n\n[lib]\ndoctest = false\nbench = false\n\n[[test]]\nname = \"default\"\npath = \"tests/test_default.rs\"\n\n[[test]]\nname = \"default-bytes\"\npath = \"tests/test_default_bytes.rs\"\n\n[[test]]\nname = \"nfa\"\npath = \"tests/test_nfa.rs\"\n\n[[test]]\nname = \"nfa-utf8bytes\"\npath = \"tests/test_nfa_utf8bytes.rs\"\n\n[[test]]\nname = \"nfa-bytes\"\npath = \"tests/test_nfa_bytes.rs\"\n\n[[test]]\nname = \"backtrack\"\npath = \"tests/test_backtrack.rs\"\n\n[[test]]\nname = \"backtrack-utf8bytes\"\npath = \"tests/test_backtrack_utf8bytes.rs\"\n\n[[test]]\nname = \"backtrack-bytes\"\npath = \"tests/test_backtrack_bytes.rs\"\n\n[[test]]\nname = \"crates-regex\"\npath = \"tests/test_crates_regex.rs\"\n[dependencies.aho-corasick]\nversion = \"0.7.18\"\noptional = true\n\n[dependencies.memchr]\nversion = \"2.4.0\"\noptional = true\n\n[dependencies.regex-syntax]\nversion = \"0.6.25\"\ndefault-features = false\n[dev-dependencies.lazy_static]\nversion = \"1\"\n\n[dev-dependencies.quickcheck]\nversion = \"1.0.3\"\ndefault-features = false\n\n[dev-dependencies.rand]\nversion = \"0.8.3\"\nfeatures = [\"getrandom\", \"small_rng\"]\ndefault-features = false\n\n[features]\ndefault = [\"std\", \"perf\", \"unicode\", \"regex-syntax/default\"]\npattern = []\nperf = [\"perf-cache\", \"perf-dfa\", \"perf-inline\", \"perf-literal\"]\nperf-cache = []\nperf-dfa = []\nperf-inline = []\nperf-literal = [\"aho-corasick\", \"memchr\"]\nstd = []\nunicode = [\"unicode-age\", \"unicode-bool\", \"unicode-case\", \"unicode-gencat\", \"unicode-perl\", \"unicode-script\", \"unicode-segment\", \"regex-syntax/unicode\"]\nunicode-age = [\"regex-syntax/unicode-age\"]\nunicode-bool = [\"regex-syntax/unicode-bool\"]\nunicode-case = [\"regex-syntax/unicode-case\"]\nunicode-gencat = [\"regex-syntax/unicode-gencat\"]\nunicode-perl = [\"regex-syntax/unicode-perl\"]\nunicode-script = [\"regex-syntax/unicode-script\"]\nunicode-segment = [\"regex-syntax/unicode-segment\"]\nunstable = [\"pattern\"]\nuse_std = [\"std\"]\n",
+                "content_hash": null,
+                "content_normalized": null,
+                "matcher": {
+                  "name": "cargo",
+                  "confidence": 90
+                },
+                "matched_license": "NOASSERTION"
+              },
+              {
+                "filename": "src/testdata/LICENSE",
+                "content": "The following license covers testregex.c and all associated test data.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of THIS SOFTWARE FILE (the \"Software\"), to deal in the Software\nwithout restriction, including without limitation the rights to use,\ncopy, modify, merge, publish, distribute, and/or sell copies of the\nSoftware, and to permit persons to whom the Software is furnished to do\nso, subject to the following disclaimer:\n\nTHIS SOFTWARE IS PROVIDED BY AT&T ``AS IS'' AND ANY EXPRESS OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF\nMERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\nIN NO EVENT SHALL AT&T BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
+                "content_hash": "3f141e685a8ef3e799f177b25424edd218ec6f30",
+                "content_normalized": "the following license covers testregex.c and all associated test data. permission is hereby granted, free of charge, to any person obtaining a copy of this software file (the \"software\"), to deal in the software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, and/or sell copies of the software, and to permit persons to whom the software is furnished to do so, subject to the following disclaimer: this software is provided by atandt \"as is\" and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. in no event shall atandt be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage.",
+                "matcher": null,
+                "matched_license": "NOASSERTION"
+              }
+            ]
+          }
+        }
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-MIT",
+          "token": "6485b8ed310d3f0340bf1ad1f47645069ce4069dcc6bb46c7d5c6faf41de1fdb"
+        },
+        {
+          "path": "LICENSE-APACHE",
+          "token": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+        },
+        {
+          "path": "Cargo.toml",
+          "token": "e7d4b8f4c64431d8f31fd3bd1d3fa5ce6e4a85170035964e0d64afca379ffc65"
+        },
+        {
+          "path": "src/testdata/LICENSE",
+          "token": "58cf078acc03da3e280a938c2bd9943f554fc9b6ced89ad93ba35ca436872899"
+        }
+      ]
+    }
+  },
+  "scancode": {
+    "3.2.2": {
+      "_metadata": {
+        "type": "scancode",
+        "url": "cd:/crate/cratesio/-/regex/1.5.3",
+        "fetchedAt": "2021-05-02T02:46:03.632Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:regex:revision:1.5.3:tool:scancode:3.2.2",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:regex:revision:1.5.3:tool:scancode",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "3.2.2",
+        "toolVersion": "3.0.2",
+        "contentType": "application/json",
+        "releaseDate": "2021-05-02T00:31:11.663737+00:00",
+        "processedAt": "2021-05-02T02:46:41.020Z"
+      },
+      "content": {
+        "headers": [
+          {
+            "tool_name": "scancode-toolkit",
+            "tool_version": "3.0.2",
+            "options": {
+              "input": "/tmp/cd-oBCNff/crate/regex-1.5.3",
+              "--classify": true,
+              "--copyright": true,
+              "--email": true,
+              "--generated": true,
+              "--info": true,
+              "--is-license-text": true,
+              "--json-pp": "/tmp/cd-64PK82",
+              "--license": true,
+              "--license-clarity-score": true,
+              "--license-diag": true,
+              "--license-text": true,
+              "--package": true,
+              "--processes": "2",
+              "--strip-root": true,
+              "--summary": true,
+              "--summary-key-files": true,
+              "--timeout": "1000.0",
+              "--url": true
+            },
+            "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+            "start_timestamp": "2021-05-02T024604.924249",
+            "end_timestamp": "2021-05-02T024640.033393",
+            "message": null,
+            "errors": [],
+            "extra_data": {
+              "files_count": 83
+            }
+          }
+        ],
+        "summary": {
+          "license_expressions": [
+            {
+              "value": null,
+              "count": 77
+            },
+            {
+              "value": "mit",
+              "count": 6
+            },
+            {
+              "value": "apache-2.0",
+              "count": 4
+            },
+            {
+              "value": "mit-synopsys",
+              "count": 1
+            },
+            {
+              "value": "unicode",
+              "count": 1
+            },
+            {
+              "value": "unknown",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 81
+            },
+            {
+              "value": "Copyright (c) The Rust Project",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 82
+            },
+            {
+              "value": "The Rust Project",
+              "count": 1
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 81
+            },
+            {
+              "value": "The Rust Project",
+              "count": 2
+            }
+          ],
+          "programming_language": [
+            {
+              "value": "Rust",
+              "count": 63
+            },
+            {
+              "value": null,
+              "count": 16
+            },
+            {
+              "value": "Objective-C",
+              "count": 2
+            },
+            {
+              "value": "Bash",
+              "count": 1
+            },
+            {
+              "value": "Python",
+              "count": 1
+            }
+          ],
+          "packages": []
+        },
+        "license_clarity_score": {
+          "score": 30,
+          "has_declared_license_in_key_files": true,
+          "file_level_license_and_copyright_coverage": 0,
+          "has_consistent_key_and_file_level_licenses": false,
+          "is_using_only_spdx_licenses": false,
+          "has_full_text_for_all_licenses": false
+        },
+        "summary_of_key_files": {
+          "license_expressions": [
+            {
+              "value": "mit",
+              "count": 4
+            },
+            {
+              "value": "apache-2.0",
+              "count": 2
+            },
+            {
+              "value": "unicode",
+              "count": 1
+            },
+            {
+              "value": "unknown",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 2
+            },
+            {
+              "value": "Copyright (c) The Rust Project",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 2
+            },
+            {
+              "value": "The Rust Project",
+              "count": 1
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 3
+            }
+          ],
+          "programming_language": [
+            {
+              "value": null,
+              "count": 2
+            },
+            {
+              "value": "Objective-C",
+              "count": 1
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": ".cargo_vcs_info.json",
+            "type": "file",
+            "name": ".cargo_vcs_info.json",
+            "base_name": ".cargo_vcs_info",
+            "extension": ".json",
+            "size": 74,
+            "date": "1970-01-01",
+            "sha1": "c6108fa93ea6059c5b97c318d0982c615012c632",
+            "md5": "316626c44c94998196b67ad4e1647cbe",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.lock",
+            "type": "file",
+            "name": "Cargo.lock",
+            "base_name": "Cargo",
+            "extension": ".lock",
+            "size": 2563,
+            "date": "1970-01-01",
+            "sha1": "a8699e010c9db2000c80e7e97e51962afdf07e84",
+            "md5": "f8c0f3f4cf9b5d684cd0c0399f4f5e1a",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/crates.io-index",
+                "start_line": 8,
+                "end_line": 8
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml",
+            "type": "file",
+            "name": "Cargo.toml",
+            "base_name": "Cargo",
+            "extension": ".toml",
+            "size": 2979,
+            "date": "1970-01-01",
+            "sha1": "b07141b5e27d535ad7e8acd0b81d762cb4537c87",
+            "md5": "781aa9e5590b3cd91738128643b4559c",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 25,
+                "end_line": 25,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "license = \"MIT"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 25,
+                "end_line": 25,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0\""
+              }
+            ],
+            "license_expressions": [
+              "mit",
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "The Rust Project",
+                "start_line": 17,
+                "end_line": 19
+              }
+            ],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex",
+                "start_line": 21,
+                "end_line": 21
+              },
+              {
+                "url": "https://docs.rs/regex",
+                "start_line": 22,
+                "end_line": 22
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml.orig",
+            "type": "file",
+            "name": "Cargo.toml.orig",
+            "base_name": "Cargo.toml",
+            "extension": ".orig",
+            "size": 6210,
+            "date": "1970-01-01",
+            "sha1": "88d6f53837b51db7a1f140b046ff646f4488b312",
+            "md5": "7775335d08b7ceee44fa3c257c0755a5",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "license = \"MIT"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0\""
+              }
+            ],
+            "license_expressions": [
+              "mit",
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "The Rust Project",
+                "start_line": 4,
+                "end_line": 6
+              }
+            ],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://docs.rs/regex",
+                "start_line": 8,
+                "end_line": 8
+              },
+              {
+                "url": "https://docs.rs/regex/*/#crate-features",
+                "start_line": 33,
+                "end_line": 33
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/684",
+                "start_line": 132,
+                "end_line": 132
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/685",
+                "start_line": 133,
+                "end_line": 133
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "CHANGELOG.md",
+            "type": "file",
+            "name": "CHANGELOG.md",
+            "base_name": "CHANGELOG",
+            "extension": ".md",
+            "size": 39669,
+            "date": "1970-01-01",
+            "sha1": "8b997ec5af3fd33b890eb50937383a68d9de8b38",
+            "md5": "d9f88bef51a81e61bd3e4ca1f6e16b47",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/issues/769",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/768",
+                "start_line": 18,
+                "end_line": 18
+              },
+              {
+                "url": "https://github.com/BurntSushi/ripgrep/issues/1860",
+                "start_line": 20,
+                "end_line": 20
+              },
+              {
+                "url": "https://docs.rs/memchr/2.4.0/memchr/memmem/index.html",
+                "start_line": 37,
+                "end_line": 37
+              },
+              {
+                "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33579",
+                "start_line": 51,
+                "end_line": 51
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/750",
+                "start_line": 64,
+                "end_line": 64
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/362",
+                "start_line": 76,
+                "end_line": 76
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/576",
+                "start_line": 78,
+                "end_line": 78
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/749",
+                "start_line": 80,
+                "end_line": 80
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/734",
+                "start_line": 91,
+                "end_line": 91
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/735",
+                "start_line": 93,
+                "end_line": 93
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/722",
+                "start_line": 103,
+                "end_line": 103
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/719",
+                "start_line": 113,
+                "end_line": 113
+              },
+              {
+                "url": "https://github.com/DavidKorczynski",
+                "start_line": 124,
+                "end_line": 124
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/649",
+                "start_line": 129,
+                "end_line": 129
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/687",
+                "start_line": 131,
+                "end_line": 131
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/689",
+                "start_line": 133,
+                "end_line": 133
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/715",
+                "start_line": 135,
+                "end_line": 135
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/694",
+                "start_line": 140,
+                "end_line": 140
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/698",
+                "start_line": 142,
+                "end_line": 142
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/711",
+                "start_line": 144,
+                "end_line": 144
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/685",
+                "start_line": 156,
+                "end_line": 156
+              },
+              {
+                "url": "https://github.com/sliquister",
+                "start_line": 165,
+                "end_line": 165
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/677",
+                "start_line": 166,
+                "end_line": 166
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/523",
+                "start_line": 170,
+                "end_line": 170
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/524",
+                "start_line": 172,
+                "end_line": 172
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/659",
+                "start_line": 174,
+                "end_line": 174
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/665",
+                "start_line": 186,
+                "end_line": 186
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/657",
+                "start_line": 197,
+                "end_line": 197
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/653",
+                "start_line": 207,
+                "end_line": 207
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/640",
+                "start_line": 219,
+                "end_line": 219
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/631",
+                "start_line": 236,
+                "end_line": 236
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/521",
+                "start_line": 241,
+                "end_line": 241
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/594",
+                "start_line": 243,
+                "end_line": 243
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/627",
+                "start_line": 245,
+                "end_line": 245
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/633",
+                "start_line": 247,
+                "end_line": 247
+              },
+              {
+                "url": "https://github.com/rust-lang/docs.rs/issues/400",
+                "start_line": 254,
+                "end_line": 254
+              },
+              {
+                "url": "https://docs.rs/regex/*/#crate-features",
+                "start_line": 264,
+                "end_line": 264
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/474",
+                "start_line": 271,
+                "end_line": 271
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/583",
+                "start_line": 275,
+                "end_line": 275
+              },
+              {
+                "url": "https://docs.rs/aho-corasick/0.7.6/aho_corasick/packed/index.html",
+                "start_line": 288,
+                "end_line": 288
+              },
+              {
+                "url": "https://docs.rs/regex-syntax/0.6.11/regex_syntax/utf8/index.html",
+                "start_line": 291,
+                "end_line": 291
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/593",
+                "start_line": 320,
+                "end_line": 320
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/545",
+                "start_line": 331,
+                "end_line": 331
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/588",
+                "start_line": 333,
+                "end_line": 333
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/591",
+                "start_line": 335,
+                "end_line": 335
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/557",
+                "start_line": 347,
+                "end_line": 347
+              },
+              {
+                "url": "https://github.com/BurntSushi/ripgrep/issues/1247",
+                "start_line": 349,
+                "end_line": 349
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/570",
+                "start_line": 362,
+                "end_line": 362
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/pull/568",
+                "start_line": 375,
+                "end_line": 375
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "HACKING.md",
+            "type": "file",
+            "name": "HACKING.md",
+            "base_name": "HACKING",
+            "extension": ".md",
+            "size": 16937,
+            "date": "1970-01-01",
+            "sha1": "cc0709c914a2d4bfaeb434cf8cf77e0e532f2646",
+            "md5": "37992465b4f2176e72f164d844f44e44",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://swtch.com/~rsc/regexp/",
+                "start_line": 8,
+                "end_line": 8
+              },
+              {
+                "url": "https://swtch.com/~rsc/regexp/regexp2.html",
+                "start_line": 18,
+                "end_line": 18
+              },
+              {
+                "url": "https://github.com/BurntSushi/cargo-benchcmp",
+                "start_line": 316,
+                "end_line": 316
+              },
+              {
+                "url": "https://github.com/rust-lang/rust/issues/15347",
+                "start_line": 340,
+                "end_line": 340
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-APACHE",
+            "type": "file",
+            "name": "LICENSE-APACHE",
+            "base_name": "LICENSE-APACHE",
+            "extension": "",
+            "size": 10847,
+            "date": "1970-01-01",
+            "sha1": "5798832c31663cedc1618d18544d445da0295229",
+            "md5": "1836efb2eb779966696f473ee8540542",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 100,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 1,
+                "end_line": 201,
+                "matched_rule": {
+                  "identifier": "apache-2.0.LICENSE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "1-hash",
+                  "rule_length": 1608,
+                  "matched_length": 1608,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License."
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://www.apache.org/licenses/",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 195,
+                "end_line": 195
+              }
+            ],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": true,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-MIT",
+            "type": "file",
+            "name": "LICENSE-MIT",
+            "base_name": "LICENSE-MIT",
+            "extension": "",
+            "size": 1071,
+            "date": "1970-01-01",
+            "sha1": "9f3c36d2b7d381d9cf382a00166f3fbd06783636",
+            "md5": "362255802eb5aa87810d12ddf3cfedb4",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 100,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 3,
+                "end_line": 25,
+                "matched_rule": {
+                  "identifier": "mit.LICENSE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 163,
+                  "matched_length": 163,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Permission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE."
+              }
+            ],
+            "license_expressions": [
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright (c) 2014 The Rust Project",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "PERFORMANCE.md",
+            "type": "file",
+            "name": "PERFORMANCE.md",
+            "base_name": "PERFORMANCE",
+            "extension": ".md",
+            "size": 13588,
+            "date": "1970-01-01",
+            "sha1": "8df261024386414895b3fc724d881526f73963cc",
+            "md5": "bfca80b6c92bc574de0bf23861ee16e5",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Python",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://docs.rs/regex",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://crates.io/crates/lazy_static",
+                "start_line": 62,
+                "end_line": 62
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "README.md",
+            "type": "file",
+            "name": "README.md",
+            "base_name": "README",
+            "extension": ".md",
+            "size": 8226,
+            "date": "1970-01-01",
+            "sha1": "5eb97556aa4471d0ec412e08770fd7e02a40ff79",
+            "md5": "bdf44df027630149af3625553d8be104",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Objective-C",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "unknown",
+                "score": 11,
+                "name": "Unknown license detected but not recognized",
+                "short_name": "unknown",
+                "category": "Unstated License",
+                "is_exception": false,
+                "owner": "Unspecified",
+                "homepage_url": "",
+                "text_url": "",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:unknown",
+                "spdx_license_key": "",
+                "spdx_url": "",
+                "start_line": 239,
+                "end_line": 239,
+                "matched_rule": {
+                  "identifier": "unknown_28.RULE",
+                  "license_expression": "unknown",
+                  "licenses": [
+                    "unknown"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 11
+                },
+                "matched_text": "licensed under"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 27,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 241,
+                "end_line": 241,
+                "matched_rule": {
+                  "identifier": "apache-2.0_48.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "Apache License, Version 2.0, (["
+              },
+              {
+                "key": "mit",
+                "score": 80,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 243,
+                "end_line": 243,
+                "matched_rule": {
+                  "identifier": "mit_14.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 80
+                },
+                "matched_text": "MIT license (["
+              },
+              {
+                "key": "mit",
+                "score": 22,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 243,
+                "end_line": 243,
+                "matched_rule": {
+                  "identifier": "mit_154.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 4,
+                  "matched_length": 4,
+                  "match_coverage": 100,
+                  "rule_relevance": 22
+                },
+                "matched_text": "LICENSE-MIT](LICENSE-MIT)"
+              },
+              {
+                "key": "mit",
+                "score": 27,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 244,
+                "end_line": 244,
+                "matched_rule": {
+                  "identifier": "mit_65.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "https://opensource.org/licenses/MIT)"
+              },
+              {
+                "key": "unicode",
+                "score": 60.5,
+                "name": "Unicode Inc License Agreement",
+                "short_name": "Unicode Inc License Agreement",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Unicode Consortium",
+                "homepage_url": "http://unicode.org/",
+                "text_url": "http://unicode.org/copyright.html",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:unicode",
+                "spdx_license_key": "",
+                "spdx_url": "",
+                "start_line": 248,
+                "end_line": 250,
+                "matched_rule": {
+                  "identifier": "unicode_16.RULE",
+                  "license_expression": "unicode",
+                  "licenses": [
+                    "unicode"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": true,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 14,
+                  "matched_length": 11,
+                  "match_coverage": 78.57,
+                  "rule_relevance": 77
+                },
+                "matched_text": "unicode_tables/` is licensed under the Unicode\nLicense Agreement\n([LICENSE-UNICODE]("
+              }
+            ],
+            "license_expressions": [
+              "unknown",
+              "apache-2.0",
+              "mit",
+              "mit",
+              "mit",
+              "unicode"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/google/re2",
+                "start_line": 8,
+                "end_line": 8
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/workflows/ci/badge.svg",
+                "start_line": 10,
+                "end_line": 10
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/actions",
+                "start_line": 10,
+                "end_line": 10
+              },
+              {
+                "url": "https://meritbadge.herokuapp.com/regex",
+                "start_line": 11,
+                "end_line": 11
+              },
+              {
+                "url": "https://crates.io/crates/regex",
+                "start_line": 11,
+                "end_line": 11
+              },
+              {
+                "url": "https://img.shields.io/badge/rust-1.28.0+-blue.svg?maxAge=3600",
+                "start_line": 12,
+                "end_line": 12
+              },
+              {
+                "url": "https://github.com/rust-lang/regex",
+                "start_line": 12,
+                "end_line": 12
+              },
+              {
+                "url": "https://docs.rs/regex",
+                "start_line": 16,
+                "end_line": 16
+              },
+              {
+                "url": "https://docs.rs/regex/*/regex/struct.Regex.html",
+                "start_line": 22,
+                "end_line": 22
+              },
+              {
+                "url": "https://crates.io/crates/lazy_static",
+                "start_line": 97,
+                "end_line": 97
+              },
+              {
+                "url": "https://docs.rs/regex-syntax",
+                "start_line": 193,
+                "end_line": 193
+              },
+              {
+                "url": "https://docs.rs/regex/*/#crate-features",
+                "start_line": 220,
+                "end_line": 220
+              },
+              {
+                "url": "https://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 242,
+                "end_line": 242
+              },
+              {
+                "url": "https://opensource.org/licenses/MIT",
+                "start_line": 244,
+                "end_line": 244
+              },
+              {
+                "url": "https://www.unicode.org/copyright.html#License",
+                "start_line": 250,
+                "end_line": 250
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": true,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "rustfmt.toml",
+            "type": "file",
+            "name": "rustfmt.toml",
+            "base_name": "rustfmt",
+            "extension": ".toml",
+            "size": 44,
+            "date": "1970-01-01",
+            "sha1": "558a7c72e415544f0b8790cd8c752690d0bc05c6",
+            "md5": "d4560d998cc82ae1808d3295f615d613",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "test",
+            "type": "file",
+            "name": "test",
+            "base_name": "test",
+            "extension": "",
+            "size": 839,
+            "date": "1970-01-01",
+            "sha1": "d2e9ca45ca440a6a8e8ad05134949a6d2349afc4",
+            "md5": "ab564f4e31bf2b021cc94ba1dc421f80",
+            "mime_type": "text/x-shellscript",
+            "file_type": "Bourne-Again shell script, ASCII text executable",
+            "programming_language": "Bash",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": true,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "UNICODE.md",
+            "type": "file",
+            "name": "UNICODE.md",
+            "base_name": "UNICODE",
+            "extension": ".md",
+            "size": 10405,
+            "date": "1970-01-01",
+            "sha1": "673be359a1e5d0b4c688fc231ade12a5bf540e3c",
+            "md5": "926dec37e8c706091c99dda9032cc57d",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Objective-C",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://unicode.org/reports/tr18",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#RL1.2a",
+                "start_line": 13,
+                "end_line": 13
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#Hex_notation",
+                "start_line": 28,
+                "end_line": 28
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#Categories",
+                "start_line": 57,
+                "end_line": 57
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#General_Category_Property",
+                "start_line": 64,
+                "end_line": 64
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#Script_Property",
+                "start_line": 65,
+                "end_line": 65
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#Age",
+                "start_line": 66,
+                "end_line": 66
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#RL1.2",
+                "start_line": 68,
+                "end_line": 68
+              },
+              {
+                "url": "https://www.unicode.org/Public/UCD/latest/ucd/PropertyAliases.txt",
+                "start_line": 73,
+                "end_line": 73
+              },
+              {
+                "url": "https://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt",
+                "start_line": 75,
+                "end_line": 75
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#Compatibility_Properties",
+                "start_line": 155,
+                "end_line": 155
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#Subtraction_and_Intersection",
+                "start_line": 168,
+                "end_line": 168
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#Simple_Word_Boundaries",
+                "start_line": 181,
+                "end_line": 181
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#Simple_Loose_Matches",
+                "start_line": 214,
+                "end_line": 214
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#Line_Boundaries",
+                "start_line": 229,
+                "end_line": 229
+              },
+              {
+                "url": "https://unicode.org/reports/tr18/#Supplementary_Characters",
+                "start_line": 242,
+                "end_line": 242
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples",
+            "type": "directory",
+            "name": "examples",
+            "base_name": "examples",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 8,
+            "dirs_count": 0,
+            "size_count": 113325,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/regexdna-input.txt",
+            "type": "file",
+            "name": "regexdna-input.txt",
+            "base_name": "regexdna-input",
+            "extension": ".txt",
+            "size": 101745,
+            "date": "1970-01-01",
+            "sha1": "02fcdd8ce1c10a024f5f56d74e12abf5776d6acb",
+            "md5": "3550678d7ae37f4369a20f5e0e95ab04",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/regexdna-output.txt",
+            "type": "file",
+            "name": "regexdna-output.txt",
+            "base_name": "regexdna-output",
+            "extension": ".txt",
+            "size": 267,
+            "date": "1970-01-01",
+            "sha1": "432c22ec703378d047762ec6674fddbb37141f95",
+            "md5": "fdf3e6e9c599754e1eec3e524ea13fed",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/shootout-regex-dna-bytes.rs",
+            "type": "file",
+            "name": "shootout-regex-dna-bytes.rs",
+            "base_name": "shootout-regex-dna-bytes",
+            "extension": ".rs",
+            "size": 2092,
+            "date": "1970-01-01",
+            "sha1": "5531123c4f4bfb2194a1301a2d77a2302be8d35a",
+            "md5": "37e251cd3eb1b0dfb967008512d1faa1",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://benchmarksgame-team.pages.debian.net/benchmarksgame/",
+                "start_line": 2,
+                "end_line": 2
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/shootout-regex-dna-cheat.rs",
+            "type": "file",
+            "name": "shootout-regex-dna-cheat.rs",
+            "base_name": "shootout-regex-dna-cheat",
+            "extension": ".rs",
+            "size": 2838,
+            "date": "1970-01-01",
+            "sha1": "d3356abdcdb7bd7737360b592f9703a6c8661ec1",
+            "md5": "131ff474ad99be5114fcbf91992896db",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://benchmarksgame-team.pages.debian.net/benchmarksgame/",
+                "start_line": 2,
+                "end_line": 2
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/shootout-regex-dna-replace.rs",
+            "type": "file",
+            "name": "shootout-regex-dna-replace.rs",
+            "base_name": "shootout-regex-dna-replace",
+            "extension": ".rs",
+            "size": 462,
+            "date": "1970-01-01",
+            "sha1": "0f7fac4e7d4a3e4f44df49a1f1ca38f05f05e586",
+            "md5": "5bd888cd87ce2ad7607c19c919bcc62d",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/shootout-regex-dna-single-cheat.rs",
+            "type": "file",
+            "name": "shootout-regex-dna-single-cheat.rs",
+            "base_name": "shootout-regex-dna-single-cheat",
+            "extension": ".rs",
+            "size": 2218,
+            "date": "1970-01-01",
+            "sha1": "54773da206e058e80d95c81245976330ccf53a0f",
+            "md5": "3625a0cce9f9ee35c1a603d5a26e6f19",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://benchmarksgame-team.pages.debian.net/benchmarksgame/",
+                "start_line": 2,
+                "end_line": 2
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/shootout-regex-dna-single.rs",
+            "type": "file",
+            "name": "shootout-regex-dna-single.rs",
+            "base_name": "shootout-regex-dna-single",
+            "extension": ".rs",
+            "size": 1684,
+            "date": "1970-01-01",
+            "sha1": "1ca372884f811be0be7ff494f01588be9f411a82",
+            "md5": "f89368e31dbd698f0c87550ce55d8d4e",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://benchmarksgame-team.pages.debian.net/benchmarksgame/",
+                "start_line": 2,
+                "end_line": 2
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/shootout-regex-dna.rs",
+            "type": "file",
+            "name": "shootout-regex-dna.rs",
+            "base_name": "shootout-regex-dna",
+            "extension": ".rs",
+            "size": 2019,
+            "date": "1970-01-01",
+            "sha1": "87ddf491ed3fa7c64130175892de4441706f9cb7",
+            "md5": "3f5e57c46dcb3defcfdda95236083ef1",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://benchmarksgame-team.pages.debian.net/benchmarksgame/",
+                "start_line": 2,
+                "end_line": 2
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src",
+            "type": "directory",
+            "name": "src",
+            "base_name": "src",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 28,
+            "dirs_count": 2,
+            "size_count": 463627,
+            "scan_errors": []
+          },
+          {
+            "path": "src/backtrack.rs",
+            "type": "file",
+            "name": "backtrack.rs",
+            "base_name": "backtrack",
+            "extension": ".rs",
+            "size": 10699,
+            "date": "1970-01-01",
+            "sha1": "0ce4af66cbbf5eb7b4ec3e895ccd9e8a1e0e5619",
+            "md5": "ebe1201acd420b94c705e3524ef97ccd",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/issues/215",
+                "start_line": 37,
+                "end_line": 37
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/compile.rs",
+            "type": "file",
+            "name": "compile.rs",
+            "base_name": "compile",
+            "extension": ".rs",
+            "size": 44368,
+            "date": "1970-01-01",
+            "sha1": "994606f5444b3bd24cff12abf22e89df5c92b1cb",
+            "md5": "c90adb43452ed1a5327efaabef828b69",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function",
+                "start_line": 1122,
+                "end_line": 1122
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/dfa.rs",
+            "type": "file",
+            "name": "dfa.rs",
+            "base_name": "dfa",
+            "extension": ".rs",
+            "size": 75618,
+            "date": "1970-01-01",
+            "sha1": "17171b41c83ac19a67ed7664228c3af45609a247",
+            "md5": "8fd4224cb349c4c0aae4858b12e35649",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://swtch.com/~rsc/regexp/",
+                "start_line": 34,
+                "end_line": 34
+              },
+              {
+                "url": "https://developers.google.com/protocol-buffers/docs/encoding#varints",
+                "start_line": 1848,
+                "end_line": 1848
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/error.rs",
+            "type": "file",
+            "name": "error.rs",
+            "base_name": "error",
+            "extension": ".rs",
+            "size": 2396,
+            "date": "1970-01-01",
+            "sha1": "848b397b1379cd7054b1c052eb6dcfba3751fad0",
+            "md5": "0f1ba388bbd63c859fcc3b7ac27b504c",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/exec.rs",
+            "type": "file",
+            "name": "exec.rs",
+            "base_name": "exec",
+            "extension": ".rs",
+            "size": 57211,
+            "date": "1970-01-01",
+            "sha1": "35084b1e0e7a1bcd2c6516596dbfaaca9cbd5cf6",
+            "md5": "7703168ee18d91b12044bc3401dedd12",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/expand.rs",
+            "type": "file",
+            "name": "expand.rs",
+            "base_name": "expand",
+            "extension": ".rs",
+            "size": 7116,
+            "date": "1970-01-01",
+            "sha1": "45c3c35a3d6ab2d5030c92d598bc2898b0187509",
+            "md5": "ed9260b089eefb266870f652f89166e3",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/pull/585",
+                "start_line": 223,
+                "end_line": 223
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/find_byte.rs",
+            "type": "file",
+            "name": "find_byte.rs",
+            "base_name": "find_byte",
+            "extension": ".rs",
+            "size": 634,
+            "date": "1970-01-01",
+            "sha1": "a395097fa0fa7f55e3c8ab7799b7b6a26f524488",
+            "md5": "d6b375fcfcda9b4e9c5cf600db4f6828",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/freqs.rs",
+            "type": "file",
+            "name": "freqs.rs",
+            "base_name": "freqs",
+            "extension": ".rs",
+            "size": 4527,
+            "date": "1970-01-01",
+            "sha1": "8a63c576ee115d36a87415461f0d315690ddb980",
+            "md5": "ca1542a51a77512c8fdbb9fc93e5ead2",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [
+              {
+                "value": "(c) 83",
+                "start_line": 174,
+                "end_line": 176
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/input.rs",
+            "type": "file",
+            "name": "input.rs",
+            "base_name": "input",
+            "extension": ".rs",
+            "size": 12069,
+            "date": "1970-01-01",
+            "sha1": "293cb8a3eec498c9eb8c0bf7c836498ebb99e9c9",
+            "md5": "80c39e2a4448a202beb5415f62f1410e",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/lib.rs",
+            "type": "file",
+            "name": "lib.rs",
+            "base_name": "lib",
+            "extension": ".rs",
+            "size": 28289,
+            "date": "1970-01-01",
+            "sha1": "5f96c5a2b3e1f32a387659cdce33e80e5322349a",
+            "md5": "c6c0b8ea4da1eeca8fb1cafff6390d60",
+            "mime_type": "text/x-c",
+            "file_type": "C source, UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://crates.io/crates/regex",
+                "start_line": 17,
+                "end_line": 17
+              },
+              {
+                "url": "https://doc.rust-lang.org/stable/reference/tokens.html#raw-string-literals",
+                "start_line": 43,
+                "end_line": 43
+              },
+              {
+                "url": "https://crates.io/crates/lazy_static",
+                "start_line": 59,
+                "end_line": 59
+              },
+              {
+                "url": "https://unicode.org/reports/tr18",
+                "start_line": 248,
+                "end_line": 248
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/blob/master/UNICODE.md",
+                "start_line": 250,
+                "end_line": 250
+              },
+              {
+                "url": "https://docs.rs/regex-syntax",
+                "start_line": 280,
+                "end_line": 280
+              },
+              {
+                "url": "https://www.unicode.org/reports/tr18/#Compatibility_Properties",
+                "start_line": 450,
+                "end_line": 450
+              },
+              {
+                "url": "https://www.unicode.org/reports/tr44/tr44-24.html#Character_Age",
+                "start_line": 545,
+                "end_line": 545
+              },
+              {
+                "url": "https://www.unicode.org/reports/tr18/#Simple_Loose_Matches",
+                "start_line": 554,
+                "end_line": 554
+              },
+              {
+                "url": "https://www.unicode.org/reports/tr44/tr44-24.html#General_Category_Values",
+                "start_line": 557,
+                "end_line": 557
+              },
+              {
+                "url": "https://www.unicode.org/reports/tr24",
+                "start_line": 568,
+                "end_line": 568
+              },
+              {
+                "url": "https://www.unicode.org/reports/tr29",
+                "start_line": 573,
+                "end_line": 573
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/684",
+                "start_line": 617,
+                "end_line": 617
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/685",
+                "start_line": 618,
+                "end_line": 618
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/pattern.rs",
+            "type": "file",
+            "name": "pattern.rs",
+            "base_name": "pattern",
+            "extension": ".rs",
+            "size": 1819,
+            "date": "1970-01-01",
+            "sha1": "abbbc722428eaca4d456c2159e9a03f0c50c49b4",
+            "md5": "753171bfa726818d514b8b3c64204752",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/pikevm.rs",
+            "type": "file",
+            "name": "pikevm.rs",
+            "base_name": "pikevm",
+            "extension": ".rs",
+            "size": 12700,
+            "date": "1970-01-01",
+            "sha1": "e4ccc6a75ee3ac71147044874e1ef036d7e0231e",
+            "md5": "19789ec4f85b8efaf0727e0b46bab1dc",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/pool.rs",
+            "type": "file",
+            "name": "pool.rs",
+            "base_name": "pool",
+            "extension": ".rs",
+            "size": 14633,
+            "date": "1970-01-01",
+            "sha1": "bc4d6328566e5bf40bc499d54824d206807b67a7",
+            "md5": "7fa81b96a50eb0a9cf159c015d945091",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/issues/362",
+                "start_line": 31,
+                "end_line": 31
+              },
+              {
+                "url": "https://github.com/BurntSushi/rure-go/issues/3",
+                "start_line": 53,
+                "end_line": 53
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/prog.rs",
+            "type": "file",
+            "name": "prog.rs",
+            "base_name": "prog",
+            "extension": ".rs",
+            "size": 15742,
+            "date": "1970-01-01",
+            "sha1": "1a5193ae480732beb6d7b582f648ea6712e6bbb8",
+            "md5": "dc9b744d339f1bcbce192c4523813b61",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/re_builder.rs",
+            "type": "file",
+            "name": "re_builder.rs",
+            "base_name": "re_builder",
+            "extension": ".rs",
+            "size": 18944,
+            "date": "1970-01-01",
+            "sha1": "7af2b6681b26f79e186ee3003554833532014464",
+            "md5": "e58d08356cd63adc7138b77e08c0057b",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/re_bytes.rs",
+            "type": "file",
+            "name": "re_bytes.rs",
+            "base_name": "re_bytes",
+            "extension": ".rs",
+            "size": 43517,
+            "date": "1970-01-01",
+            "sha1": "65cdd8fb0bdd9ee1d88aef5498f26a640cff1ea1",
+            "md5": "5360642fa66d266661ef6f70f3e4bd05",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/re_set.rs",
+            "type": "file",
+            "name": "re_set.rs",
+            "base_name": "re_set",
+            "extension": ".rs",
+            "size": 15769,
+            "date": "1970-01-01",
+            "sha1": "3d3f5923a87a9ff626f449bd1a9943b32bb7b6d2",
+            "md5": "bff14d00cdf8447b61984281806437cc",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/re_trait.rs",
+            "type": "file",
+            "name": "re_trait.rs",
+            "base_name": "re_trait",
+            "extension": ".rs",
+            "size": 8467,
+            "date": "1970-01-01",
+            "sha1": "9beabe1741eff38b56d0c1c6108d2b2db52c4854",
+            "md5": "9d5fb0c581ce1bdf18f5a5118be62f9f",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/re_unicode.rs",
+            "type": "file",
+            "name": "re_unicode.rs",
+            "base_name": "re_unicode",
+            "extension": ".rs",
+            "size": 44695,
+            "date": "1970-01-01",
+            "sha1": "6049a24a6f11dfa56e1559b7ffd6081294e3a993",
+            "md5": "faa2afe276895b36c431f233b1d4b992",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/sparse.rs",
+            "type": "file",
+            "name": "sparse.rs",
+            "base_name": "sparse",
+            "extension": ".rs",
+            "size": 2245,
+            "date": "1970-01-01",
+            "sha1": "458ec7e85c3621e160228c53534b4c68d143c7cc",
+            "md5": "109e709a0fb3238275958d1f89de51a2",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://research.swtch.com/sparse",
+                "start_line": 11,
+                "end_line": 11
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/utf8.rs",
+            "type": "file",
+            "name": "utf8.rs",
+            "base_name": "utf8",
+            "extension": ".rs",
+            "size": 8776,
+            "date": "1970-01-01",
+            "sha1": "b9d2f2f89997c4d2671437ee055bf5a3bd248f8e",
+            "md5": "e472c4cd63f3d2ef73dcf60ed78671c8",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/literal",
+            "type": "directory",
+            "name": "literal",
+            "base_name": "literal",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 2,
+            "dirs_count": 0,
+            "size_count": 13910,
+            "scan_errors": []
+          },
+          {
+            "path": "src/literal/imp.rs",
+            "type": "file",
+            "name": "imp.rs",
+            "base_name": "imp",
+            "extension": ".rs",
+            "size": 12776,
+            "date": "1970-01-01",
+            "sha1": "ee7ca8c60eb1dc6342f6a831d9d7aec74b144b53",
+            "md5": "d69a4bec14a0e7e8d858591189f98294",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/literal/mod.rs",
+            "type": "file",
+            "name": "mod.rs",
+            "base_name": "mod",
+            "extension": ".rs",
+            "size": 1134,
+            "date": "1970-01-01",
+            "sha1": "f498786b8dd7091f42ce6f8856b5d431d507233f",
+            "md5": "17eb694532ed4e6943e647a53698e9dc",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/testdata",
+            "type": "directory",
+            "name": "testdata",
+            "base_name": "testdata",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 5,
+            "dirs_count": 0,
+            "size_count": 19483,
+            "scan_errors": []
+          },
+          {
+            "path": "src/testdata/basic.dat",
+            "type": "file",
+            "name": "basic.dat",
+            "base_name": "basic",
+            "extension": ".dat",
+            "size": 8737,
+            "date": "1970-01-01",
+            "sha1": "bf772321e16a4806ee201346e4285d9658695a4a",
+            "md5": "1364773fb8ededa72440973eb03c9dcb",
+            "mime_type": "application/octet-stream",
+            "file_type": "data",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/testdata/LICENSE",
+            "type": "file",
+            "name": "LICENSE",
+            "base_name": "LICENSE",
+            "extension": "",
+            "size": 1156,
+            "date": "1970-01-01",
+            "sha1": "553e82bef8637312393c95bc62e23e8f81fd9e47",
+            "md5": "29303077b607c58fcaf6fc3299effac1",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit-synopsys",
+                "score": 79.21,
+                "name": "MIT Synopsys License",
+                "short_name": "MIT Synopsys License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Synopsys",
+                "homepage_url": "",
+                "text_url": "",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit-synopsys",
+                "spdx_license_key": "",
+                "spdx_url": "",
+                "start_line": 3,
+                "end_line": 19,
+                "matched_rule": {
+                  "identifier": "mit-synopsys.LICENSE",
+                  "license_expression": "mit-synopsys",
+                  "licenses": [
+                    "mit-synopsys"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "3-seq",
+                  "rule_length": 202,
+                  "matched_length": 160,
+                  "match_coverage": 79.21,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Permission is hereby granted, free of charge, to any person obtaining a\ncopy of THIS SOFTWARE [FILE] (the \"Software\"), to deal in the Software\nwithout restriction, including without limitation the rights to use,\ncopy, modify, merge, publish, distribute, and/or sell copies of the\nSoftware, and to permit persons to whom the Software is furnished to do\nso, subject to the following [disclaimer]:\n\n[THIS] [SOFTWARE] [IS] [PROVIDED] [BY] [AT]&[T] ``[AS] [IS]'' AND ANY EXPRESS OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF\nMERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\nIN NO EVENT SHALL [AT]&[T] BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\nLIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\nDATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\nTHEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+              }
+            ],
+            "license_expressions": [
+              "mit-synopsys"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/testdata/nullsubexpr.dat",
+            "type": "file",
+            "name": "nullsubexpr.dat",
+            "base_name": "nullsubexpr",
+            "extension": ".dat",
+            "size": 2086,
+            "date": "1970-01-01",
+            "sha1": "9631512e2ad27414672e44f3bfc040d0f83cf686",
+            "md5": "dc8f89c5577c9e97d90c25c8341830db",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/testdata/README",
+            "type": "file",
+            "name": "README",
+            "base_name": "README",
+            "extension": "",
+            "size": 736,
+            "date": "1970-01-01",
+            "sha1": "01f8233ffcdab4cd03c4a2a05a155f6d6eae3290",
+            "md5": "c71a8bc6aef9469fcde039f94e242894",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://www2.research.att.com/~astopen/testregex/testregex.html",
+                "start_line": 4,
+                "end_line": 4
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": true,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/testdata/repetition.dat",
+            "type": "file",
+            "name": "repetition.dat",
+            "base_name": "repetition",
+            "extension": ".dat",
+            "size": 6768,
+            "date": "1970-01-01",
+            "sha1": "7115777cd017589c96cebe2456e28a3827da0a2a",
+            "md5": "d74a2270e824df28aeed25dcfd500905",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [
+              {
+                "email": "gsf@research.att.com",
+                "start_line": 3,
+                "end_line": 3
+              }
+            ],
+            "urls": [
+              {
+                "url": "http://www.haskell.org/",
+                "start_line": 85,
+                "end_line": 85
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests",
+            "type": "directory",
+            "name": "tests",
+            "base_name": "tests",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 34,
+            "dirs_count": 0,
+            "size_count": 246754,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/api.rs",
+            "type": "file",
+            "name": "api.rs",
+            "base_name": "api",
+            "extension": ".rs",
+            "size": 6999,
+            "date": "1970-01-01",
+            "sha1": "28ee18875c468cb7cf27a6e735750f07e5235d99",
+            "md5": "7b8a1bd1f8f7a99b76d0d911a0689fa6",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/api_str.rs",
+            "type": "file",
+            "name": "api_str.rs",
+            "base_name": "api_str",
+            "extension": ".rs",
+            "size": 1100,
+            "date": "1970-01-01",
+            "sha1": "f50036ff5054be66c0697660eb0bc8619e6b9dbc",
+            "md5": "79b3487c9f6417cf1657c7d35095db58",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/bytes.rs",
+            "type": "file",
+            "name": "bytes.rs",
+            "base_name": "bytes",
+            "extension": ".rs",
+            "size": 3435,
+            "date": "1970-01-01",
+            "sha1": "2868995c1c7f9a0fbdce42f4a7e6f737f5e29fa4",
+            "md5": "73c929a13eb68873a4b8f2559f275f7a",
+            "mime_type": "text/x-c",
+            "file_type": "C source, UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/issues/277",
+                "start_line": 65,
+                "end_line": 65
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/303",
+                "start_line": 85,
+                "end_line": 85
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/264",
+                "start_line": 102,
+                "end_line": 102
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/271",
+                "start_line": 106,
+                "end_line": 106
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/consistent.rs",
+            "type": "file",
+            "name": "consistent.rs",
+            "base_name": "consistent",
+            "extension": ".rs",
+            "size": 8508,
+            "date": "1970-01-01",
+            "sha1": "932b495a6cde0c50a740b9c32366ceb46defe2bb",
+            "md5": "7d34016f300c85b35bc77522a84830ac",
+            "mime_type": "text/x-asm",
+            "file_type": "assembler source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/crates_regex.rs",
+            "type": "file",
+            "name": "crates_regex.rs",
+            "base_name": "crates_regex",
+            "extension": ".rs",
+            "size": 126143,
+            "date": "1970-01-01",
+            "sha1": "c2ea44c1bea699bf5710873fbcefc983e7db648b",
+            "md5": "b75f4855f587c9ce2e9a59a97a5459fc",
+            "mime_type": "text/plain",
+            "file_type": "exported SGML document, UTF-8 Unicode text, with very long lines",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://lorempixel.com/100/100/",
+                "start_line": 973,
+                "end_line": 973
+              },
+              {
+                "url": "http://lorempixel.com/100/100/cats",
+                "start_line": 976,
+                "end_line": 976
+              },
+              {
+                "url": "https://github.com/",
+                "start_line": 1768,
+                "end_line": 1768
+              },
+              {
+                "url": "https://gitlab.com/",
+                "start_line": 1774,
+                "end_line": 1774
+              },
+              {
+                "url": "http://domain.org/",
+                "start_line": 1873,
+                "end_line": 1873
+              },
+              {
+                "url": "http://domain.org/nocookies.sjs",
+                "start_line": 1888,
+                "end_line": 1888
+              },
+              {
+                "url": "http://domain.org/ok.html",
+                "start_line": 1897,
+                "end_line": 1897
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/crazy.rs",
+            "type": "file",
+            "name": "crazy.rs",
+            "base_name": "crazy",
+            "extension": ".rs",
+            "size": 11214,
+            "date": "1970-01-01",
+            "sha1": "129615cc2d9640aeb07cadf043855af4f1b64b93",
+            "md5": "8f9a36e51329acf7996f86d4a5c8e696",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [
+              {
+                "email": "jam.slam@gmail.com",
+                "start_line": 23,
+                "end_line": 23
+              }
+            ],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/flags.rs",
+            "type": "file",
+            "name": "flags.rs",
+            "base_name": "flags",
+            "extension": ".rs",
+            "size": 895,
+            "date": "1970-01-01",
+            "sha1": "60d870b1aa441c62cfc48d3a3dd554a8b2fee507",
+            "md5": "09c05df80bc5d0cd89b72715f40d5748",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/fowler.rs",
+            "type": "file",
+            "name": "fowler.rs",
+            "base_name": "fowler",
+            "extension": ".rs",
+            "size": 34121,
+            "date": "1970-01-01",
+            "sha1": "cd4bed571684b4542ad028ff6e5f7e8d4c3b60b1",
+            "md5": "cce4cdca03be9d3c40f6bb000b5e5cde",
+            "mime_type": "application/octet-stream",
+            "file_type": "data",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/macros.rs",
+            "type": "file",
+            "name": "macros.rs",
+            "base_name": "macros",
+            "extension": ".rs",
+            "size": 5212,
+            "date": "1970-01-01",
+            "sha1": "9dbdd1065e0e97edc1a1a07a6a1b5760e830c33f",
+            "md5": "cd3673efa8aacfd1211f52f7472f6c18",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/macros_bytes.rs",
+            "type": "file",
+            "name": "macros_bytes.rs",
+            "base_name": "macros_bytes",
+            "extension": ".rs",
+            "size": 1165,
+            "date": "1970-01-01",
+            "sha1": "1b9f2a9bfbd5ff06d5b6d3de57d212b66e69ff4c",
+            "md5": "b612c33f675d6b69c936e0f34203e6b1",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/macros_str.rs",
+            "type": "file",
+            "name": "macros_str.rs",
+            "base_name": "macros_str",
+            "extension": ".rs",
+            "size": 1344,
+            "date": "1970-01-01",
+            "sha1": "59d2b598cd7b7e8b5b18a8ee6f5a46a0d10caa93",
+            "md5": "99f62e4bfca832453ee762121902d8d6",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/misc.rs",
+            "type": "file",
+            "name": "misc.rs",
+            "base_name": "misc",
+            "extension": ".rs",
+            "size": 206,
+            "date": "1970-01-01",
+            "sha1": "b5d590ef3de94e2445dd7fd7ddb87b50faa20ad3",
+            "md5": "2c9f3b071eb1dba7ad57d035ea6c9288",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/multiline.rs",
+            "type": "file",
+            "name": "multiline.rs",
+            "base_name": "multiline",
+            "extension": ".rs",
+            "size": 2530,
+            "date": "1970-01-01",
+            "sha1": "c08bc71c9748bd62971d1cf20395099e93314050",
+            "md5": "21a4632f5ffdc909e26fea8e2b308ac4",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/noparse.rs",
+            "type": "file",
+            "name": "noparse.rs",
+            "base_name": "noparse",
+            "extension": ".rs",
+            "size": 1582,
+            "date": "1970-01-01",
+            "sha1": "310ae03fac7684f446d4f2368e6380cc1dc6daab",
+            "md5": "06b10de047f4094ea49d335be7ca467f",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/regression.rs",
+            "type": "file",
+            "name": "regression.rs",
+            "base_name": "regression",
+            "extension": ".rs",
+            "size": 6694,
+            "date": "1970-01-01",
+            "sha1": "f2a03e99b05fc586295615006a8c5febfe927f19",
+            "md5": "d67ae8338b0132dd964e06d94b3244fe",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/issues/48",
+                "start_line": 1,
+                "end_line": 1
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/98",
+                "start_line": 10,
+                "end_line": 10
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/555",
+                "start_line": 17,
+                "end_line": 17
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/527",
+                "start_line": 23,
+                "end_line": 23
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/75",
+                "start_line": 29,
+                "end_line": 29
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/99",
+                "start_line": 33,
+                "end_line": 33
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/101",
+                "start_line": 39,
+                "end_line": 39
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/129",
+                "start_line": 42,
+                "end_line": 42
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/153",
+                "start_line": 50,
+                "end_line": 50
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/169",
+                "start_line": 54,
+                "end_line": 54
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/76",
+                "start_line": 57,
+                "end_line": 57
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/191",
+                "start_line": 61,
+                "end_line": 61
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/204",
+                "start_line": 69,
+                "end_line": 69
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/268",
+                "start_line": 98,
+                "end_line": 98
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/280",
+                "start_line": 101,
+                "end_line": 101
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/289",
+                "start_line": 105,
+                "end_line": 105
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/291",
+                "start_line": 108,
+                "end_line": 108
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/271",
+                "start_line": 120,
+                "end_line": 120
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/321",
+                "start_line": 127,
+                "end_line": 127
+              },
+              {
+                "url": "https://github.com/BurntSushi/ripgrep/issues/1203",
+                "start_line": 131,
+                "end_line": 131
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/334",
+                "start_line": 136,
+                "end_line": 136
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/557",
+                "start_line": 137,
+                "end_line": 137
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/437",
+                "start_line": 156,
+                "end_line": 156
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/533",
+                "start_line": 164,
+                "end_line": 164
+              },
+              {
+                "url": "https://github.com/BurntSushi/ripgrep/issues/1247",
+                "start_line": 195,
+                "end_line": 195
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/640",
+                "start_line": 203,
+                "end_line": 203
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/659",
+                "start_line": 214,
+                "end_line": 214
+              },
+              {
+                "url": "https://en.wikipedia.org/wiki/Je_",
+                "start_line": 217,
+                "end_line": 217
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/regression_fuzz.rs",
+            "type": "file",
+            "name": "regression_fuzz.rs",
+            "base_name": "regression_fuzz",
+            "extension": ".rs",
+            "size": 1103,
+            "date": "1970-01-01",
+            "sha1": "af9600e2249bc0e9e5a51480c34346507b34fefa",
+            "md5": "e46722a54ceec899d843a50825da03aa",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://oss-fuzz.com/testcase-detail/5673225499181056",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26505",
+                "start_line": 14,
+                "end_line": 14
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/722",
+                "start_line": 15,
+                "end_line": 15
+              },
+              {
+                "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33579",
+                "start_line": 26,
+                "end_line": 26
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/replace.rs",
+            "type": "file",
+            "name": "replace.rs",
+            "base_name": "replace",
+            "extension": ".rs",
+            "size": 4353,
+            "date": "1970-01-01",
+            "sha1": "1ef541a4e4165691418ff1e30ba986a64208a8a5",
+            "md5": "fc380e6aea269d3cb85b405b352226b9",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/issues/314",
+                "start_line": 111,
+                "end_line": 111
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/393",
+                "start_line": 121,
+                "end_line": 121
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/399",
+                "start_line": 124,
+                "end_line": 124
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/searcher.rs",
+            "type": "file",
+            "name": "searcher.rs",
+            "base_name": "searcher",
+            "extension": ".rs",
+            "size": 2459,
+            "date": "1970-01-01",
+            "sha1": "e7ceb209b2d556ea94eada036ecf25692b702164",
+            "md5": "bed117bff168866a621b3013739e3a68",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/set.rs",
+            "type": "file",
+            "name": "set.rs",
+            "base_name": "set",
+            "extension": ".rs",
+            "size": 2099,
+            "date": "1970-01-01",
+            "sha1": "c0d70fd37a36275897b808833a512b8a54ddbae4",
+            "md5": "dadcc1f402b6b82546493836e6a2c8c9",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/issues/187",
+                "start_line": 43,
+                "end_line": 43
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/shortest_match.rs",
+            "type": "file",
+            "name": "shortest_match.rs",
+            "base_name": "shortest_match",
+            "extension": ".rs",
+            "size": 438,
+            "date": "1970-01-01",
+            "sha1": "04387f3ad627444f1bfdcc2d9ab9c8a2b8916192",
+            "md5": "c8cd82b504404657e287b187be1d0053",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/suffix_reverse.rs",
+            "type": "file",
+            "name": "suffix_reverse.rs",
+            "base_name": "suffix_reverse",
+            "extension": ".rs",
+            "size": 322,
+            "date": "1970-01-01",
+            "sha1": "2408f57b62224bff2ba09a54875ea9672204939e",
+            "md5": "6e907a4fb124b3f2f8e0d336f1cfd3f6",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test_backtrack.rs",
+            "type": "file",
+            "name": "test_backtrack.rs",
+            "base_name": "test_backtrack",
+            "extension": ".rs",
+            "size": 1096,
+            "date": "1970-01-01",
+            "sha1": "7bdab4e10a7ad6d9e9c003ce1cf856007d8ede7a",
+            "md5": "b86c4a39171741596910e6533bf2812e",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test_backtrack_bytes.rs",
+            "type": "file",
+            "name": "test_backtrack_bytes.rs",
+            "base_name": "test_backtrack_bytes",
+            "extension": ".rs",
+            "size": 1097,
+            "date": "1970-01-01",
+            "sha1": "1c20c7c3436d1fa02db9561078e85576653b16a5",
+            "md5": "a26c6286fbc68a2746269c97084b069e",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test_backtrack_utf8bytes.rs",
+            "type": "file",
+            "name": "test_backtrack_utf8bytes.rs",
+            "base_name": "test_backtrack_utf8bytes",
+            "extension": ".rs",
+            "size": 1146,
+            "date": "1970-01-01",
+            "sha1": "ec0689437246dd8cbf7dd8bd0fbfb42252d19542",
+            "md5": "9397e511a803c177d21958ef1efd21f5",
+            "mime_type": "text/x-asm",
+            "file_type": "assembler source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test_crates_regex.rs",
+            "type": "file",
+            "name": "test_crates_regex.rs",
+            "base_name": "test_crates_regex",
+            "extension": ".rs",
+            "size": 1377,
+            "date": "1970-01-01",
+            "sha1": "a8a031a12ec6469856c92e225e698e8c138912b1",
+            "md5": "52b8735955a1d8a7a5de0f1bb7c3ec88",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test_default.rs",
+            "type": "file",
+            "name": "test_default.rs",
+            "base_name": "test_default",
+            "extension": ".rs",
+            "size": 4017,
+            "date": "1970-01-01",
+            "sha1": "fdcb3fb3f4f24cab29403b61ce91f6431beffb02",
+            "md5": "700e91f663e39c19f9f8f052b7698686",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/issues/568",
+                "start_line": 130,
+                "end_line": 130
+              },
+              {
+                "url": "https://github.com/rust-lang/regex/issues/750",
+                "start_line": 139,
+                "end_line": 139
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test_default_bytes.rs",
+            "type": "file",
+            "name": "test_default_bytes.rs",
+            "base_name": "test_default_bytes",
+            "extension": ".rs",
+            "size": 1514,
+            "date": "1970-01-01",
+            "sha1": "95ff26130a8cb3a223424c7a3323792b9307bb47",
+            "md5": "b9ae1ab464c982c066278ae0e3e4067b",
+            "mime_type": "text/x-c",
+            "file_type": "C source, UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/issues/321",
+                "start_line": 39,
+                "end_line": 39
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test_nfa.rs",
+            "type": "file",
+            "name": "test_nfa.rs",
+            "base_name": "test_nfa",
+            "extension": ".rs",
+            "size": 984,
+            "date": "1970-01-01",
+            "sha1": "a83b98f631fbbfbf0b609bee3b4d30770284ecd8",
+            "md5": "402a205f3dae09172f2750c85e39626e",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test_nfa_bytes.rs",
+            "type": "file",
+            "name": "test_nfa_bytes.rs",
+            "base_name": "test_nfa_bytes",
+            "extension": ".rs",
+            "size": 1065,
+            "date": "1970-01-01",
+            "sha1": "d1d1f5c60a254aaa2afe825ed81a4bfebc56144a",
+            "md5": "6b3a118efb81c30758db56d9b0cecba5",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/test_nfa_utf8bytes.rs",
+            "type": "file",
+            "name": "test_nfa_utf8bytes.rs",
+            "base_name": "test_nfa_utf8bytes",
+            "extension": ".rs",
+            "size": 1060,
+            "date": "1970-01-01",
+            "sha1": "999d5295a5212cdabaebb20ecb36ac83215652c2",
+            "md5": "59ef26a3ee8c472b868bcf76716ed3d0",
+            "mime_type": "text/x-asm",
+            "file_type": "assembler source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/unicode.rs",
+            "type": "file",
+            "name": "unicode.rs",
+            "base_name": "unicode",
+            "extension": ".rs",
+            "size": 6952,
+            "date": "1970-01-01",
+            "sha1": "da5038d8ba955495a6ca95c0171c891dc7a132ea",
+            "md5": "3364bd8a0a1eb96b5d36e98b71fd3fb8",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/regex/issues/719",
+                "start_line": 77,
+                "end_line": 77
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/word_boundary.rs",
+            "type": "file",
+            "name": "word_boundary.rs",
+            "base_name": "word_boundary",
+            "extension": ".rs",
+            "size": 3781,
+            "date": "1970-01-01",
+            "sha1": "4bb48b2eb2d5d4767327c280b87683090ea0ab96",
+            "md5": "e7238ee326b3286a987666f571d5cadd",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/word_boundary_ascii.rs",
+            "type": "file",
+            "name": "word_boundary_ascii.rs",
+            "base_name": "word_boundary_ascii",
+            "extension": ".rs",
+            "size": 477,
+            "date": "1970-01-01",
+            "sha1": "9b586ecdf6ef6dafe24bb954688c15547a7a05ff",
+            "md5": "a1f0798b8be30dcd26a134f177d6e0ce",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "tests/word_boundary_unicode.rs",
+            "type": "file",
+            "name": "word_boundary_unicode.rs",
+            "base_name": "word_boundary_unicode",
+            "extension": ".rs",
+            "size": 266,
+            "date": "1970-01-01",
+            "sha1": "d21c987013ae8dd41ea9c84ce372a708e33464b2",
+            "md5": "17ba13b2d8e7fbe3a55992065fd1aab4",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/business/evidence/crate-serde-1.0.123.json
+++ b/test/business/evidence/crate-serde-1.0.123.json
@@ -1,0 +1,3352 @@
+{
+  "clearlydefined": {
+    "1.2.0": {
+      "_metadata": {
+        "type": "crate",
+        "url": "cd:/crate/cratesio/-/serde/1.0.123",
+        "fetchedAt": "2021-01-29T16:36:42.919Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:serde:revision:1.0.123:tool:clearlydefined:1.2.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:serde:revision:1.0.123:tool:clearlydefined",
+            "type": "collection"
+          },
+          "licensee": {
+            "href": "urn:crate:cratesio:-:serde:revision:1.0.123:tool:licensee",
+            "type": "collection"
+          },
+          "scancode": {
+            "href": "urn:crate:cratesio:-:serde:revision:1.0.123:tool:scancode",
+            "type": "collection"
+          },
+          "source": {
+            "href": "urn:git:github:serde-rs:serde:revision:3d6c4149b177e9cadfb948ebc6d1e55b33861792",
+            "type": "resource"
+          }
+        },
+        "schemaVersion": "1.2.0",
+        "toolVersion": "1.0.0"
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-APACHE",
+          "token": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+        },
+        {
+          "path": "LICENSE-MIT",
+          "token": "23f18e03dc49df91622fe2a76176497404e46ced8a715d9d2b67a7446571cca3"
+        }
+      ],
+      "summaryInfo": {
+        "k": 501,
+        "count": 27,
+        "hashes": {
+          "sha1": "968b745d5ea557515eed94f918bc2365d7ac9d7c",
+          "sha256": "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+        }
+      },
+      "files": [
+        {
+          "path": ".cargo_vcs_info.json",
+          "hashes": {
+            "sha1": "598e56ffb4b722e24ff813b9f86655ee4e7368af",
+            "sha256": "166f2bfc626ae4b78a1400ff91c0a1c5cadd969a9fa63f2bf606add8e4322b85"
+          }
+        },
+        {
+          "path": "Cargo.toml",
+          "hashes": {
+            "sha1": "5c2b91a3aec04b5dd9ed7f305b3f571455b4259c",
+            "sha256": "6c9c8ff479865fac1f930e0d937d496089a862b18b3b48b2294f73527ee03633"
+          }
+        },
+        {
+          "path": "Cargo.toml.orig",
+          "hashes": {
+            "sha1": "b0fbe29be72e1f95eefa22d417fee2ec4f15331e",
+            "sha256": "92a24b67baf0ccf468a6d172975fcb78ba96916042a9d3dd0e505ac046094b69"
+          }
+        },
+        {
+          "path": "LICENSE-APACHE",
+          "hashes": {
+            "sha1": "5798832c31663cedc1618d18544d445da0295229",
+            "sha256": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+          }
+        },
+        {
+          "path": "LICENSE-MIT",
+          "hashes": {
+            "sha1": "ce3a2603094e799f42ce99c40941544dfcc5c4a5",
+            "sha256": "23f18e03dc49df91622fe2a76176497404e46ced8a715d9d2b67a7446571cca3"
+          }
+        },
+        {
+          "path": "README.md",
+          "hashes": {
+            "sha1": "df577d0370d9349360247b1a7ee7bb06b6e925ea",
+            "sha256": "5cf9d2158d70048a2916360ad59d9079f6233c6f68781a7a792e70f8b772d8ce"
+          }
+        },
+        {
+          "path": "build.rs",
+          "hashes": {
+            "sha1": "5b18cbfe592282076a4957488930d50fddc93b30",
+            "sha256": "acb97ae670fac691f1137cd72305971de597e10306ec977334fca5468b90d482"
+          }
+        },
+        {
+          "path": "crates-io.md",
+          "hashes": {
+            "sha1": "40ca313f755628a0e54d86c0ff82b51a33096f5d",
+            "sha256": "25ed421fe25d0f6f74c4b78674144bef2843a5f78bf552d0a8ec633be69d282b"
+          }
+        },
+        {
+          "path": "src/de/ignored_any.rs",
+          "hashes": {
+            "sha1": "3e4c14aa8d8527a42e1e8dc3104d84ae4cee4ed0",
+            "sha256": "c69d6071191c2075372218442e9e73991335c6b4be18736a7a789f04bb305525"
+          }
+        },
+        {
+          "path": "src/de/impls.rs",
+          "hashes": {
+            "sha1": "2a5bce6f8c22fa8baaa1d09b8e6fc3641629d7a6",
+            "sha256": "7e510f972d5f64837946fdbbd20a655c5f86f1bec6f11473c7226773de703c9d"
+          }
+        },
+        {
+          "path": "src/de/mod.rs",
+          "hashes": {
+            "sha1": "f60feed73d82247779f6c854dfab6da91493f91f",
+            "sha256": "4db241ed202d418c85fdcee34b70a807269514f8678a3997d52ced96aef85b95"
+          }
+        },
+        {
+          "path": "src/de/seed.rs",
+          "hashes": {
+            "sha1": "da542a0d31c10ed59ecd23c65cf9fb8a7a1ff728",
+            "sha256": "e8cf0233afe0af5b8fb9e4c94f301c92729c5ba417280af9e2201b732e374a72"
+          }
+        },
+        {
+          "path": "src/de/utf8.rs",
+          "hashes": {
+            "sha1": "a751f40d78f33755537d481915fa682825687bd4",
+            "sha256": "f17524ee0af98ec3abcfd7d0b812fbd1033263bd8e2ce2f57c1e1999ce153558"
+          }
+        },
+        {
+          "path": "src/de/value.rs",
+          "hashes": {
+            "sha1": "1f9188dc54bd5442f7002be2cbd721c5d568f5e9",
+            "sha256": "82d530d0bc50cba75a095c819b4269d58229a7384043f7f6e674891cc6dae7bb"
+          }
+        },
+        {
+          "path": "src/integer128.rs",
+          "hashes": {
+            "sha1": "57f6216ec2b3912ac18fddfd5f5ab99f197aa5c4",
+            "sha256": "12f6ce6a513c1c293398db38cf1d3ea7c0c5a6717152621bcba61f49abc7b5b1"
+          }
+        },
+        {
+          "path": "src/lib.rs",
+          "hashes": {
+            "sha1": "597aff1885023f230d8298cb2ebdb874884a2385",
+            "sha256": "ea5d73407f121e76ef88c0429ac0a4ccb6404759d7617feafe9f83c9f3e7f36e"
+          }
+        },
+        {
+          "path": "src/macros.rs",
+          "hashes": {
+            "sha1": "0b7d14e30c68261a106c3e7b55cc520c0ee638a8",
+            "sha256": "3d695a51f0a07f9f719dcb5620012c21a1b084c06a6283349cabf574ceba8123"
+          }
+        },
+        {
+          "path": "src/private/de.rs",
+          "hashes": {
+            "sha1": "e495677229c9cd0fdc952e2b242ad9da3b4e5eb5",
+            "sha256": "8bbb2af37030ddd41d20cc09642680c3c1daf97dca1845e911f33e06323c64c0"
+          }
+        },
+        {
+          "path": "src/private/doc.rs",
+          "hashes": {
+            "sha1": "d71e4c92100ff7cf4ad5d60bf9d1a891609252ab",
+            "sha256": "e9801a43c3088fccd5f1fac76416698f948e65b647024aa9da17d673e1e8c217"
+          }
+        },
+        {
+          "path": "src/private/mod.rs",
+          "hashes": {
+            "sha1": "57a5944a2d4bf5b8b18298cb0236de07d2ed1255",
+            "sha256": "67cf4471f6bfd390f0e591a96603b3c434ba2912d8392e3520ec7578b9b42ab3"
+          }
+        },
+        {
+          "path": "src/private/ser.rs",
+          "hashes": {
+            "sha1": "59a95c19b4022ee1e5985ec78396f130623a48e5",
+            "sha256": "3a90dfb5c17e81bf1d959fed60a9477713498e9d0934463627c98709132f066e"
+          }
+        },
+        {
+          "path": "src/private/size_hint.rs",
+          "hashes": {
+            "sha1": "c8e315d616e690dafaeb90799b6a7668fd8d8bc6",
+            "sha256": "605521227e9ba3100fbb9d5ea7fd5853385097c35015ce6908bd5f1ea20d59ad"
+          }
+        },
+        {
+          "path": "src/ser/fmt.rs",
+          "hashes": {
+            "sha1": "384b453b24db9404ef94527677a5d531f66e17f4",
+            "sha256": "7827ed07fd8897e6324f75625ba0c926a4c4e7ec2914cd067391ce54d942ac7b"
+          }
+        },
+        {
+          "path": "src/ser/impls.rs",
+          "hashes": {
+            "sha1": "2d336b0ba735e04bc3694d15b7dbe134d88205d2",
+            "sha256": "496b7ba45529e569ffdf5d755c6df99c1321fddc89b9f64f5cc58e24052caefc"
+          }
+        },
+        {
+          "path": "src/ser/impossible.rs",
+          "hashes": {
+            "sha1": "50a0fb487bcae7b4260d503f0f6b87a552bc4486",
+            "sha256": "db17913522c1c27389c5a085113911353b9813c1b116518681362e7c8b692c3a"
+          }
+        },
+        {
+          "path": "src/ser/mod.rs",
+          "hashes": {
+            "sha1": "e6d85f319683df0aa137377d88aaea4a79f26a67",
+            "sha256": "2ad1f3a41a23d8413affe4f6ab261c7c888ba924c7aada030332d178d7872c98"
+          }
+        },
+        {
+          "path": "src/std_error.rs",
+          "hashes": {
+            "sha1": "d9cbedc053165a06a20d922612c80f493be90c63",
+            "sha256": "3aac687856c035517fae44ed2906dd4a1e3184bae4bf613adcdeb73f74126c57"
+          }
+        }
+      ],
+      "manifest": {
+        "id": "serde",
+        "name": "serde",
+        "updated_at": "2021-01-25T21:44:12.137298+00:00",
+        "versions": [
+          331767,
+          331369,
+          330972,
+          329177,
+          326110,
+          312296,
+          293950,
+          282474,
+          271456,
+          254679,
+          254044,
+          252312,
+          246881,
+          239581,
+          239560,
+          239539,
+          239190,
+          227557,
+          222448,
+          196666,
+          192011,
+          185512,
+          176433,
+          174777,
+          169951,
+          165828,
+          163551,
+          163530,
+          163315,
+          158762,
+          157964,
+          153883,
+          148904,
+          143032,
+          136515,
+          134063,
+          131792,
+          131387,
+          128970,
+          124929,
+          124370,
+          121941,
+          121344,
+          112600,
+          108387,
+          107452,
+          107194,
+          106477,
+          105274,
+          105095,
+          104994,
+          104714,
+          102798,
+          98987,
+          98381,
+          98173,
+          98016,
+          95252,
+          95083,
+          94732,
+          94573,
+          94279,
+          94247,
+          94157,
+          93640,
+          93502,
+          93389,
+          93321,
+          92524,
+          92451,
+          92219,
+          92111,
+          91900,
+          91781,
+          91765,
+          91754,
+          91688,
+          91650,
+          91189,
+          91090,
+          90044,
+          89843,
+          89650,
+          89580,
+          89317,
+          88972,
+          87282,
+          86577,
+          86245,
+          85939,
+          84991,
+          84617,
+          84593,
+          84464,
+          83988,
+          83920,
+          75967,
+          75649,
+          75346,
+          73760,
+          72753,
+          72731,
+          71461,
+          71138,
+          70551,
+          70126,
+          69858,
+          69089,
+          65588,
+          64913,
+          64909,
+          64467,
+          60822,
+          59405,
+          58325,
+          54218,
+          53794,
+          53565,
+          53302,
+          52979,
+          52929,
+          51535,
+          51127,
+          50790,
+          51126,
+          50524,
+          49588,
+          48856,
+          47109,
+          46591,
+          46261,
+          46038,
+          45106,
+          44406,
+          44024,
+          43807,
+          43637,
+          43599,
+          43329,
+          43318,
+          43304,
+          43171,
+          42968,
+          42394,
+          42863,
+          42059,
+          40411,
+          39818,
+          38347,
+          38113,
+          37118,
+          36469,
+          36343,
+          36273,
+          35932,
+          35429,
+          35097,
+          34843,
+          34413,
+          33310,
+          33161,
+          32970,
+          32850,
+          32248,
+          32069,
+          32001,
+          31618,
+          30852,
+          30643,
+          30335,
+          30311,
+          30770,
+          29783,
+          29631,
+          29528,
+          29103,
+          28472,
+          28379,
+          28223,
+          28002,
+          27920,
+          26955,
+          26577,
+          23031,
+          22773,
+          22586,
+          22363,
+          22293,
+          21214,
+          20958,
+          19789,
+          19124,
+          16846,
+          15358,
+          15304,
+          14755,
+          14442,
+          14255,
+          13253,
+          12279,
+          11493,
+          10471,
+          9752,
+          9492,
+          8748,
+          7654,
+          6133,
+          6130,
+          857
+        ],
+        "keywords": [
+          "serialization",
+          "no_std",
+          "serde"
+        ],
+        "categories": [
+          "encoding"
+        ],
+        "badges": [],
+        "created_at": "2014-12-05T20:20:39.487502+00:00",
+        "downloads": 36048260,
+        "recent_downloads": 5503544,
+        "max_version": "1.0.123",
+        "newest_version": "1.0.123",
+        "max_stable_version": "1.0.123",
+        "description": "A generic serialization/deserialization framework",
+        "homepage": "https://serde.rs",
+        "documentation": "https://docs.serde.rs/serde/",
+        "repository": "https://github.com/serde-rs/serde",
+        "links": {
+          "version_downloads": "/api/v1/crates/serde/downloads",
+          "versions": null,
+          "owners": "/api/v1/crates/serde/owners",
+          "owner_team": "/api/v1/crates/serde/owner_team",
+          "owner_user": "/api/v1/crates/serde/owner_user",
+          "reverse_dependencies": "/api/v1/crates/serde/reverse_dependencies"
+        },
+        "exact_match": false
+      },
+      "registryData": {
+        "id": 331767,
+        "crate": "serde",
+        "num": "1.0.123",
+        "dl_path": "/api/v1/crates/serde/1.0.123/download",
+        "readme_path": "/api/v1/crates/serde/1.0.123/readme",
+        "updated_at": "2021-01-25T21:44:12.137298+00:00",
+        "created_at": "2021-01-25T21:44:12.137298+00:00",
+        "downloads": 156946,
+        "features": {
+          "alloc": [],
+          "default": [
+            "std"
+          ],
+          "derive": [
+            "serde_derive"
+          ],
+          "rc": [],
+          "std": [],
+          "unstable": []
+        },
+        "yanked": false,
+        "license": "MIT OR Apache-2.0",
+        "links": {
+          "dependencies": "/api/v1/crates/serde/1.0.123/dependencies",
+          "version_downloads": "/api/v1/crates/serde/1.0.123/downloads",
+          "authors": "/api/v1/crates/serde/1.0.123/authors"
+        },
+        "crate_size": 74379,
+        "published_by": {
+          "id": 3618,
+          "login": "dtolnay",
+          "name": "David Tolnay",
+          "avatar": "https://avatars2.githubusercontent.com/u/1940490?v=4",
+          "url": "https://github.com/dtolnay"
+        },
+        "audit_actions": [
+          {
+            "action": "publish",
+            "user": {
+              "id": 3618,
+              "login": "dtolnay",
+              "name": "David Tolnay",
+              "avatar": "https://avatars2.githubusercontent.com/u/1940490?v=4",
+              "url": "https://github.com/dtolnay"
+            },
+            "time": "2021-01-25T21:44:12.137298+00:00"
+          }
+        ]
+      },
+      "sourceInfo": {
+        "type": "git",
+        "provider": "github",
+        "namespace": "serde-rs",
+        "name": "serde",
+        "revision": "3d6c4149b177e9cadfb948ebc6d1e55b33861792",
+        "url": null,
+        "path": null
+      }
+    }
+  },
+  "licensee": {
+    "9.13.0": {
+      "_metadata": {
+        "type": "licensee",
+        "url": "cd:/crate/cratesio/-/serde/1.0.123",
+        "fetchedAt": "2021-01-29T16:36:43.887Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:serde:revision:1.0.123:tool:licensee:9.13.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:serde:revision:1.0.123:tool:licensee",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "9.13.0",
+        "toolVersion": "9.11.0",
+        "processedAt": "2021-01-29T16:36:48.060Z"
+      },
+      "licensee": {
+        "version": "9.11.0",
+        "parameters": [
+          "--json",
+          "--no-readme"
+        ],
+        "output": {
+          "contentType": "application/json",
+          "content": {
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "spdx_id": "Apache-2.0",
+                "meta": {
+                  "title": "Apache License 2.0",
+                  "source": "https://spdx.org/licenses/Apache-2.0.html",
+                  "description": "A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.",
+                  "using": [
+                    {
+                      "Kubernetes": "https://github.com/kubernetes/kubernetes/blob/master/LICENSE"
+                    },
+                    {
+                      "PDF.js": "https://github.com/mozilla/pdf.js/blob/master/LICENSE"
+                    },
+                    {
+                      "Swift": "https://github.com/apple/swift/blob/master/LICENSE.txt"
+                    }
+                  ],
+                  "featured": true,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": "The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix."
+                },
+                "url": "http://choosealicense.com/licenses/apache-2.0/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "patent-use",
+                      "label": "Patent use",
+                      "description": "This license provides an express grant of patent rights from contributors."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    },
+                    {
+                      "tag": "document-changes",
+                      "label": "State changes",
+                      "description": "Changes made to the code must be documented."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "trademark-use",
+                      "label": "Trademark use",
+                      "description": "This license explicitly states that it does NOT grant trademark rights, even though licenses without such a statement probably do not grant any implicit trademark rights."
+                    },
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "mit",
+                "spdx_id": "MIT",
+                "meta": {
+                  "title": "MIT License",
+                  "source": "https://spdx.org/licenses/MIT.html",
+                  "description": "A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.",
+                  "using": [
+                    {
+                      "Babel": "https://github.com/babel/babel/blob/master/LICENSE"
+                    },
+                    {
+                      ".NET Core": "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+                    },
+                    {
+                      "Rails": "https://github.com/rails/rails/blob/master/MIT-LICENSE"
+                    }
+                  ],
+                  "featured": true,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": null
+                },
+                "url": "http://choosealicense.com/licenses/mit/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [
+                  {
+                    "name": "year",
+                    "description": "The current year"
+                  },
+                  {
+                    "name": "fullname",
+                    "description": "The full name or username of the repository owner"
+                  }
+                ],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "other",
+                "spdx_id": "NOASSERTION",
+                "meta": {
+                  "title": null,
+                  "source": null,
+                  "description": null,
+                  "how": null,
+                  "using": null,
+                  "featured": false,
+                  "hidden": true,
+                  "nickname": null,
+                  "note": null
+                },
+                "url": "http://choosealicense.com/licenses/other/",
+                "rules": {
+                  "permissions": [],
+                  "conditions": [],
+                  "limitations": []
+                },
+                "fields": [],
+                "other": true,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              }
+            ],
+            "matched_files": [
+              {
+                "filename": "LICENSE-APACHE",
+                "content": "                              Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
+                "content_hash": "ab3901051663cb8ee5dea9ebdff406ad136910e3",
+                "content_normalized": "terms and conditions for use, reproduction, and distribution - definitions. \"license\" shall mean the terms and conditions for use, reproduction, and distribution as defined by sections 1 through 9 of this document. \"licensor\" shall mean the copyright holder or entity authorized by the copyright holder that is granting the license. \"legal entity\" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. for the purposes of this definition, \"control\" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity. \"you\" (or \"your\") shall mean an individual or legal entity exercising permissions granted by this license. \"source\" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files. \"object\" form shall mean any form resulting from mechanical transformation or translation of a source form, including but not limited to compiled object code, generated documentation, and conversions to other media types. \"work\" shall mean the work of authorship, whether in source or object form, made available under the license, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the appendix below). \"derivative works\" shall mean any work, whether in source or object form, that is based on (or derived from) the work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. for the purposes of this license, derivative works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the work and derivative works thereof. \"contribution\" shall mean any work of authorship, including the original version of the work and any modifications or additions to that work or derivative works thereof, that is intentionally submitted to licensor for inclusion in the work by the copyright holder or by an individual or legal entity authorized to submit on behalf of the copyright holder. for the purposes of this definition, \"submitted\" means any form of electronic, verbal, or written communication sent to the licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the licensor for the purpose of discussing and improving the work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright holder as \"not a contribution.\" \"contributor\" shall mean licensor and any individual or legal entity on behalf of whom a contribution has been received by licensor and subsequently incorporated within the work. - grant of copyright license. subject to the terms and conditions of this license, each contributor hereby grants to you a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute the work and such derivative works in source or object form. - grant of patent license. subject to the terms and conditions of this license, each contributor hereby grants to you a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the work, where such license applies only to those patent claims licensable by such contributor that are necessarily infringed by their contribution(s) alone or by combination of their contribution(s) with the work to which such contribution(s) was submitted. if you institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the work or a contribution incorporated within the work constitutes direct or contributory patent infringement, then any patent licenses granted to you under this license for that work shall terminate as of the date such litigation is filed. - redistribution. you may reproduce and distribute copies of the work or derivative works thereof in any medium, with or without modifications, and in source or object form, provided that you meet the following conditions: * you must give any other recipients of the work or derivative works a copy of this license; and * you must cause any modified files to carry prominent notices stating that you changed the files; and * you must retain, in the source form of any derivative works that you distribute, all copyright, patent, trademark, and attribution notices from the source form of the work, excluding those notices that do not pertain to any part of the derivative works; and * if the work includes a \"notice\" text file as part of its distribution, then any derivative works that you distribute must include a readable copy of the attribution notices contained within such notice file, excluding those notices that do not pertain to any part of the derivative works, in at least one of the following places: within a notice text file distributed as part of the derivative works; within the source form or documentation, if provided along with the derivative works; or, within a display generated by the derivative works, if and wherever such third-party notices normally appear. the contents of the notice file are for informational purposes only and do not modify the license. you may add your own attribution notices within derivative works that you distribute, alongside or as an addendum to the notice text from the work, provided that such additional attribution notices cannot be construed as modifying the license. you may add your own copyright statement to your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of your modifications, or for any such derivative works as a whole, provided your use, reproduction, and distribution of the work otherwise complies with the conditions stated in this license. - submission of contributions. unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you to the licensor shall be under the terms and conditions of this license, without any additional terms or conditions. notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with licensor regarding such contributions. - trademarks. this license does not grant permission to use the trade names, trademarks, service marks, or product names of the licensor, except as required for reasonable and customary use in describing the origin of the work and reproducing the content of the notice file. - disclaimer of warranty. unless required by applicable law or agreed to in writing, licensor provides the work (and each contributor provides its contributions) on an \"as is\" basis, without warranties or conditions of any kind, either express or implied, including, without limitation, any warranties or conditions of title, non-infringement, merchantability, or fitness for a particular purpose. you are solely responsible for determining the appropriateness of using or redistributing the work and assume any risks associated with your exercise of permissions under this license. - limitation of liability. in no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any contributor be liable to you for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this license or out of the use or inability to use the work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such contributor has been advised of the possibility of such damages. - accepting warranty or additional liability. while redistributing the work or derivative works thereof, you may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this license. however, in accepting such obligations, you may act only on your own behalf and on your sole responsibility, not on behalf of any other contributor, and only if you agree to indemnify, defend, and hold each contributor harmless for any liability incurred by, or claims asserted against, such contributor by reason of your accepting any such warranty or additional liability.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "Apache-2.0"
+              },
+              {
+                "filename": "LICENSE-MIT",
+                "content": "Permission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE.\n",
+                "content_hash": "d64f3bb4282a97b37454b5bb96a8a264a3363dc3",
+                "content_normalized": "permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"software\"), to deal in the software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the software, and to permit persons to whom the software is furnished to do so, subject to the following conditions: the above copyright notice and this permission notice shall be included in all copies or substantial portions of the software. the software is provided \"as is\", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. in no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "MIT"
+              },
+              {
+                "filename": "Cargo.toml",
+                "content": "# THIS FILE IS AUTOMATICALLY GENERATED BY CARGO\n#\n# When uploading crates to the registry Cargo will automatically\n# \"normalize\" Cargo.toml files for maximal compatibility\n# with all versions of Cargo and also rewrite `path` dependencies\n# to registry (e.g., crates.io) dependencies\n#\n# If you believe there's an error in this file please file an\n# issue against the rust-lang/cargo repository. If you're\n# editing this file be aware that the upstream Cargo.toml\n# will likely look very different (and much more reasonable)\n\n[package]\nname = \"serde\"\nversion = \"1.0.123\"\nauthors = [\"Erick Tryzelaar <erick.tryzelaar@gmail.com>\", \"David Tolnay <dtolnay@gmail.com>\"]\nbuild = \"build.rs\"\ninclude = [\"build.rs\", \"src/**/*.rs\", \"crates-io.md\", \"README.md\", \"LICENSE-APACHE\", \"LICENSE-MIT\"]\ndescription = \"A generic serialization/deserialization framework\"\nhomepage = \"https://serde.rs\"\ndocumentation = \"https://docs.serde.rs/serde/\"\nreadme = \"crates-io.md\"\nkeywords = [\"serde\", \"serialization\", \"no_std\"]\ncategories = [\"encoding\"]\nlicense = \"MIT OR Apache-2.0\"\nrepository = \"https://github.com/serde-rs/serde\"\n[package.metadata.docs.rs]\ntargets = [\"x86_64-unknown-linux-gnu\"]\n\n[package.metadata.playground]\nfeatures = [\"derive\", \"rc\"]\n[dependencies.serde_derive]\nversion = \"=1.0.123\"\noptional = true\n[dev-dependencies.serde_derive]\nversion = \"1.0\"\n\n[features]\nalloc = []\ndefault = [\"std\"]\nderive = [\"serde_derive\"]\nrc = []\nstd = []\nunstable = []\n",
+                "content_hash": null,
+                "content_normalized": null,
+                "matcher": {
+                  "name": "cargo",
+                  "confidence": 90
+                },
+                "matched_license": "NOASSERTION"
+              }
+            ]
+          }
+        }
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-APACHE",
+          "token": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+        },
+        {
+          "path": "LICENSE-MIT",
+          "token": "23f18e03dc49df91622fe2a76176497404e46ced8a715d9d2b67a7446571cca3"
+        },
+        {
+          "path": "Cargo.toml",
+          "token": "6c9c8ff479865fac1f930e0d937d496089a862b18b3b48b2294f73527ee03633"
+        }
+      ]
+    }
+  },
+  "scancode": {
+    "3.2.2": {
+      "_metadata": {
+        "type": "scancode",
+        "url": "cd:/crate/cratesio/-/serde/1.0.123",
+        "fetchedAt": "2021-01-29T16:36:44.063Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:serde:revision:1.0.123:tool:scancode:3.2.2",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:serde:revision:1.0.123:tool:scancode",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "3.2.2",
+        "toolVersion": "3.0.2",
+        "contentType": "application/json",
+        "releaseDate": "2021-01-25T21:44:12.137298+00:00",
+        "processedAt": "2021-01-29T16:37:24.202Z"
+      },
+      "content": {
+        "headers": [
+          {
+            "tool_name": "scancode-toolkit",
+            "tool_version": "3.0.2",
+            "options": {
+              "input": "/tmp/cd-2TnKdb/crate/serde-1.0.123",
+              "--classify": true,
+              "--copyright": true,
+              "--email": true,
+              "--generated": true,
+              "--info": true,
+              "--is-license-text": true,
+              "--json-pp": "/tmp/cd-eMyoYe",
+              "--license": true,
+              "--license-clarity-score": true,
+              "--license-diag": true,
+              "--license-text": true,
+              "--package": true,
+              "--processes": "2",
+              "--strip-root": true,
+              "--summary": true,
+              "--summary-key-files": true,
+              "--timeout": "1000.0",
+              "--url": true
+            },
+            "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+            "start_timestamp": "2021-01-29T163647.469266",
+            "end_timestamp": "2021-01-29T163722.187276",
+            "message": null,
+            "errors": [],
+            "extra_data": {
+              "files_count": 27
+            }
+          }
+        ],
+        "summary": {
+          "license_expressions": [
+            {
+              "value": null,
+              "count": 22
+            },
+            {
+              "value": "mit",
+              "count": 7
+            },
+            {
+              "value": "apache-2.0",
+              "count": 5
+            },
+            {
+              "value": "free-unknown",
+              "count": 1
+            },
+            {
+              "value": "unknown",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 26
+            },
+            {
+              "value": "(c), None Ok",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 26
+            },
+            {
+              "value": "None Ok",
+              "count": 1
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 25
+            },
+            {
+              "value": "Erick Tryzelaar <erick.tryzelaar@gmail.com> , David Tolnay <dtolnay@gmail.com>",
+              "count": 2
+            }
+          ],
+          "programming_language": [
+            {
+              "value": "Rust",
+              "count": 20
+            },
+            {
+              "value": null,
+              "count": 5
+            },
+            {
+              "value": "Objective-C",
+              "count": 2
+            }
+          ],
+          "packages": []
+        },
+        "license_clarity_score": {
+          "score": 30,
+          "has_declared_license_in_key_files": true,
+          "file_level_license_and_copyright_coverage": 0,
+          "has_consistent_key_and_file_level_licenses": false,
+          "is_using_only_spdx_licenses": false,
+          "has_full_text_for_all_licenses": false
+        },
+        "summary_of_key_files": {
+          "license_expressions": [
+            {
+              "value": "apache-2.0",
+              "count": 3
+            },
+            {
+              "value": "mit",
+              "count": 3
+            },
+            {
+              "value": "free-unknown",
+              "count": 1
+            },
+            {
+              "value": "unknown",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 3
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 3
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 3
+            }
+          ],
+          "programming_language": [
+            {
+              "value": null,
+              "count": 2
+            },
+            {
+              "value": "Objective-C",
+              "count": 1
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": ".cargo_vcs_info.json",
+            "type": "file",
+            "name": ".cargo_vcs_info.json",
+            "base_name": ".cargo_vcs_info",
+            "extension": ".json",
+            "size": 74,
+            "date": "1970-01-01",
+            "sha1": "598e56ffb4b722e24ff813b9f86655ee4e7368af",
+            "md5": "083eacd827e2620c5b5c3fa4fa158dcb",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "build.rs",
+            "type": "file",
+            "name": "build.rs",
+            "base_name": "build",
+            "extension": ".rs",
+            "size": 4678,
+            "date": "1970-01-01",
+            "sha1": "5b18cbfe592282076a4957488930d50fddc93b30",
+            "md5": "393605f5ce28bda3579318243ce3f922",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://doc.rust-lang.org/core/ops/enum.Bound.html",
+                "start_line": 19,
+                "end_line": 19
+              },
+              {
+                "url": "https://doc.rust-lang.org/stable/core/cmp/struct.Reverse.html",
+                "start_line": 27,
+                "end_line": 27
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/ffi/struct.CString.html#method.into_boxed_c_str",
+                "start_line": 33,
+                "end_line": 33
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.into_boxed_path",
+                "start_line": 34,
+                "end_line": 34
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/rc/struct.Rc.html#impl-From",
+                "start_line": 41,
+                "end_line": 41
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/sync/struct.Arc.html#impl-From",
+                "start_line": 42,
+                "end_line": 42
+              },
+              {
+                "url": "https://blog.rust-lang.org/2018/03/29/Rust-1.25.html#library-stabilizations",
+                "start_line": 48,
+                "end_line": 48
+              },
+              {
+                "url": "https://blog.rust-lang.org/2018/05/10/Rust-1.26.html",
+                "start_line": 54,
+                "end_line": 54
+              },
+              {
+                "url": "https://github.com/rust-lang/rust/pull/50758",
+                "start_line": 63,
+                "end_line": 63
+              },
+              {
+                "url": "https://blog.rust-lang.org/2018/08/02/Rust-1.28.html#library-stabilizations",
+                "start_line": 69,
+                "end_line": 69
+              },
+              {
+                "url": "https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html#tryfrom-and-tryinto",
+                "start_line": 80,
+                "end_line": 80
+              },
+              {
+                "url": "https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html#library-stabilizations",
+                "start_line": 81,
+                "end_line": 81
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml",
+            "type": "file",
+            "name": "Cargo.toml",
+            "base_name": "Cargo",
+            "extension": ".toml",
+            "size": 1439,
+            "date": "1970-01-01",
+            "sha1": "5c2b91a3aec04b5dd9ed7f305b3f571455b4259c",
+            "md5": "91b441e762175c57ce20e5de15bf66cb",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 18,
+                "end_line": 18,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT\"]"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 25,
+                "end_line": 25,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "license = \"MIT"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 25,
+                "end_line": 25,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0\""
+              }
+            ],
+            "license_expressions": [
+              "mit",
+              "mit",
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "Erick Tryzelaar <erick.tryzelaar@gmail.com> , David Tolnay <dtolnay@gmail.com>",
+                "start_line": 16,
+                "end_line": 18
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "erick.tryzelaar@gmail.com",
+                "start_line": 16,
+                "end_line": 16
+              },
+              {
+                "email": "dtolnay@gmail.com",
+                "start_line": 16,
+                "end_line": 16
+              }
+            ],
+            "urls": [
+              {
+                "url": "https://serde.rs/",
+                "start_line": 20,
+                "end_line": 20
+              },
+              {
+                "url": "https://docs.serde.rs/serde/",
+                "start_line": 21,
+                "end_line": 21
+              },
+              {
+                "url": "https://github.com/serde-rs/serde",
+                "start_line": 26,
+                "end_line": 26
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml.orig",
+            "type": "file",
+            "name": "Cargo.toml.orig",
+            "base_name": "Cargo.toml",
+            "extension": ".orig",
+            "size": 1947,
+            "date": "1970-01-01",
+            "sha1": "b0fbe29be72e1f95eefa22d417fee2ec4f15331e",
+            "md5": "c1af9dab2c494c127f2c17d9e358d76b",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "license = \"MIT"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0\""
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 13,
+                "end_line": 13,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT\"]"
+              }
+            ],
+            "license_expressions": [
+              "mit",
+              "apache-2.0",
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "Erick Tryzelaar <erick.tryzelaar@gmail.com> , David Tolnay <dtolnay@gmail.com>",
+                "start_line": 4,
+                "end_line": 6
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "erick.tryzelaar@gmail.com",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "email": "dtolnay@gmail.com",
+                "start_line": 4,
+                "end_line": 4
+              }
+            ],
+            "urls": [
+              {
+                "url": "https://serde.rs/",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://github.com/serde-rs/serde",
+                "start_line": 8,
+                "end_line": 8
+              },
+              {
+                "url": "https://docs.serde.rs/serde/",
+                "start_line": 9,
+                "end_line": 9
+              },
+              {
+                "url": "https://github.com/serde-rs/serde/issues/812",
+                "start_line": 44,
+                "end_line": 44
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "crates-io.md",
+            "type": "file",
+            "name": "crates-io.md",
+            "base_name": "crates-io",
+            "extension": ".md",
+            "size": 2332,
+            "date": "1970-01-01",
+            "sha1": "40ca313f755628a0e54d86c0ff82b51a33096f5d",
+            "md5": "fe5b3b7614b026ceeeab748a82263dcc",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Objective-C",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://serde.rs/",
+                "start_line": 9,
+                "end_line": 9
+              },
+              {
+                "url": "https://serde.rs/#data-formats",
+                "start_line": 10,
+                "end_line": 10
+              },
+              {
+                "url": "https://serde.rs/derive.html",
+                "start_line": 11,
+                "end_line": 11
+              },
+              {
+                "url": "https://serde.rs/examples.html",
+                "start_line": 12,
+                "end_line": 12
+              },
+              {
+                "url": "https://docs.serde.rs/serde",
+                "start_line": 13,
+                "end_line": 13
+              },
+              {
+                "url": "https://github.com/serde-rs/serde/releases",
+                "start_line": 14,
+                "end_line": 14
+              },
+              {
+                "url": "https://discord.com/channels/273534239310479360/274215136414400513",
+                "start_line": 56,
+                "end_line": 56
+              },
+              {
+                "url": "https://discord.com/channels/273534239310479360/273541522815713281",
+                "start_line": 57,
+                "end_line": 57
+              },
+              {
+                "url": "https://discord.com/channels/442252698964721669/443150878111694848",
+                "start_line": 58,
+                "end_line": 58
+              },
+              {
+                "url": "https://rust-lang.zulipchat.com/#narrow/stream/122651-general",
+                "start_line": 59,
+                "end_line": 59
+              },
+              {
+                "url": "https://stackoverflow.com/questions/tagged/rust",
+                "start_line": 60,
+                "end_line": 60
+              },
+              {
+                "url": "https://www.reddit.com/r/rust",
+                "start_line": 61,
+                "end_line": 61
+              },
+              {
+                "url": "https://users.rust-lang.org/",
+                "start_line": 62,
+                "end_line": 62
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-APACHE",
+            "type": "file",
+            "name": "LICENSE-APACHE",
+            "base_name": "LICENSE-APACHE",
+            "extension": "",
+            "size": 10847,
+            "date": "1970-01-01",
+            "sha1": "5798832c31663cedc1618d18544d445da0295229",
+            "md5": "1836efb2eb779966696f473ee8540542",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 100,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 1,
+                "end_line": 201,
+                "matched_rule": {
+                  "identifier": "apache-2.0.LICENSE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "1-hash",
+                  "rule_length": 1608,
+                  "matched_length": 1608,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License."
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://www.apache.org/licenses/",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 195,
+                "end_line": 195
+              }
+            ],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": true,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-MIT",
+            "type": "file",
+            "name": "LICENSE-MIT",
+            "base_name": "LICENSE-MIT",
+            "extension": "",
+            "size": 1023,
+            "date": "1970-01-01",
+            "sha1": "ce3a2603094e799f42ce99c40941544dfcc5c4a5",
+            "md5": "b377b220f43d747efdec40d69fcaa69d",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 100,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 1,
+                "end_line": 23,
+                "matched_rule": {
+                  "identifier": "mit.LICENSE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "1-hash",
+                  "rule_length": 163,
+                  "matched_length": 163,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Permission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE."
+              }
+            ],
+            "license_expressions": [
+              "mit"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "README.md",
+            "type": "file",
+            "name": "README.md",
+            "base_name": "README",
+            "extension": ".md",
+            "size": 4138,
+            "date": "1970-01-01",
+            "sha1": "df577d0370d9349360247b1a7ee7bb06b6e925ea",
+            "md5": "86492bf4a203c6471ec593e4f9217191",
+            "mime_type": "text/html",
+            "file_type": "HTML document, ASCII text",
+            "programming_language": "Objective-C",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "unknown",
+                "score": 11,
+                "name": "Unknown license detected but not recognized",
+                "short_name": "unknown",
+                "category": "Unstated License",
+                "is_exception": false,
+                "owner": "Unspecified",
+                "homepage_url": "",
+                "text_url": "",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:unknown",
+                "spdx_license_key": "",
+                "spdx_url": "",
+                "start_line": 101,
+                "end_line": 101,
+                "matched_rule": {
+                  "identifier": "unknown_28.RULE",
+                  "license_expression": "unknown",
+                  "licenses": [
+                    "unknown"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 11
+                },
+                "matched_text": "Licensed under"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 27,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 101,
+                "end_line": 102,
+                "matched_rule": {
+                  "identifier": "apache-2.0_48.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 5,
+                  "matched_length": 5,
+                  "match_coverage": 100,
+                  "rule_relevance": 27
+                },
+                "matched_text": "Apache License, Version\n2.0</"
+              },
+              {
+                "key": "mit",
+                "score": 99,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 102,
+                "end_line": 102,
+                "matched_rule": {
+                  "identifier": "mit_34.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 99
+                },
+                "matched_text": "LICENSE-MIT\">"
+              },
+              {
+                "key": "mit",
+                "score": 80,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 102,
+                "end_line": 102,
+                "matched_rule": {
+                  "identifier": "mit_14.RULE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 80
+                },
+                "matched_text": "MIT license</"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 109,
+                "end_line": 109,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0"
+              },
+              {
+                "key": "free-unknown",
+                "score": 11,
+                "name": "Free unknown license detected but not recognized",
+                "short_name": "Free unknown",
+                "category": "Unstated License",
+                "is_exception": false,
+                "owner": "Unspecified",
+                "homepage_url": "",
+                "text_url": "",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:free-unknown",
+                "spdx_license_key": "",
+                "spdx_url": "",
+                "start_line": 110,
+                "end_line": 110,
+                "matched_rule": {
+                  "identifier": "free-unknown_31.RULE",
+                  "license_expression": "free-unknown",
+                  "licenses": [
+                    "free-unknown"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 11
+                },
+                "matched_text": "dual licensed"
+              }
+            ],
+            "license_expressions": [
+              "unknown",
+              "apache-2.0",
+              "mit",
+              "mit",
+              "apache-2.0",
+              "free-unknown"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://img.shields.io/github/workflow/status/serde-rs/serde/CI/master",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "https://github.com/serde-rs/serde/actions?query=branch:master",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://img.shields.io/crates/v/serde.svg",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://crates.io/crates/serde",
+                "start_line": 6,
+                "end_line": 6
+              },
+              {
+                "url": "https://img.shields.io/badge/serde-rustc_1.13+-lightgray.svg",
+                "start_line": 7,
+                "end_line": 7
+              },
+              {
+                "url": "https://img.shields.io/badge/serde_derive-rustc_1.31+-lightgray.svg",
+                "start_line": 8,
+                "end_line": 8
+              },
+              {
+                "url": "https://blog.rust-lang.org/2016/11/10/Rust-1.13.html",
+                "start_line": 9,
+                "end_line": 9
+              },
+              {
+                "url": "https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html",
+                "start_line": 10,
+                "end_line": 10
+              },
+              {
+                "url": "https://serde.rs/",
+                "start_line": 18,
+                "end_line": 18
+              },
+              {
+                "url": "https://serde.rs/#data-formats",
+                "start_line": 19,
+                "end_line": 19
+              },
+              {
+                "url": "https://serde.rs/derive.html",
+                "start_line": 20,
+                "end_line": 20
+              },
+              {
+                "url": "https://serde.rs/examples.html",
+                "start_line": 21,
+                "end_line": 21
+              },
+              {
+                "url": "https://docs.serde.rs/serde",
+                "start_line": 22,
+                "end_line": 22
+              },
+              {
+                "url": "https://github.com/serde-rs/serde/releases",
+                "start_line": 23,
+                "end_line": 23
+              },
+              {
+                "url": "https://play.rust-lang.org/?edition=2018&gist=72755f28f99afc95e01d63174b28c1f5",
+                "start_line": 30,
+                "end_line": 30
+              },
+              {
+                "url": "https://discord.com/channels/273534239310479360/274215136414400513",
+                "start_line": 88,
+                "end_line": 88
+              },
+              {
+                "url": "https://discord.com/channels/273534239310479360/273541522815713281",
+                "start_line": 89,
+                "end_line": 89
+              },
+              {
+                "url": "https://discord.com/channels/442252698964721669/443150878111694848",
+                "start_line": 90,
+                "end_line": 90
+              },
+              {
+                "url": "https://rust-lang.zulipchat.com/#narrow/stream/122651-general",
+                "start_line": 91,
+                "end_line": 91
+              },
+              {
+                "url": "https://stackoverflow.com/questions/tagged/rust",
+                "start_line": 92,
+                "end_line": 92
+              },
+              {
+                "url": "https://www.reddit.com/r/rust",
+                "start_line": 93,
+                "end_line": 93
+              },
+              {
+                "url": "https://users.rust-lang.org/",
+                "start_line": 94,
+                "end_line": 94
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": true,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src",
+            "type": "directory",
+            "name": "src",
+            "base_name": "src",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 19,
+            "dirs_count": 3,
+            "size_count": 466155,
+            "scan_errors": []
+          },
+          {
+            "path": "src/integer128.rs",
+            "type": "file",
+            "name": "integer128.rs",
+            "base_name": "integer128",
+            "extension": ".rs",
+            "size": 2318,
+            "date": "1970-01-01",
+            "sha1": "57f6216ec2b3912ac18fddfd5f5ab99f197aa5c4",
+            "md5": "52aa88d16d1ec9fde4fb4bfbe1285246",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/lib.rs",
+            "type": "file",
+            "name": "lib.rs",
+            "base_name": "lib",
+            "extension": ".rs",
+            "size": 11141,
+            "date": "1970-01-01",
+            "sha1": "597aff1885023f230d8298cb2ebdb874884a2385",
+            "md5": "e07f6d8e913252255a6dfe2f4f284c34",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://serde.rs/",
+                "start_line": 12,
+                "end_line": 12
+              },
+              {
+                "url": "https://github.com/serde-rs/json",
+                "start_line": 61,
+                "end_line": 61
+              },
+              {
+                "url": "https://github.com/servo/bincode",
+                "start_line": 62,
+                "end_line": 62
+              },
+              {
+                "url": "https://github.com/pyfisch/cbor",
+                "start_line": 63,
+                "end_line": 63
+              },
+              {
+                "url": "https://github.com/dtolnay/serde-yaml",
+                "start_line": 64,
+                "end_line": 64
+              },
+              {
+                "url": "https://github.com/3Hren/msgpack-rust",
+                "start_line": 65,
+                "end_line": 65
+              },
+              {
+                "url": "https://github.com/alexcrichton/toml-rs",
+                "start_line": 66,
+                "end_line": 66
+              },
+              {
+                "url": "https://github.com/birkenfeld/serde-pickle",
+                "start_line": 67,
+                "end_line": 67
+              },
+              {
+                "url": "https://github.com/ron-rs/ron",
+                "start_line": 68,
+                "end_line": 68
+              },
+              {
+                "url": "https://github.com/zonyitoo/bson-rs",
+                "start_line": 69,
+                "end_line": 69
+              },
+              {
+                "url": "https://github.com/flavray/avro-rs",
+                "start_line": 70,
+                "end_line": 70
+              },
+              {
+                "url": "https://github.com/callum-oakley/json5-rs",
+                "start_line": 71,
+                "end_line": 71
+              },
+              {
+                "url": "https://github.com/jamesmunns/postcard",
+                "start_line": 72,
+                "end_line": 72
+              },
+              {
+                "url": "https://docs.rs/serde_qs",
+                "start_line": 73,
+                "end_line": 73
+              },
+              {
+                "url": "https://github.com/softprops/envy",
+                "start_line": 74,
+                "end_line": 74
+              },
+              {
+                "url": "https://github.com/softprops/envy-store",
+                "start_line": 75,
+                "end_line": 75
+              },
+              {
+                "url": "http://doc.crates.io/manifest.html",
+                "start_line": 76,
+                "end_line": 76
+              },
+              {
+                "url": "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html",
+                "start_line": 77,
+                "end_line": 77
+              },
+              {
+                "url": "https://github.com/rotty/lexpr-rs",
+                "start_line": 78,
+                "end_line": 78
+              },
+              {
+                "url": "https://docs.rs/zvariant",
+                "start_line": 79,
+                "end_line": 79
+              },
+              {
+                "url": "https://github.com/google/flatbuffers/tree/master/rust/flexbuffers",
+                "start_line": 80,
+                "end_line": 80
+              },
+              {
+                "url": "https://docs.rs/serde_dynamo",
+                "start_line": 81,
+                "end_line": 81
+              },
+              {
+                "url": "https://docs.rs/rusoto_dynamodb",
+                "start_line": 82,
+                "end_line": 82
+              },
+              {
+                "url": "https://docs.rs/serde/1.0.123",
+                "start_line": 87,
+                "end_line": 87
+              },
+              {
+                "url": "https://github.com/serde-rs/serde/issues/812",
+                "start_line": 93,
+                "end_line": 93
+              },
+              {
+                "url": "https://github.com/rust-lang/rust-clippy/issues/5704",
+                "start_line": 102,
+                "end_line": 102
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/macros.rs",
+            "type": "file",
+            "name": "macros.rs",
+            "base_name": "macros",
+            "extension": ".rs",
+            "size": 8360,
+            "date": "1970-01-01",
+            "sha1": "0b7d14e30c68261a106c3e7b55cc520c0ee638a8",
+            "md5": "7c8146539b28581c5cae0d67b440fe0c",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/std_error.rs",
+            "type": "file",
+            "name": "std_error.rs",
+            "base_name": "std_error",
+            "extension": ".rs",
+            "size": 1340,
+            "date": "1970-01-01",
+            "sha1": "d9cbedc053165a06a20d922612c80f493be90c63",
+            "md5": "c4ec7a8e860af9bcfe82af4a3068dc4d",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/de",
+            "type": "directory",
+            "name": "de",
+            "base_name": "de",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 6,
+            "dirs_count": 0,
+            "size_count": 211398,
+            "scan_errors": []
+          },
+          {
+            "path": "src/de/ignored_any.rs",
+            "type": "file",
+            "name": "ignored_any.rs",
+            "base_name": "ignored_any",
+            "extension": ".rs",
+            "size": 6234,
+            "date": "1970-01-01",
+            "sha1": "3e4c14aa8d8527a42e1e8dc3104d84ae4cee4ed0",
+            "md5": "324976cfb80caf388e72574375853fb2",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/de/impls.rs",
+            "type": "file",
+            "name": "impls.rs",
+            "base_name": "impls",
+            "extension": ".rs",
+            "size": 80627,
+            "date": "1970-01-01",
+            "sha1": "2a5bce6f8c22fa8baaa1d09b8e6fc3641629d7a6",
+            "md5": "16784359bcd2eaceab2c4b5af5bbed5c",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [
+              {
+                "value": "None Ok",
+                "start_line": 345,
+                "end_line": 346
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "(c), None Ok",
+                "start_line": 345,
+                "end_line": 346
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://serde.rs/feature-flags.html#-features-rc",
+                "start_line": 1700,
+                "end_line": 1700
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/de/mod.rs",
+            "type": "file",
+            "name": "mod.rs",
+            "base_name": "mod",
+            "extension": ".rs",
+            "size": 79708,
+            "date": "1970-01-01",
+            "sha1": "f60feed73d82247779f6c854dfab6da91493f91f",
+            "md5": "44d8e662f7413c8f89c8580f6a9efbe4",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://serde.rs/impl-deserialize.html",
+                "start_line": 103,
+                "end_line": 103
+              },
+              {
+                "url": "https://docs.rs/linked-hash-map/*/linked_hash_map/struct.LinkedHashMap.html",
+                "start_line": 106,
+                "end_line": 106
+              },
+              {
+                "url": "https://github.com/servo/bincode",
+                "start_line": 107,
+                "end_line": 107
+              },
+              {
+                "url": "https://crates.io/crates/linked-hash-map",
+                "start_line": 108,
+                "end_line": 108
+              },
+              {
+                "url": "https://crates.io/crates/serde_derive",
+                "start_line": 109,
+                "end_line": 109
+              },
+              {
+                "url": "https://github.com/serde-rs/json",
+                "start_line": 110,
+                "end_line": 110
+              },
+              {
+                "url": "https://github.com/dtolnay/serde-yaml",
+                "start_line": 111,
+                "end_line": 111
+              },
+              {
+                "url": "https://serde.rs/derive.html",
+                "start_line": 112,
+                "end_line": 112
+              },
+              {
+                "url": "https://serde.rs/#data-formats",
+                "start_line": 113,
+                "end_line": 113
+              },
+              {
+                "url": "https://serde.rs/data-format.html",
+                "start_line": 157,
+                "end_line": 157
+              },
+              {
+                "url": "https://docs.serde.rs/serde/de/index.html",
+                "start_line": 519,
+                "end_line": 519
+              },
+              {
+                "url": "https://serde.rs/lifetimes.html",
+                "start_line": 529,
+                "end_line": 529
+              },
+              {
+                "url": "https://serde.rs/data-model.html",
+                "start_line": 883,
+                "end_line": 883
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/de/seed.rs",
+            "type": "file",
+            "name": "seed.rs",
+            "base_name": "seed",
+            "extension": ".rs",
+            "size": 556,
+            "date": "1970-01-01",
+            "sha1": "da542a0d31c10ed59ecd23c65cf9fb8a7a1ff728",
+            "md5": "5906b89b8aafd99233d864f146a9f904",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/de/utf8.rs",
+            "type": "file",
+            "name": "utf8.rs",
+            "base_name": "utf8",
+            "extension": ".rs",
+            "size": 1224,
+            "date": "1970-01-01",
+            "sha1": "a751f40d78f33755537d481915fa682825687bd4",
+            "md5": "49381b6cb3f3358f1707ce730b58d484",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/de/value.rs",
+            "type": "file",
+            "name": "value.rs",
+            "base_name": "value",
+            "extension": ".rs",
+            "size": 43049,
+            "date": "1970-01-01",
+            "sha1": "1f9188dc54bd5442f7002be2cbd721c5d568f5e9",
+            "md5": "b109f30c4e219c3c0b4e6796b3507a20",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/private",
+            "type": "directory",
+            "name": "private",
+            "base_name": "private",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 5,
+            "dirs_count": 0,
+            "size_count": 133764,
+            "scan_errors": []
+          },
+          {
+            "path": "src/private/de.rs",
+            "type": "file",
+            "name": "de.rs",
+            "base_name": "de",
+            "extension": ".rs",
+            "size": 88734,
+            "date": "1970-01-01",
+            "sha1": "e495677229c9cd0fdc952e2b242ad9da3b4e5eb5",
+            "md5": "189ce10b1e68d928d4510d89e68ace99",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/serde-rs/serde/issues/741",
+                "start_line": 204,
+                "end_line": 204
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/private/doc.rs",
+            "type": "file",
+            "name": "doc.rs",
+            "base_name": "doc",
+            "extension": ".rs",
+            "size": 4874,
+            "date": "1970-01-01",
+            "sha1": "d71e4c92100ff7cf4ad5d60bf9d1a891609252ab",
+            "md5": "9f01643589cf35cca392a36ef2dabf27",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/private/mod.rs",
+            "type": "file",
+            "name": "mod.rs",
+            "base_name": "mod",
+            "extension": ".rs",
+            "size": 1468,
+            "date": "1970-01-01",
+            "sha1": "57a5944a2d4bf5b8b18298cb0236de07d2ed1255",
+            "md5": "b7f26b6f5d66455dbd2b1dfdea5bacdc",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/rust/issues/67295",
+                "start_line": 8,
+                "end_line": 8
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/private/ser.rs",
+            "type": "file",
+            "name": "ser.rs",
+            "base_name": "ser",
+            "extension": ".rs",
+            "size": 38252,
+            "date": "1970-01-01",
+            "sha1": "59a95c19b4022ee1e5985ec78396f130623a48e5",
+            "md5": "d40b06e5dbe42895c5590f2b5b7759de",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/private/size_hint.rs",
+            "type": "file",
+            "name": "size_hint.rs",
+            "base_name": "size_hint",
+            "extension": ".rs",
+            "size": 436,
+            "date": "1970-01-01",
+            "sha1": "c8e315d616e690dafaeb90799b6a7668fd8d8bc6",
+            "md5": "da90ba3e22c7f1fc2a6b8141c108dadd",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/ser",
+            "type": "directory",
+            "name": "ser",
+            "base_name": "ser",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 4,
+            "dirs_count": 0,
+            "size_count": 97834,
+            "scan_errors": []
+          },
+          {
+            "path": "src/ser/fmt.rs",
+            "type": "file",
+            "name": "fmt.rs",
+            "base_name": "fmt",
+            "extension": ".rs",
+            "size": 4195,
+            "date": "1970-01-01",
+            "sha1": "384b453b24db9404ef94527677a5d531f66e17f4",
+            "md5": "0fdac4cb7703c2a9fdf4a8245f8af03d",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/ser/impls.rs",
+            "type": "file",
+            "name": "impls.rs",
+            "base_name": "impls",
+            "extension": ".rs",
+            "size": 24881,
+            "date": "1970-01-01",
+            "sha1": "2d336b0ba735e04bc3694d15b7dbe134d88205d2",
+            "md5": "ac570c5cfdbc8545bb4cc874925f7e7a",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://serde.rs/feature-flags.html#-features-rc",
+                "start_line": 411,
+                "end_line": 411
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/ser/impossible.rs",
+            "type": "file",
+            "name": "impossible.rs",
+            "base_name": "impossible",
+            "extension": ".rs",
+            "size": 5273,
+            "date": "1970-01-01",
+            "sha1": "50a0fb487bcae7b4260d503f0f6b87a552bc4486",
+            "md5": "65a92de43aa7d9da975d4ff2f40771cc",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/ser/mod.rs",
+            "type": "file",
+            "name": "mod.rs",
+            "base_name": "mod",
+            "extension": ".rs",
+            "size": 63485,
+            "date": "1970-01-01",
+            "sha1": "e6d85f319683df0aa137377d88aaea4a79f26a67",
+            "md5": "62b41c5350223072d8b5eec654e29183",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://serde.rs/impl-serialize.html",
+                "start_line": 98,
+                "end_line": 98
+              },
+              {
+                "url": "https://docs.rs/linked-hash-map/*/linked_hash_map/struct.LinkedHashMap.html",
+                "start_line": 99,
+                "end_line": 99
+              },
+              {
+                "url": "https://github.com/servo/bincode",
+                "start_line": 102,
+                "end_line": 102
+              },
+              {
+                "url": "https://crates.io/crates/linked-hash-map",
+                "start_line": 103,
+                "end_line": 103
+              },
+              {
+                "url": "https://crates.io/crates/serde_derive",
+                "start_line": 104,
+                "end_line": 104
+              },
+              {
+                "url": "https://github.com/serde-rs/json",
+                "start_line": 105,
+                "end_line": 105
+              },
+              {
+                "url": "https://github.com/dtolnay/serde-yaml",
+                "start_line": 106,
+                "end_line": 106
+              },
+              {
+                "url": "https://serde.rs/derive.html",
+                "start_line": 107,
+                "end_line": 107
+              },
+              {
+                "url": "https://serde.rs/#data-formats",
+                "start_line": 108,
+                "end_line": 108
+              },
+              {
+                "url": "https://serde.rs/data-format.html",
+                "start_line": 138,
+                "end_line": 138
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/path/struct.Path.html",
+                "start_line": 173,
+                "end_line": 173
+              },
+              {
+                "url": "https://docs.serde.rs/serde/ser/index.html",
+                "start_line": 215,
+                "end_line": 215
+              },
+              {
+                "url": "https://serde.rs/data-model.html",
+                "start_line": 323,
+                "end_line": 323
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/io/trait.Write.html",
+                "start_line": 339,
+                "end_line": 339
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/option/enum.Option.html#variant.None",
+                "start_line": 769,
+                "end_line": 769
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some",
+                "start_line": 802,
+                "end_line": 802
+              },
+              {
+                "url": "https://doc.rust-lang.org/std/string/struct.String.html",
+                "start_line": 1356,
+                "end_line": 1356
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/business/evidence/crate-slog-2.7.0.json
+++ b/test/business/evidence/crate-slog-2.7.0.json
@@ -1,0 +1,3068 @@
+{
+  "clearlydefined": {
+    "1.2.0": {
+      "_metadata": {
+        "type": "crate",
+        "url": "cd:/crate/cratesio/-/slog/2.7.0",
+        "fetchedAt": "2021-03-02T16:33:37.386Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:slog:revision:2.7.0:tool:clearlydefined:1.2.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:slog:revision:2.7.0:tool:clearlydefined",
+            "type": "collection"
+          },
+          "licensee": {
+            "href": "urn:crate:cratesio:-:slog:revision:2.7.0:tool:licensee",
+            "type": "collection"
+          },
+          "scancode": {
+            "href": "urn:crate:cratesio:-:slog:revision:2.7.0:tool:scancode",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "1.2.0",
+        "toolVersion": "1.0.0"
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-APACHE",
+          "token": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+        },
+        {
+          "path": "LICENSE-MIT",
+          "token": "6485b8ed310d3f0340bf1ad1f47645069ce4069dcc6bb46c7d5c6faf41de1fdb"
+        }
+      ],
+      "summaryInfo": {
+        "k": 208,
+        "count": 31,
+        "hashes": {
+          "sha1": "dd6b0a72ac00becc778c713007b1b21b5421d1d2",
+          "sha256": "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+        }
+      },
+      "files": [
+        {
+          "path": ".cargo/config",
+          "hashes": {
+            "sha1": "5d39cb708d5a0427fb26d94a30a5b07156330861",
+            "sha256": "b1d2b4fdf0d7fcfa75533a98408cfad4a537048ce0cd7ac72027d0feda4126b6"
+          }
+        },
+        {
+          "path": ".cargo_vcs_info.json",
+          "hashes": {
+            "sha1": "1d54699ee615462d73286da816a74d3c6b50f726",
+            "sha256": "b7f78a9e5f76c111b4d047977776071637b7b375b5bf0b617d5aa530cd261674"
+          }
+        },
+        {
+          "path": ".editorconfig",
+          "hashes": {
+            "sha1": "5a6d6c61f983762dfbb771455ccc6721622257dd",
+            "sha256": "7bbf4fd0a90ff4c383b4ac32ccf3e8c937b50a8e48441cfe3ee1d05815fd3623"
+          }
+        },
+        {
+          "path": ".github/ISSUE_TEMPLATE.md",
+          "hashes": {
+            "sha1": "b865c4d12c6d833b8213a57acd40b4c26642b108",
+            "sha256": "511ce9db25107f037b24865dd7bf33d8205e1d7c95fec7a4674713cc9a36804c"
+          }
+        },
+        {
+          "path": ".github/pull_request_template.md",
+          "hashes": {
+            "sha1": "28f7b270c8906808a3495a883bc00eb17ee50145",
+            "sha256": "82f8dd323277d0a7f10114e06dece38c0cd99a4e8daa5faebc519062f5d90178"
+          }
+        },
+        {
+          "path": ".gitignore",
+          "hashes": {
+            "sha1": "9e0ae69080904c613e9b8cf02f230213f1f38072",
+            "sha256": "5ff3c1131b57ea6f2e048cf69e99c8900163251c1938f8789d16296d1c000f4c"
+          }
+        },
+        {
+          "path": ".rustfmt.toml",
+          "hashes": {
+            "sha1": "57df9e89df2624f1a3055c39a207f5f8e9a98047",
+            "sha256": "a2bfc13700118e2210353957d1d024513b4e542487c91aaeebe683ef4da77e27"
+          }
+        },
+        {
+          "path": ".travis.yml",
+          "hashes": {
+            "sha1": "6dc601c63e2a0c5b52375360cba28f7692f94d4f",
+            "sha256": "57fbe59145eda76446f10dd478863392121b756276ddc4c52144c7462333f749"
+          }
+        },
+        {
+          "path": ".vimrc",
+          "hashes": {
+            "sha1": "f4461254d7aeea6b9d07b1a56879d0699d717c57",
+            "sha256": "65deb3b163326a90200a91143a28637b486a9a7e66e7d9d8876985b0ead15213"
+          }
+        },
+        {
+          "path": "CHANGELOG.md",
+          "hashes": {
+            "sha1": "ce1454b82510c1c95f98a0f4473b65dd1c0a572a",
+            "sha256": "a49373a54ed7dd456f76e7137e5065572853a2b1788684463604935cad49147c"
+          }
+        },
+        {
+          "path": "Cargo.lock",
+          "hashes": {
+            "sha1": "cdab24c42fb9ea0aa24b9dfed40b3a9890589348",
+            "sha256": "7144850c80bef918af8952ae9410417fdebd665f2f805421828b08ac47232891"
+          }
+        },
+        {
+          "path": "Cargo.toml",
+          "hashes": {
+            "sha1": "9e6c5391ba1eacb63bb3ce3e8e66ca94179e73a3",
+            "sha256": "4142407a78484ee95f3e5ec73a20b0ac344c73cc914178ded8c5f25fc18e1cff"
+          }
+        },
+        {
+          "path": "Cargo.toml.orig",
+          "hashes": {
+            "sha1": "466637a3f847f1b3ba2527592e4837956d7e0b06",
+            "sha256": "e6c78ac9cac8ac2eb6c7abdcbdc4cb3ba24192df40b64c294e1b7c5de4c3acaa"
+          }
+        },
+        {
+          "path": "LICENSE-APACHE",
+          "hashes": {
+            "sha1": "5798832c31663cedc1618d18544d445da0295229",
+            "sha256": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+          }
+        },
+        {
+          "path": "LICENSE-MIT",
+          "hashes": {
+            "sha1": "9f3c36d2b7d381d9cf382a00166f3fbd06783636",
+            "sha256": "6485b8ed310d3f0340bf1ad1f47645069ce4069dcc6bb46c7d5c6faf41de1fdb"
+          }
+        },
+        {
+          "path": "LICENSE-MPL2",
+          "hashes": {
+            "sha1": "9744cedce099f727b327cd9913a1fdc58a7f5599",
+            "sha256": "fab3dd6bdab226f1c08630b1dd917e11fcb4ec5e1e020e2c16f83a0a13863e85"
+          }
+        },
+        {
+          "path": "Makefile",
+          "hashes": {
+            "sha1": "291da9e1767a3a679aa1fb9124f9f418ea875719",
+            "sha256": "6523caf1bbaee74e50a3c45bc449fd6e73db68665f708ec5ccc6d7b5793298d0"
+          }
+        },
+        {
+          "path": "README.md",
+          "hashes": {
+            "sha1": "ff6225f438038d0b9bc62b8b2460eb35122e8766",
+            "sha256": "0b4dcba040439bdd2f927d715e380925cf06b282c4e37e1ae4bf1a6d22b0b21f"
+          }
+        },
+        {
+          "path": "benches.txt",
+          "hashes": {
+            "sha1": "b5bdeb49cbcb1cab141fbbaff2ba1a010630fb46",
+            "sha256": "dd19c2f77e35973a0bf28ec289652436e9709dcb90536ac447c5ed62d9a8a68e"
+          }
+        },
+        {
+          "path": "build.rs",
+          "hashes": {
+            "sha1": "59e7efa4b2b8203c0bb6d36864aa47daebb5b469",
+            "sha256": "698793d8da1f1216cda4a1dbb0c741bb488358106421c9682084be83f19b3afe"
+          }
+        },
+        {
+          "path": "examples/README.md",
+          "hashes": {
+            "sha1": "19011e76c7b85ec1bade882e2f104e3d99d6de3d",
+            "sha256": "2f696ea5541644ce13046c3992466e1392eb0b338b7851895d5107627d39cbc7"
+          }
+        },
+        {
+          "path": "examples/common/mod.rs",
+          "hashes": {
+            "sha1": "d2eda06edbabd3a9c56e775ef1757f635119b910",
+            "sha256": "18aff9a53296ef77315ca3016e141faa54845950360d75b797b8123d45c19621"
+          }
+        },
+        {
+          "path": "examples/named.rs",
+          "hashes": {
+            "sha1": "8232f5de9b54aae23aba733d4c3798789b5a2a3e",
+            "sha256": "473e6c5953aa764423475ce4088a35e360f3bbbf4f018e8217414e6ecb20b46f"
+          }
+        },
+        {
+          "path": "examples/singlethread.rs",
+          "hashes": {
+            "sha1": "84dc12c5df67953b413f5c906cfaf8224de92183",
+            "sha256": "2db8418d1d1c9af556860f78b28a887e65fd30aec91dd1ea1f76562b892a1d20"
+          }
+        },
+        {
+          "path": "examples/struct-log-self.rs",
+          "hashes": {
+            "sha1": "5e3a825bf62d00e54143100077adcd167e654295",
+            "sha256": "f5609dfe4aa54ec0ee270719a4ba2f6cd359c2df120e37f7d9a9f554d99b44b3"
+          }
+        },
+        {
+          "path": "src/key/dynamic.rs",
+          "hashes": {
+            "sha1": "9bec0fef29f03a3ecfc68faad3436f546d428fb3",
+            "sha256": "d781417d6087165e44878414384183f0195466cbdeb739bc8b25b1a666d8c2f9"
+          }
+        },
+        {
+          "path": "src/key/dynamic_nostd.rs",
+          "hashes": {
+            "sha1": "8f0a97a9f643224be1d1ee67ea845ba84c66af6f",
+            "sha256": "083b13805827dbbb1596f925305348f7f5ccd8285b1113e21adc076fee2d813b"
+          }
+        },
+        {
+          "path": "src/key/mod.rs",
+          "hashes": {
+            "sha1": "d2e3c3267ffbfbe8e4ddfea5db8b00f58ac209d0",
+            "sha256": "55263ebdcdce64276795644723b3ec2b762e9397aba7234407e1ca2a1f1140a5"
+          }
+        },
+        {
+          "path": "src/key/static.rs",
+          "hashes": {
+            "sha1": "73d116633ba81dbae661af896ae14c67862e69ad",
+            "sha256": "51c1b4c200be690aebfc2d443c08fd8d6dad9e1260926949408bf254360dfd0c"
+          }
+        },
+        {
+          "path": "src/lib.rs",
+          "hashes": {
+            "sha1": "2f7bb444d81d767e1f003eb9c3a0e75f49aca66e",
+            "sha256": "246c8d8307fbad7ee442b9daaad02ffb8804f78a958f17069d26b89fabc54233"
+          }
+        },
+        {
+          "path": "src/tests.rs",
+          "hashes": {
+            "sha1": "58b1356e3f4383e97cb93747e8be0842ad0b7797",
+            "sha256": "56a69bf574aacda14af2e89862d26790dd34ae268e6ee5bb301cbac4923e0672"
+          }
+        }
+      ],
+      "manifest": {
+        "id": "slog",
+        "name": "slog",
+        "updated_at": "2020-11-30T06:26:09.367402+00:00",
+        "versions": [
+          310558,
+          164531,
+          162394,
+          162392,
+          110811,
+          110069,
+          105782,
+          101202,
+          100627,
+          100626,
+          86786,
+          86485,
+          86224,
+          73825,
+          73818,
+          65401,
+          65286,
+          64867,
+          63226,
+          63225,
+          54878,
+          53432,
+          52414,
+          52411,
+          50192,
+          50103,
+          50100,
+          46215,
+          45783,
+          47028,
+          48806,
+          48750,
+          48246,
+          48144,
+          47585,
+          47092,
+          70734,
+          70730,
+          68834,
+          44993,
+          44991,
+          44818,
+          42720,
+          40983,
+          38155,
+          38154,
+          36997,
+          36797,
+          36448,
+          36226,
+          35571,
+          34335,
+          33990,
+          33869,
+          33355,
+          32611,
+          31932,
+          31154,
+          30410,
+          29839,
+          29182,
+          28994,
+          28885,
+          28532
+        ],
+        "keywords": [
+          "log",
+          "structured",
+          "hierarchical",
+          "logging"
+        ],
+        "categories": [
+          "development-tools::debugging"
+        ],
+        "badges": [],
+        "created_at": "2016-06-12T23:00:53.182275+00:00",
+        "downloads": 2550299,
+        "recent_downloads": 453019,
+        "max_version": "2.7.0",
+        "newest_version": "2.7.0",
+        "max_stable_version": "2.7.0",
+        "description": "Structured, extensible, composable logging for Rust",
+        "homepage": "https://github.com/slog-rs/slog",
+        "documentation": "https://docs.rs/slog",
+        "repository": "https://github.com/slog-rs/slog",
+        "links": {
+          "version_downloads": "/api/v1/crates/slog/downloads",
+          "versions": null,
+          "owners": "/api/v1/crates/slog/owners",
+          "owner_team": "/api/v1/crates/slog/owner_team",
+          "owner_user": "/api/v1/crates/slog/owner_user",
+          "reverse_dependencies": "/api/v1/crates/slog/reverse_dependencies"
+        },
+        "exact_match": false
+      },
+      "registryData": {
+        "id": 310558,
+        "crate": "slog",
+        "num": "2.7.0",
+        "dl_path": "/api/v1/crates/slog/2.7.0/download",
+        "readme_path": "/api/v1/crates/slog/2.7.0/readme",
+        "updated_at": "2020-11-30T06:26:09.367402+00:00",
+        "created_at": "2020-11-30T06:26:09.367402+00:00",
+        "downloads": 300653,
+        "features": {
+          "default": [
+            "std"
+          ],
+          "dynamic-keys": [],
+          "max_level_debug": [],
+          "max_level_error": [],
+          "max_level_info": [],
+          "max_level_off": [],
+          "max_level_trace": [],
+          "max_level_warn": [],
+          "nested-values": [
+            "erased-serde"
+          ],
+          "nothreads": [],
+          "release_max_level_debug": [],
+          "release_max_level_error": [],
+          "release_max_level_info": [],
+          "release_max_level_off": [],
+          "release_max_level_trace": [],
+          "release_max_level_warn": [],
+          "std": []
+        },
+        "yanked": false,
+        "license": "MPL-2.0 OR MIT OR Apache-2.0",
+        "links": {
+          "dependencies": "/api/v1/crates/slog/2.7.0/dependencies",
+          "version_downloads": "/api/v1/crates/slog/2.7.0/downloads",
+          "authors": "/api/v1/crates/slog/2.7.0/authors"
+        },
+        "crate_size": 45432,
+        "published_by": {
+          "id": 133,
+          "login": "dpc",
+          "name": "Dawid Ciężarkiewicz",
+          "avatar": "https://avatars2.githubusercontent.com/u/9209?v=4",
+          "url": "https://github.com/dpc"
+        },
+        "audit_actions": [
+          {
+            "action": "publish",
+            "user": {
+              "id": 133,
+              "login": "dpc",
+              "name": "Dawid Ciężarkiewicz",
+              "avatar": "https://avatars2.githubusercontent.com/u/9209?v=4",
+              "url": "https://github.com/dpc"
+            },
+            "time": "2020-11-30T06:26:09.367402+00:00"
+          }
+        ]
+      }
+    }
+  },
+  "licensee": {
+    "9.13.0": {
+      "_metadata": {
+        "type": "licensee",
+        "url": "cd:/crate/cratesio/-/slog/2.7.0",
+        "fetchedAt": "2021-03-02T17:40:17.006Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:slog:revision:2.7.0:tool:licensee:9.13.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:slog:revision:2.7.0:tool:licensee",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "9.13.0",
+        "toolVersion": "9.11.0",
+        "processedAt": "2021-03-02T17:40:19.141Z"
+      },
+      "licensee": {
+        "version": "9.11.0",
+        "parameters": [
+          "--json",
+          "--no-readme"
+        ],
+        "output": {
+          "contentType": "application/json",
+          "content": {
+            "licenses": [
+              {
+                "key": "mit",
+                "spdx_id": "MIT",
+                "meta": {
+                  "title": "MIT License",
+                  "source": "https://spdx.org/licenses/MIT.html",
+                  "description": "A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.",
+                  "using": [
+                    {
+                      "Babel": "https://github.com/babel/babel/blob/master/LICENSE"
+                    },
+                    {
+                      ".NET Core": "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT"
+                    },
+                    {
+                      "Rails": "https://github.com/rails/rails/blob/master/MIT-LICENSE"
+                    }
+                  ],
+                  "featured": true,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": null
+                },
+                "url": "http://choosealicense.com/licenses/mit/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [
+                  {
+                    "name": "year",
+                    "description": "The current year"
+                  },
+                  {
+                    "name": "fullname",
+                    "description": "The full name or username of the repository owner"
+                  }
+                ],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "apache-2.0",
+                "spdx_id": "Apache-2.0",
+                "meta": {
+                  "title": "Apache License 2.0",
+                  "source": "https://spdx.org/licenses/Apache-2.0.html",
+                  "description": "A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without source code.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.",
+                  "using": [
+                    {
+                      "Kubernetes": "https://github.com/kubernetes/kubernetes/blob/master/LICENSE"
+                    },
+                    {
+                      "PDF.js": "https://github.com/mozilla/pdf.js/blob/master/LICENSE"
+                    },
+                    {
+                      "Swift": "https://github.com/apple/swift/blob/master/LICENSE.txt"
+                    }
+                  ],
+                  "featured": true,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": "The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix."
+                },
+                "url": "http://choosealicense.com/licenses/apache-2.0/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "patent-use",
+                      "label": "Patent use",
+                      "description": "This license provides an express grant of patent rights from contributors."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    },
+                    {
+                      "tag": "document-changes",
+                      "label": "State changes",
+                      "description": "Changes made to the code must be documented."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "trademark-use",
+                      "label": "Trademark use",
+                      "description": "This license explicitly states that it does NOT grant trademark rights, even though licenses without such a statement probably do not grant any implicit trademark rights."
+                    },
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "mpl-2.0",
+                "spdx_id": "MPL-2.0",
+                "meta": {
+                  "title": "Mozilla Public License 2.0",
+                  "source": "https://spdx.org/licenses/MPL-2.0.html",
+                  "description": "Permissions of this weak copyleft license are conditioned on making available source code of licensed files and modifications of those files under the same license (or in certain cases, one of the GNU licenses). Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work may be distributed under different terms and without source code for files added in the larger work.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.",
+                  "using": [
+                    {
+                      "Servo": "https://github.com/servo/servo/blob/master/LICENSE"
+                    },
+                    {
+                      "Syncthing": "https://github.com/syncthing/syncthing/blob/master/LICENSE"
+                    },
+                    {
+                      "TimelineJS3": "https://github.com/NUKnightLab/TimelineJS3/blob/master/LICENSE"
+                    }
+                  ],
+                  "featured": false,
+                  "hidden": false,
+                  "nickname": null,
+                  "note": "The Mozilla Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license (Exhibit A)."
+                },
+                "url": "http://choosealicense.com/licenses/mpl-2.0/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "patent-use",
+                      "label": "Patent use",
+                      "description": "This license provides an express grant of patent rights from contributors."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "disclose-source",
+                      "label": "Disclose source",
+                      "description": "Source code must be made available when the software is distributed."
+                    },
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    },
+                    {
+                      "tag": "same-license--file",
+                      "label": "Same license (file)",
+                      "description": "Modifications of existing files must be released under the same license when distributing the software. In some cases a similar or related license may be used."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "trademark-use",
+                      "label": "Trademark use",
+                      "description": "This license explicitly states that it does NOT grant trademark rights, even though licenses without such a statement probably do not grant any implicit trademark rights."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [],
+                "other": false,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              },
+              {
+                "key": "other",
+                "spdx_id": "NOASSERTION",
+                "meta": {
+                  "title": null,
+                  "source": null,
+                  "description": null,
+                  "how": null,
+                  "using": null,
+                  "featured": false,
+                  "hidden": true,
+                  "nickname": null,
+                  "note": null
+                },
+                "url": "http://choosealicense.com/licenses/other/",
+                "rules": {
+                  "permissions": [],
+                  "conditions": [],
+                  "limitations": []
+                },
+                "fields": [],
+                "other": true,
+                "gpl": false,
+                "lgpl": false,
+                "cc": false
+              }
+            ],
+            "matched_files": [
+              {
+                "filename": "LICENSE-MIT",
+                "content": "Copyright (c) 2014 The Rust Project Developers\n\nPermission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE.\n",
+                "content_hash": "d64f3bb4282a97b37454b5bb96a8a264a3363dc3",
+                "content_normalized": "permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"software\"), to deal in the software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the software, and to permit persons to whom the software is furnished to do so, subject to the following conditions: the above copyright notice and this permission notice shall be included in all copies or substantial portions of the software. the software is provided \"as is\", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. in no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "MIT"
+              },
+              {
+                "filename": "LICENSE-APACHE",
+                "content": "                              Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
+                "content_hash": "ab3901051663cb8ee5dea9ebdff406ad136910e3",
+                "content_normalized": "terms and conditions for use, reproduction, and distribution - definitions. \"license\" shall mean the terms and conditions for use, reproduction, and distribution as defined by sections 1 through 9 of this document. \"licensor\" shall mean the copyright holder or entity authorized by the copyright holder that is granting the license. \"legal entity\" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. for the purposes of this definition, \"control\" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity. \"you\" (or \"your\") shall mean an individual or legal entity exercising permissions granted by this license. \"source\" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files. \"object\" form shall mean any form resulting from mechanical transformation or translation of a source form, including but not limited to compiled object code, generated documentation, and conversions to other media types. \"work\" shall mean the work of authorship, whether in source or object form, made available under the license, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the appendix below). \"derivative works\" shall mean any work, whether in source or object form, that is based on (or derived from) the work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. for the purposes of this license, derivative works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the work and derivative works thereof. \"contribution\" shall mean any work of authorship, including the original version of the work and any modifications or additions to that work or derivative works thereof, that is intentionally submitted to licensor for inclusion in the work by the copyright holder or by an individual or legal entity authorized to submit on behalf of the copyright holder. for the purposes of this definition, \"submitted\" means any form of electronic, verbal, or written communication sent to the licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the licensor for the purpose of discussing and improving the work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright holder as \"not a contribution.\" \"contributor\" shall mean licensor and any individual or legal entity on behalf of whom a contribution has been received by licensor and subsequently incorporated within the work. - grant of copyright license. subject to the terms and conditions of this license, each contributor hereby grants to you a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute the work and such derivative works in source or object form. - grant of patent license. subject to the terms and conditions of this license, each contributor hereby grants to you a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the work, where such license applies only to those patent claims licensable by such contributor that are necessarily infringed by their contribution(s) alone or by combination of their contribution(s) with the work to which such contribution(s) was submitted. if you institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the work or a contribution incorporated within the work constitutes direct or contributory patent infringement, then any patent licenses granted to you under this license for that work shall terminate as of the date such litigation is filed. - redistribution. you may reproduce and distribute copies of the work or derivative works thereof in any medium, with or without modifications, and in source or object form, provided that you meet the following conditions: * you must give any other recipients of the work or derivative works a copy of this license; and * you must cause any modified files to carry prominent notices stating that you changed the files; and * you must retain, in the source form of any derivative works that you distribute, all copyright, patent, trademark, and attribution notices from the source form of the work, excluding those notices that do not pertain to any part of the derivative works; and * if the work includes a \"notice\" text file as part of its distribution, then any derivative works that you distribute must include a readable copy of the attribution notices contained within such notice file, excluding those notices that do not pertain to any part of the derivative works, in at least one of the following places: within a notice text file distributed as part of the derivative works; within the source form or documentation, if provided along with the derivative works; or, within a display generated by the derivative works, if and wherever such third-party notices normally appear. the contents of the notice file are for informational purposes only and do not modify the license. you may add your own attribution notices within derivative works that you distribute, alongside or as an addendum to the notice text from the work, provided that such additional attribution notices cannot be construed as modifying the license. you may add your own copyright statement to your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of your modifications, or for any such derivative works as a whole, provided your use, reproduction, and distribution of the work otherwise complies with the conditions stated in this license. - submission of contributions. unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you to the licensor shall be under the terms and conditions of this license, without any additional terms or conditions. notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with licensor regarding such contributions. - trademarks. this license does not grant permission to use the trade names, trademarks, service marks, or product names of the licensor, except as required for reasonable and customary use in describing the origin of the work and reproducing the content of the notice file. - disclaimer of warranty. unless required by applicable law or agreed to in writing, licensor provides the work (and each contributor provides its contributions) on an \"as is\" basis, without warranties or conditions of any kind, either express or implied, including, without limitation, any warranties or conditions of title, non-infringement, merchantability, or fitness for a particular purpose. you are solely responsible for determining the appropriateness of using or redistributing the work and assume any risks associated with your exercise of permissions under this license. - limitation of liability. in no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any contributor be liable to you for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this license or out of the use or inability to use the work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such contributor has been advised of the possibility of such damages. - accepting warranty or additional liability. while redistributing the work or derivative works thereof, you may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this license. however, in accepting such obligations, you may act only on your own behalf and on your sole responsibility, not on behalf of any other contributor, and only if you agree to indemnify, defend, and hold each contributor harmless for any liability incurred by, or claims asserted against, such contributor by reason of your accepting any such warranty or additional liability.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "Apache-2.0"
+              },
+              {
+                "filename": "LICENSE-MPL2",
+                "content": "Mozilla Public License Version 2.0\n==================================\n\n1. Definitions\n--------------\n\n1.1. \"Contributor\"\n    means each individual or legal entity that creates, contributes to\n    the creation of, or owns Covered Software.\n\n1.2. \"Contributor Version\"\n    means the combination of the Contributions of others (if any) used\n    by a Contributor and that particular Contributor's Contribution.\n\n1.3. \"Contribution\"\n    means Covered Software of a particular Contributor.\n\n1.4. \"Covered Software\"\n    means Source Code Form to which the initial Contributor has attached\n    the notice in Exhibit A, the Executable Form of such Source Code\n    Form, and Modifications of such Source Code Form, in each case\n    including portions thereof.\n\n1.5. \"Incompatible With Secondary Licenses\"\n    means\n\n    (a) that the initial Contributor has attached the notice described\n        in Exhibit B to the Covered Software; or\n\n    (b) that the Covered Software was made available under the terms of\n        version 1.1 or earlier of the License, but not also under the\n        terms of a Secondary License.\n\n1.6. \"Executable Form\"\n    means any form of the work other than Source Code Form.\n\n1.7. \"Larger Work\"\n    means a work that combines Covered Software with other material, in \n    a separate file or files, that is not Covered Software.\n\n1.8. \"License\"\n    means this document.\n\n1.9. \"Licensable\"\n    means having the right to grant, to the maximum extent possible,\n    whether at the time of the initial grant or subsequently, any and\n    all of the rights conveyed by this License.\n\n1.10. \"Modifications\"\n    means any of the following:\n\n    (a) any file in Source Code Form that results from an addition to,\n        deletion from, or modification of the contents of Covered\n        Software; or\n\n    (b) any new file in Source Code Form that contains any Covered\n        Software.\n\n1.11. \"Patent Claims\" of a Contributor\n    means any patent claim(s), including without limitation, method,\n    process, and apparatus claims, in any patent Licensable by such\n    Contributor that would be infringed, but for the grant of the\n    License, by the making, using, selling, offering for sale, having\n    made, import, or transfer of either its Contributions or its\n    Contributor Version.\n\n1.12. \"Secondary License\"\n    means either the GNU General Public License, Version 2.0, the GNU\n    Lesser General Public License, Version 2.1, the GNU Affero General\n    Public License, Version 3.0, or any later versions of those\n    licenses.\n\n1.13. \"Source Code Form\"\n    means the form of the work preferred for making modifications.\n\n1.14. \"You\" (or \"Your\")\n    means an individual or a legal entity exercising rights under this\n    License. For legal entities, \"You\" includes any entity that\n    controls, is controlled by, or is under common control with You. For\n    purposes of this definition, \"control\" means (a) the power, direct\n    or indirect, to cause the direction or management of such entity,\n    whether by contract or otherwise, or (b) ownership of more than\n    fifty percent (50%) of the outstanding shares or beneficial\n    ownership of such entity.\n\n2. License Grants and Conditions\n--------------------------------\n\n2.1. Grants\n\nEach Contributor hereby grants You a world-wide, royalty-free,\nnon-exclusive license:\n\n(a) under intellectual property rights (other than patent or trademark)\n    Licensable by such Contributor to use, reproduce, make available,\n    modify, display, perform, distribute, and otherwise exploit its\n    Contributions, either on an unmodified basis, with Modifications, or\n    as part of a Larger Work; and\n\n(b) under Patent Claims of such Contributor to make, use, sell, offer\n    for sale, have made, import, and otherwise transfer either its\n    Contributions or its Contributor Version.\n\n2.2. Effective Date\n\nThe licenses granted in Section 2.1 with respect to any Contribution\nbecome effective for each Contribution on the date the Contributor first\ndistributes such Contribution.\n\n2.3. Limitations on Grant Scope\n\nThe licenses granted in this Section 2 are the only rights granted under\nthis License. No additional rights or licenses will be implied from the\ndistribution or licensing of Covered Software under this License.\nNotwithstanding Section 2.1(b) above, no patent license is granted by a\nContributor:\n\n(a) for any code that a Contributor has removed from Covered Software;\n    or\n\n(b) for infringements caused by: (i) Your and any other third party's\n    modifications of Covered Software, or (ii) the combination of its\n    Contributions with other software (except as part of its Contributor\n    Version); or\n\n(c) under Patent Claims infringed by Covered Software in the absence of\n    its Contributions.\n\nThis License does not grant any rights in the trademarks, service marks,\nor logos of any Contributor (except as may be necessary to comply with\nthe notice requirements in Section 3.4).\n\n2.4. Subsequent Licenses\n\nNo Contributor makes additional grants as a result of Your choice to\ndistribute the Covered Software under a subsequent version of this\nLicense (see Section 10.2) or under the terms of a Secondary License (if\npermitted under the terms of Section 3.3).\n\n2.5. Representation\n\nEach Contributor represents that the Contributor believes its\nContributions are its original creation(s) or it has sufficient rights\nto grant the rights to its Contributions conveyed by this License.\n\n2.6. Fair Use\n\nThis License is not intended to limit any rights You have under\napplicable copyright doctrines of fair use, fair dealing, or other\nequivalents.\n\n2.7. Conditions\n\nSections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted\nin Section 2.1.\n\n3. Responsibilities\n-------------------\n\n3.1. Distribution of Source Form\n\nAll distribution of Covered Software in Source Code Form, including any\nModifications that You create or to which You contribute, must be under\nthe terms of this License. You must inform recipients that the Source\nCode Form of the Covered Software is governed by the terms of this\nLicense, and how they can obtain a copy of this License. You may not\nattempt to alter or restrict the recipients' rights in the Source Code\nForm.\n\n3.2. Distribution of Executable Form\n\nIf You distribute Covered Software in Executable Form then:\n\n(a) such Covered Software must also be made available in Source Code\n    Form, as described in Section 3.1, and You must inform recipients of\n    the Executable Form how they can obtain a copy of such Source Code\n    Form by reasonable means in a timely manner, at a charge no more\n    than the cost of distribution to the recipient; and\n\n(b) You may distribute such Executable Form under the terms of this\n    License, or sublicense it under different terms, provided that the\n    license for the Executable Form does not attempt to limit or alter\n    the recipients' rights in the Source Code Form under this License.\n\n3.3. Distribution of a Larger Work\n\nYou may create and distribute a Larger Work under terms of Your choice,\nprovided that You also comply with the requirements of this License for\nthe Covered Software. If the Larger Work is a combination of Covered\nSoftware with a work governed by one or more Secondary Licenses, and the\nCovered Software is not Incompatible With Secondary Licenses, this\nLicense permits You to additionally distribute such Covered Software\nunder the terms of such Secondary License(s), so that the recipient of\nthe Larger Work may, at their option, further distribute the Covered\nSoftware under the terms of either this License or such Secondary\nLicense(s).\n\n3.4. Notices\n\nYou may not remove or alter the substance of any license notices\n(including copyright notices, patent notices, disclaimers of warranty,\nor limitations of liability) contained within the Source Code Form of\nthe Covered Software, except that You may alter any license notices to\nthe extent required to remedy known factual inaccuracies.\n\n3.5. Application of Additional Terms\n\nYou may choose to offer, and to charge a fee for, warranty, support,\nindemnity or liability obligations to one or more recipients of Covered\nSoftware. However, You may do so only on Your own behalf, and not on\nbehalf of any Contributor. You must make it absolutely clear that any\nsuch warranty, support, indemnity, or liability obligation is offered by\nYou alone, and You hereby agree to indemnify every Contributor for any\nliability incurred by such Contributor as a result of warranty, support,\nindemnity or liability terms You offer. You may include additional\ndisclaimers of warranty and limitations of liability specific to any\njurisdiction.\n\n4. Inability to Comply Due to Statute or Regulation\n---------------------------------------------------\n\nIf it is impossible for You to comply with any of the terms of this\nLicense with respect to some or all of the Covered Software due to\nstatute, judicial order, or regulation then You must: (a) comply with\nthe terms of this License to the maximum extent possible; and (b)\ndescribe the limitations and the code they affect. Such description must\nbe placed in a text file included with all distributions of the Covered\nSoftware under this License. Except to the extent prohibited by statute\nor regulation, such description must be sufficiently detailed for a\nrecipient of ordinary skill to be able to understand it.\n\n5. Termination\n--------------\n\n5.1. The rights granted under this License will terminate automatically\nif You fail to comply with any of its terms. However, if You become\ncompliant, then the rights granted under this License from a particular\nContributor are reinstated (a) provisionally, unless and until such\nContributor explicitly and finally terminates Your grants, and (b) on an\nongoing basis, if such Contributor fails to notify You of the\nnon-compliance by some reasonable means prior to 60 days after You have\ncome back into compliance. Moreover, Your grants from a particular\nContributor are reinstated on an ongoing basis if such Contributor\nnotifies You of the non-compliance by some reasonable means, this is the\nfirst time You have received notice of non-compliance with this License\nfrom such Contributor, and You become compliant prior to 30 days after\nYour receipt of the notice.\n\n5.2. If You initiate litigation against any entity by asserting a patent\ninfringement claim (excluding declaratory judgment actions,\ncounter-claims, and cross-claims) alleging that a Contributor Version\ndirectly or indirectly infringes any patent, then the rights granted to\nYou by any and all Contributors for the Covered Software under Section\n2.1 of this License shall terminate.\n\n5.3. In the event of termination under Sections 5.1 or 5.2 above, all\nend user license agreements (excluding distributors and resellers) which\nhave been validly granted by You or Your distributors under this License\nprior to termination shall survive termination.\n\n************************************************************************\n*                                                                      *\n*  6. Disclaimer of Warranty                                           *\n*  -------------------------                                           *\n*                                                                      *\n*  Covered Software is provided under this License on an \"as is\"       *\n*  basis, without warranty of any kind, either expressed, implied, or  *\n*  statutory, including, without limitation, warranties that the       *\n*  Covered Software is free of defects, merchantable, fit for a        *\n*  particular purpose or non-infringing. The entire risk as to the     *\n*  quality and performance of the Covered Software is with You.        *\n*  Should any Covered Software prove defective in any respect, You     *\n*  (not any Contributor) assume the cost of any necessary servicing,   *\n*  repair, or correction. This disclaimer of warranty constitutes an   *\n*  essential part of this License. No use of any Covered Software is   *\n*  authorized under this License except under this disclaimer.         *\n*                                                                      *\n************************************************************************\n\n************************************************************************\n*                                                                      *\n*  7. Limitation of Liability                                          *\n*  --------------------------                                          *\n*                                                                      *\n*  Under no circumstances and under no legal theory, whether tort      *\n*  (including negligence), contract, or otherwise, shall any           *\n*  Contributor, or anyone who distributes Covered Software as          *\n*  permitted above, be liable to You for any direct, indirect,         *\n*  special, incidental, or consequential damages of any character      *\n*  including, without limitation, damages for lost profits, loss of    *\n*  goodwill, work stoppage, computer failure or malfunction, or any    *\n*  and all other commercial damages or losses, even if such party      *\n*  shall have been informed of the possibility of such damages. This   *\n*  limitation of liability shall not apply to liability for death or   *\n*  personal injury resulting from such party's negligence to the       *\n*  extent applicable law prohibits such limitation. Some               *\n*  jurisdictions do not allow the exclusion or limitation of           *\n*  incidental or consequential damages, so this exclusion and          *\n*  limitation may not apply to You.                                    *\n*                                                                      *\n************************************************************************\n\n8. Litigation\n-------------\n\nAny litigation relating to this License may be brought only in the\ncourts of a jurisdiction where the defendant maintains its principal\nplace of business and such litigation shall be governed by laws of that\njurisdiction, without reference to its conflict-of-law provisions.\nNothing in this Section shall prevent a party's ability to bring\ncross-claims or counter-claims.\n\n9. Miscellaneous\n----------------\n\nThis License represents the complete agreement concerning the subject\nmatter hereof. If any provision of this License is held to be\nunenforceable, such provision shall be reformed only to the extent\nnecessary to make it enforceable. Any law or regulation which provides\nthat the language of a contract shall be construed against the drafter\nshall not be used to construe this License against a Contributor.\n\n10. Versions of the License\n---------------------------\n\n10.1. New Versions\n\nMozilla Foundation is the license steward. Except as provided in Section\n10.3, no one other than the license steward has the right to modify or\npublish new versions of this License. Each version will be given a\ndistinguishing version number.\n\n10.2. Effect of New Versions\n\nYou may distribute the Covered Software under the terms of the version\nof the License under which You originally received the Covered Software,\nor under the terms of any subsequent version published by the license\nsteward.\n\n10.3. Modified Versions\n\nIf you create software not governed by this License, and you want to\ncreate a new license for such software, you may create and use a\nmodified version of this License if you rename the license and remove\nany references to the name of the license steward (except to note that\nsuch modified license differs from this License).\n\n10.4. Distributing Source Code Form that is Incompatible With Secondary\nLicenses\n\nIf You choose to distribute Source Code Form that is Incompatible With\nSecondary Licenses under the terms of this version of the License, the\nnotice described in Exhibit B of this License must be attached.\n\nExhibit A - Source Code Form License Notice\n-------------------------------------------\n\n  This Source Code Form is subject to the terms of the Mozilla Public\n  License, v. 2.0. If a copy of the MPL was not distributed with this\n  file, You can obtain one at http://mozilla.org/MPL/2.0/.\n\nIf it is not possible or desirable to put the notice in a particular\nfile, then You may include the notice in a location (such as a LICENSE\nfile in a relevant directory) where a recipient would be likely to look\nfor such a notice.\n\nYou may add additional accurate notices of copyright ownership.\n\nExhibit B - \"Incompatible With Secondary Licenses\" Notice\n---------------------------------------------------------\n\n  This Source Code Form is \"Incompatible With Secondary Licenses\", as\n  defined by the Mozilla Public License, v. 2.0.\n",
+                "content_hash": "b4db668fa7573bfdcae74eb51eafc961034f0a61",
+                "content_normalized": "- definitions 1.1. \"contributor\" means each individual or legal entity that creates, contributes to the creation of, or owns covered software. 1.2. \"contributor version\" means the combination of the contributions of others (if any) used by a contributor and that particular contributor's contribution. 1.3. \"contribution\" means covered software of a particular contributor. 1.4. \"covered software\" means source code form to which the initial contributor has attached the notice in exhibit a, the executable form of such source code form, and modifications of such source code form, in each case including portions thereof. 1.5. \"incompatible with secondary licenses\" means * that the initial contributor has attached the notice described in exhibit b to the covered software; or * that the covered software was made available under the terms of version 1.1 or earlier of the license, but not also under the terms of a secondary license. 1.6. \"executable form\" means any form of the work other than source code form. 1.7. \"larger work\" means a work that combines covered software with other material, in a separate file or files, that is not covered software. 1.8. \"license\" means this document. 1.9. \"licensable\" means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently, any and all of the rights conveyed by this license. 1.10. \"modifications\" means any of the following: * any file in source code form that results from an addition to, deletion from, or modification of the contents of covered software; or * any new file in source code form that contains any covered software. 1.11. \"patent claims\" of a contributor means any patent claim(s), including without limitation, method, process, and apparatus claims, in any patent licensable by such contributor that would be infringed, but for the grant of the license, by the making, using, selling, offering for sale, having made, import, or transfer of either its contributions or its contributor version. 1.12. \"secondary license\" means either the gnu general public license, version 2.0, the gnu lesser general public license, version 2.1, the gnu affero general public license, version 3.0, or any later versions of those licenses. 1.13. \"source code form\" means the form of the work preferred for making modifications. 1.14. \"you\" (or \"your\") means an individual or a legal entity exercising rights under this license. for legal entities, \"you\" includes any entity that controls, is controlled by, or is under common control with you. for purposes of this definition, \"control\" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity. - license grants and conditions 2.1. grants each contributor hereby grants you a world-wide, royalty-free, non-exclusive license: * under intellectual property rights (other than patent or trademark) licensable by such contributor to use, reproduce, make available, modify, display, perform, distribute, and otherwise exploit its contributions, either on an unmodified basis, with modifications, or as part of a larger work; and * under patent claims of such contributor to make, use, sell, offer for sale, have made, import, and otherwise transfer either its contributions or its contributor version. 2.2. effective date the licenses granted in section 2.1 with respect to any contribution become effective for each contribution on the date the contributor first distributes such contribution. 2.3. limitations on grant scope the licenses granted in this section 2 are the only rights granted under this license. no additional rights or licenses will be implied from the distribution or licensing of covered software under this license. notwithstanding section 2.1(b) above, no patent license is granted by a contributor: * for any code that a contributor has removed from covered software; or * for infringements caused by: (i) your and any other third party's modifications of covered software, or (ii) the combination of its contributions with other software (except as part of its contributor version); or * under patent claims infringed by covered software in the absence of its contributions. this license does not grant any rights in the trademarks, service marks, or logos of any contributor (except as may be necessary to comply with the notice requirements in section 3.4). 2.4. subsequent licenses no contributor makes additional grants as a result of your choice to distribute the covered software under a subsequent version of this license (see section 10.2) or under the terms of a secondary license (if permitted under the terms of section 3.3). 2.5. representation each contributor represents that the contributor believes its contributions are its original creation(s) or it has sufficient rights to grant the rights to its contributions conveyed by this license. 2.6. fair use this license is not intended to limit any rights you have under applicable copyright doctrines of fair use, fair dealing, or other equivalents. 2.7. conditions sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in section 2.1. - responsibilities 3.1. distribution of source form all distribution of covered software in source code form, including any modifications that you create or to which you contribute, must be under the terms of this license. you must inform recipients that the source code form of the covered software is governed by the terms of this license, and how they can obtain a copy of this license. you may not attempt to alter or restrict the recipients' rights in the source code form. 3.2. distribution of executable form if you distribute covered software in executable form then: * such covered software must also be made available in source code form, as described in section 3.1, and you must inform recipients of the executable form how they can obtain a copy of such source code form by reasonable means in a timely manner, at a charge no more than the cost of distribution to the recipient; and * you may distribute such executable form under the terms of this license, or sublicense it under different terms, provided that the license for the executable form does not attempt to limit or alter the recipients' rights in the source code form under this license. 3.3. distribution of a larger work you may create and distribute a larger work under terms of your choice, provided that you also comply with the requirements of this license for the covered software. if the larger work is a combination of covered software with a work governed by one or more secondary licenses, and the covered software is not incompatible with secondary licenses, this license permits you to additionally distribute such covered software under the terms of such secondary license(s), so that the recipient of the larger work may, at their option, further distribute the covered software under the terms of either this license or such secondary license(s). 3.4. notices you may not remove or alter the substance of any license notices (including copyright notices, patent notices, disclaimers of warranty, or limitations of liability) contained within the source code form of the covered software, except that you may alter any license notices to the extent required to remedy known factual inaccuracies. 3.5. application of additional terms you may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of covered software. however, you may do so only on your own behalf, and not on behalf of any contributor. you must make it absolutely clear that any such warranty, support, indemnity, or liability obligation is offered by you alone, and you hereby agree to indemnify every contributor for any liability incurred by such contributor as a result of warranty, support, indemnity or liability terms you offer. you may include additional disclaimers of warranty and limitations of liability specific to any jurisdiction. - inability to comply due to statute or regulation if it is impossible for you to comply with any of the terms of this license with respect to some or all of the covered software due to statute, judicial order, or regulation then you must: (a) comply with the terms of this license to the maximum extent possible; and (b) describe the limitations and the code they affect. such description must be placed in a text file included with all distributions of the covered software under this license. except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it. - termination 5.1. the rights granted under this license will terminate automatically if you fail to comply with any of its terms. however, if you become compliant, then the rights granted under this license from a particular contributor are reinstated (a) provisionally, unless and until such contributor explicitly and finally terminates your grants, and (b) on an ongoing basis, if such contributor fails to notify you of the non-compliance by some reasonable means prior to 60 days after you have come back into compliance. moreover, your grants from a particular contributor are reinstated on an ongoing basis if such contributor notifies you of the non-compliance by some reasonable means, this is the first time you have received notice of non-compliance with this license from such contributor, and you become compliant prior to 30 days after your receipt of the notice. 5.2. if you initiate litigation against any entity by asserting a patent infringement claim (excluding declaratory judgement actions, counter-claims, and cross-claims) alleging that a contributor version directly or indirectly infringes any patent, then the rights granted to you by any and all contributors for the covered software under section 2.1 of this license shall terminate. 5.3. in the event of termination under sections 5.1 or 5.2 above, all end user license agreements (excluding distributors and resellers) which have been validly granted by you or your distributors under this license prior to termination shall survive termination. 6. disclaimer of warranty - covered software is provided under this license on an \"as is\" basis, without warranty of any kind, either expressed, implied, or statutory, including, without limitation, warranties that the covered software is free of defects, merchantable, fit for a particular purpose or non-infringing. the entire risk as to the quality and performance of the covered software is with you. should any covered software prove defective in any respect, you (not any contributor) assume the cost of any necessary servicing, repair, or correction. this disclaimer of warranty constitutes an essential part of this license. no use of any covered software is authorized under this license except under this disclaimer. 7. limitation of liability - under no circumstances and under no legal theory, whether tort (including negligence), contract, or otherwise, shall any contributor, or anyone who distributes covered software as permitted above, be liable to you for any direct, indirect, special, incidental, or consequential damages of any character including, without limitation, damages for lost profits, loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such party shall have been informed of the possibility of such damages. this limitation of liability shall not apply to liability for death or personal injury resulting from such party's negligence to the extent applicable law prohibits such limitation. some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to you. - litigation any litigation relating to this license may be brought only in the courts of a jurisdiction where the defendant maintains its principal place of business and such litigation shall be governed by laws of that jurisdiction, without reference to its conflict-of-law provisions. nothing in this section shall prevent a party's ability to bring cross-claims or counter-claims. - miscellaneous this license represents the complete agreement concerning the subject matter hereof. if any provision of this license is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. any law or regulation which provides that the language of a contract shall be construed against the drafter shall not be used to construe this license against a contributor. * versions of the license 10.1. new versions mozilla foundation is the license steward. except as provided in section 10.3, no one other than the license steward has the right to modify or publish new versions of this license. each version will be given a distinguishing version number. 10.2. effect of new versions you may distribute the covered software under the terms of the version of the license under which you originally received the covered software, or under the terms of any subsequent version published by the license steward. 10.3. modified versions if you create software not governed by this license, and you want to create a new license for such software, you may create and use a modified version of this license if you rename the license and remove any references to the name of the license steward (except to note that such modified license differs from this license). 10.4. distributing source code form that is incompatible with secondary licenses if you choose to distribute source code form that is incompatible with secondary licenses under the terms of this version of the license, the notice described in exhibit b of this license must be attached. exhibit a - source code form license notice this source code form is subject to the terms of the mozilla public license, v. 2.0. if a copy of the mpl was not distributed with this file, you can obtain one at https://mozilla.org/mpl/2.0/. if it is not possible or desirable to put the notice in a particular file, then you may include the notice in a location (such as a license file in a relevant directory) where a recipient would be likely to look for such a notice. you may add additional accurate notices of copyright ownership. exhibit b - \"incompatible with secondary licenses\" notice this source code form is \"incompatible with secondary licenses\", as defined by the mozilla public license, v. 2.0.",
+                "matcher": {
+                  "name": "exact",
+                  "confidence": 100
+                },
+                "matched_license": "MPL-2.0"
+              },
+              {
+                "filename": "Cargo.toml",
+                "content": "# THIS FILE IS AUTOMATICALLY GENERATED BY CARGO\n#\n# When uploading crates to the registry Cargo will automatically\n# \"normalize\" Cargo.toml files for maximal compatibility\n# with all versions of Cargo and also rewrite `path` dependencies\n# to registry (e.g., crates.io) dependencies\n#\n# If you believe there's an error in this file please file an\n# issue against the rust-lang/cargo repository. If you're\n# editing this file be aware that the upstream Cargo.toml\n# will likely look very different (and much more reasonable)\n\n[package]\nname = \"slog\"\nversion = \"2.7.0\"\nauthors = [\"Dawid Ciężarkiewicz <dpc@dpc.pw>\"]\nbuild = \"build.rs\"\nautoexamples = true\ndescription = \"Structured, extensible, composable logging for Rust\"\nhomepage = \"https://github.com/slog-rs/slog\"\ndocumentation = \"https://docs.rs/slog\"\nreadme = \"README.md\"\nkeywords = [\"log\", \"logging\", \"structured\", \"hierarchical\"]\ncategories = [\"development-tools::debugging\"]\nlicense = \"MPL-2.0 OR MIT OR Apache-2.0\"\nrepository = \"https://github.com/slog-rs/slog\"\n[package.metadata.docs.rs]\nfeatures = [\"std\", \"nested-values\", \"dynamic-keys\"]\n[profile.bench]\nopt-level = 3\nlto = true\ndebug = false\ndebug-assertions = false\n\n[profile.release]\nopt-level = 3\nlto = true\ndebug = false\ndebug-assertions = false\n\n[[example]]\nname = \"singlethread\"\nrequired-features = [\"nothreads\"]\n[dependencies.erased-serde]\nversion = \"0.3\"\noptional = true\n\n[features]\ndefault = [\"std\"]\ndynamic-keys = []\nmax_level_debug = []\nmax_level_error = []\nmax_level_info = []\nmax_level_off = []\nmax_level_trace = []\nmax_level_warn = []\nnested-values = [\"erased-serde\"]\nnothreads = []\nrelease_max_level_debug = []\nrelease_max_level_error = []\nrelease_max_level_info = []\nrelease_max_level_off = []\nrelease_max_level_trace = []\nrelease_max_level_warn = []\nstd = []\n",
+                "content_hash": null,
+                "content_normalized": null,
+                "matcher": {
+                  "name": "cargo",
+                  "confidence": 90
+                },
+                "matched_license": "NOASSERTION"
+              }
+            ]
+          }
+        }
+      },
+      "attachments": [
+        {
+          "path": "LICENSE-MIT",
+          "token": "6485b8ed310d3f0340bf1ad1f47645069ce4069dcc6bb46c7d5c6faf41de1fdb"
+        },
+        {
+          "path": "LICENSE-APACHE",
+          "token": "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2"
+        },
+        {
+          "path": "LICENSE-MPL2",
+          "token": "fab3dd6bdab226f1c08630b1dd917e11fcb4ec5e1e020e2c16f83a0a13863e85"
+        },
+        {
+          "path": "Cargo.toml",
+          "token": "4142407a78484ee95f3e5ec73a20b0ac344c73cc914178ded8c5f25fc18e1cff"
+        }
+      ]
+    }
+  },
+  "scancode": {
+    "3.2.2": {
+      "_metadata": {
+        "type": "scancode",
+        "url": "cd:/crate/cratesio/-/slog/2.7.0",
+        "fetchedAt": "2021-03-02T17:40:17.950Z",
+        "links": {
+          "self": {
+            "href": "urn:crate:cratesio:-:slog:revision:2.7.0:tool:scancode:3.2.2",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:crate:cratesio:-:slog:revision:2.7.0:tool:scancode",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "3.2.2",
+        "toolVersion": "3.0.2",
+        "contentType": "application/json",
+        "releaseDate": "2020-11-30T06:26:09.367402+00:00",
+        "processedAt": "2021-03-02T17:40:45.300Z"
+      },
+      "content": {
+        "headers": [
+          {
+            "tool_name": "scancode-toolkit",
+            "tool_version": "3.0.2",
+            "options": {
+              "input": "/tmp/cd-Ce0Y2r/crate/slog-2.7.0",
+              "--classify": true,
+              "--copyright": true,
+              "--email": true,
+              "--generated": true,
+              "--info": true,
+              "--is-license-text": true,
+              "--json-pp": "/tmp/cd-PfWC7i",
+              "--license": true,
+              "--license-clarity-score": true,
+              "--license-diag": true,
+              "--license-text": true,
+              "--package": true,
+              "--processes": "2",
+              "--strip-root": true,
+              "--summary": true,
+              "--summary-key-files": true,
+              "--timeout": "1000.0",
+              "--url": true
+            },
+            "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+            "start_timestamp": "2021-03-02T174020.503592",
+            "end_timestamp": "2021-03-02T174044.279541",
+            "message": null,
+            "errors": [],
+            "extra_data": {
+              "files_count": 30
+            }
+          }
+        ],
+        "summary": {
+          "license_expressions": [
+            {
+              "value": null,
+              "count": 25
+            },
+            {
+              "value": "apache-2.0",
+              "count": 3
+            },
+            {
+              "value": "mpl-2.0",
+              "count": 3
+            },
+            {
+              "value": "mit",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 29
+            },
+            {
+              "value": "Copyright (c) The Rust Project",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 29
+            },
+            {
+              "value": "The Rust Project",
+              "count": 1
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 28
+            },
+            {
+              "value": "Dawid Ciezarkiewicz <dpc@dpc.pw>",
+              "count": 2
+            }
+          ],
+          "programming_language": [
+            {
+              "value": null,
+              "count": 16
+            },
+            {
+              "value": "Rust",
+              "count": 11
+            },
+            {
+              "value": "Objective-C",
+              "count": 2
+            },
+            {
+              "value": "ActionScript 3",
+              "count": 1
+            }
+          ],
+          "packages": []
+        },
+        "license_clarity_score": {
+          "score": 45,
+          "has_declared_license_in_key_files": true,
+          "file_level_license_and_copyright_coverage": 0,
+          "has_consistent_key_and_file_level_licenses": false,
+          "is_using_only_spdx_licenses": true,
+          "has_full_text_for_all_licenses": false
+        },
+        "summary_of_key_files": {
+          "license_expressions": [
+            {
+              "value": null,
+              "count": 1
+            },
+            {
+              "value": "apache-2.0",
+              "count": 1
+            },
+            {
+              "value": "mit",
+              "count": 1
+            },
+            {
+              "value": "mpl-2.0",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 3
+            },
+            {
+              "value": "Copyright (c) The Rust Project",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 3
+            },
+            {
+              "value": "The Rust Project",
+              "count": 1
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 4
+            }
+          ],
+          "programming_language": [
+            {
+              "value": null,
+              "count": 3
+            },
+            {
+              "value": "Objective-C",
+              "count": 1
+            }
+          ]
+        },
+        "files": [
+          {
+            "path": ".cargo_vcs_info.json",
+            "type": "file",
+            "name": ".cargo_vcs_info.json",
+            "base_name": ".cargo_vcs_info",
+            "extension": ".json",
+            "size": 74,
+            "date": "2020-11-30",
+            "sha1": "1d54699ee615462d73286da816a74d3c6b50f726",
+            "md5": "879af87d22f042f5fbd2cf519d505d3f",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": ".editorconfig",
+            "type": "file",
+            "name": ".editorconfig",
+            "base_name": ".editorconfig",
+            "extension": "",
+            "size": 73,
+            "date": "2018-02-12",
+            "sha1": "5a6d6c61f983762dfbb771455ccc6721622257dd",
+            "md5": "0d0a6ddb3fa667a902e0baffa766c5d7",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": ".rustfmt.toml",
+            "type": "file",
+            "name": ".rustfmt.toml",
+            "base_name": ".rustfmt",
+            "extension": ".toml",
+            "size": 38,
+            "date": "2018-02-12",
+            "sha1": "57df9e89df2624f1a3055c39a207f5f8e9a98047",
+            "md5": "d090178e1f3e9b667d1569dcb4a4c2e5",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": ".travis.yml",
+            "type": "file",
+            "name": ".travis.yml",
+            "base_name": ".travis",
+            "extension": ".yml",
+            "size": 977,
+            "date": "2019-07-11",
+            "sha1": "6dc601c63e2a0c5b52375360cba28f7692f94d4f",
+            "md5": "213d654904687da99ce3eb4a4f301ed4",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "ActionScript 3",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://webhooks.gitter.im/e/87a331e1a21456b6e2ad",
+                "start_line": 29,
+                "end_line": 29
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": ".vimrc",
+            "type": "file",
+            "name": ".vimrc",
+            "base_name": ".vimrc",
+            "extension": "",
+            "size": 119,
+            "date": "2018-02-12",
+            "sha1": "f4461254d7aeea6b9d07b1a56879d0699d717c57",
+            "md5": "998330b64fa5e3c9e555e1c12cba2f03",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "benches.txt",
+            "type": "file",
+            "name": "benches.txt",
+            "base_name": "benches",
+            "extension": ".txt",
+            "size": 83,
+            "date": "2018-02-12",
+            "sha1": "b5bdeb49cbcb1cab141fbbaff2ba1a010630fb46",
+            "md5": "03ff0d2093832999ceef3764e851a178",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/slog-rs/misc/tree/master/benches",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "build.rs",
+            "type": "file",
+            "name": "build.rs",
+            "base_name": "build",
+            "extension": ".rs",
+            "size": 1120,
+            "date": "2019-07-11",
+            "sha1": "59e7efa4b2b8203c0bb6d36864aa47daebb5b469",
+            "md5": "c1174dab16027506ff4033da059240cd",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/rust/pull/42913",
+                "start_line": 40,
+                "end_line": 40
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.lock",
+            "type": "file",
+            "name": "Cargo.lock",
+            "base_name": "Cargo",
+            "extension": ".lock",
+            "size": 586,
+            "date": "2020-11-30",
+            "sha1": "cdab24c42fb9ea0aa24b9dfed40b3a9890589348",
+            "md5": "637d966066ca90f3986ee3ec4267e78c",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/rust-lang/crates.io-index",
+                "start_line": 6,
+                "end_line": 6
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml",
+            "type": "file",
+            "name": "Cargo.toml",
+            "base_name": "Cargo",
+            "extension": ".toml",
+            "size": 1790,
+            "date": "2020-11-30",
+            "sha1": "9e6c5391ba1eacb63bb3ce3e8e66ca94179e73a3",
+            "md5": "cb478f5f7637644d408d65562c298b97",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mpl-2.0",
+                "score": 50,
+                "name": "Mozilla Public License 2.0",
+                "short_name": "MPL 2.0",
+                "category": "Copyleft Limited",
+                "is_exception": false,
+                "owner": "Mozilla",
+                "homepage_url": "http://mpl.mozilla.org/2012/01/03/announcing-mpl-2-0/",
+                "text_url": "http://www.mozilla.com/MPL/2.0/",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mpl-2.0",
+                "spdx_license_key": "MPL-2.0",
+                "spdx_url": "https://spdx.org/licenses/MPL-2.0",
+                "start_line": 25,
+                "end_line": 25,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_mpl-2.0_for_mpl-2.0.RULE",
+                  "license_expression": "mpl-2.0",
+                  "licenses": [
+                    "mpl-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "MPL-2.0"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 25,
+                "end_line": 25,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0\""
+              }
+            ],
+            "license_expressions": [
+              "mpl-2.0",
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "Dawid Ciezarkiewicz <dpc@dpc.pw>",
+                "start_line": 16,
+                "end_line": 18
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "dpc@dpc.pw",
+                "start_line": 16,
+                "end_line": 16
+              }
+            ],
+            "urls": [
+              {
+                "url": "https://github.com/slog-rs/slog",
+                "start_line": 20,
+                "end_line": 20
+              },
+              {
+                "url": "https://docs.rs/slog",
+                "start_line": 21,
+                "end_line": 21
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Cargo.toml.orig",
+            "type": "file",
+            "name": "Cargo.toml.orig",
+            "base_name": "Cargo.toml",
+            "extension": ".orig",
+            "size": 1342,
+            "date": "2020-11-30",
+            "sha1": "466637a3f847f1b3ba2527592e4837956d7e0b06",
+            "md5": "d0456319ffa53dbfd42942e1197661ae",
+            "mime_type": "text/plain",
+            "file_type": "UTF-8 Unicode text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mpl-2.0",
+                "score": 50,
+                "name": "Mozilla Public License 2.0",
+                "short_name": "MPL 2.0",
+                "category": "Copyleft Limited",
+                "is_exception": false,
+                "owner": "Mozilla",
+                "homepage_url": "http://mpl.mozilla.org/2012/01/03/announcing-mpl-2-0/",
+                "text_url": "http://www.mozilla.com/MPL/2.0/",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mpl-2.0",
+                "spdx_license_key": "MPL-2.0",
+                "spdx_url": "https://spdx.org/licenses/MPL-2.0",
+                "start_line": 8,
+                "end_line": 8,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_mpl-2.0_for_mpl-2.0.RULE",
+                  "license_expression": "mpl-2.0",
+                  "licenses": [
+                    "mpl-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "MPL-2.0"
+              },
+              {
+                "key": "apache-2.0",
+                "score": 50,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 8,
+                "end_line": 8,
+                "matched_rule": {
+                  "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 3,
+                  "matched_length": 3,
+                  "match_coverage": 100,
+                  "rule_relevance": 50
+                },
+                "matched_text": "Apache-2.0\""
+              }
+            ],
+            "license_expressions": [
+              "mpl-2.0",
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [
+              {
+                "value": "Dawid Ciezarkiewicz <dpc@dpc.pw>",
+                "start_line": 4,
+                "end_line": 9
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "dpc@dpc.pw",
+                "start_line": 4,
+                "end_line": 4
+              }
+            ],
+            "urls": [
+              {
+                "url": "https://docs.rs/slog",
+                "start_line": 9,
+                "end_line": 9
+              },
+              {
+                "url": "https://github.com/slog-rs/slog",
+                "start_line": 10,
+                "end_line": 10
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "CHANGELOG.md",
+            "type": "file",
+            "name": "CHANGELOG.md",
+            "base_name": "CHANGELOG",
+            "extension": ".md",
+            "size": 6910,
+            "date": "2020-11-30",
+            "sha1": "ce1454b82510c1c95f98a0f4473b65dd1c0a572a",
+            "md5": "47bbaef9280699c8fb5a16ddbb10d272",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Objective-C",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://keepachangelog.com/",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "http://semver.org/",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "https://github.com/rust-lang/rust/pull/42125",
+                "start_line": 115,
+                "end_line": 115
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-APACHE",
+            "type": "file",
+            "name": "LICENSE-APACHE",
+            "base_name": "LICENSE-APACHE",
+            "extension": "",
+            "size": 10847,
+            "date": "2018-06-21",
+            "sha1": "5798832c31663cedc1618d18544d445da0295229",
+            "md5": "1836efb2eb779966696f473ee8540542",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "apache-2.0",
+                "score": 100,
+                "name": "Apache License 2.0",
+                "short_name": "Apache 2.0",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "Apache Software Foundation",
+                "homepage_url": "http://www.apache.org/licenses/",
+                "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+                "spdx_license_key": "Apache-2.0",
+                "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                "start_line": 1,
+                "end_line": 201,
+                "matched_rule": {
+                  "identifier": "apache-2.0.LICENSE",
+                  "license_expression": "apache-2.0",
+                  "licenses": [
+                    "apache-2.0"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "1-hash",
+                  "rule_length": 1608,
+                  "matched_length": 1608,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License."
+              }
+            ],
+            "license_expressions": [
+              "apache-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://www.apache.org/licenses/",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                "start_line": 195,
+                "end_line": 195
+              }
+            ],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": true,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-MIT",
+            "type": "file",
+            "name": "LICENSE-MIT",
+            "base_name": "LICENSE-MIT",
+            "extension": "",
+            "size": 1071,
+            "date": "2018-06-21",
+            "sha1": "9f3c36d2b7d381d9cf382a00166f3fbd06783636",
+            "md5": "362255802eb5aa87810d12ddf3cfedb4",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mit",
+                "score": 100,
+                "name": "MIT License",
+                "short_name": "MIT License",
+                "category": "Permissive",
+                "is_exception": false,
+                "owner": "MIT",
+                "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                "text_url": "http://opensource.org/licenses/mit-license.php",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+                "spdx_license_key": "MIT",
+                "spdx_url": "https://spdx.org/licenses/MIT",
+                "start_line": 3,
+                "end_line": 25,
+                "matched_rule": {
+                  "identifier": "mit.LICENSE",
+                  "license_expression": "mit",
+                  "licenses": [
+                    "mit"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "2-aho",
+                  "rule_length": 163,
+                  "matched_length": 163,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Permission is hereby granted, free of charge, to any\nperson obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the\nSoftware without restriction, including without\nlimitation the rights to use, copy, modify, merge,\npublish, distribute, sublicense, and/or sell copies of\nthe Software, and to permit persons to whom the Software\nis furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice\nshall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF\nANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED\nTO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A\nPARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT\nSHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\nOF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR\nIN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE."
+              }
+            ],
+            "license_expressions": [
+              "mit"
+            ],
+            "holders": [
+              {
+                "value": "The Rust Project",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "copyrights": [
+              {
+                "value": "Copyright (c) 2014 The Rust Project",
+                "start_line": 1,
+                "end_line": 1
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "LICENSE-MPL2",
+            "type": "file",
+            "name": "LICENSE-MPL2",
+            "base_name": "LICENSE-MPL2",
+            "extension": "",
+            "size": 16726,
+            "date": "2018-02-12",
+            "sha1": "9744cedce099f727b327cd9913a1fdc58a7f5599",
+            "md5": "815ca599c9df247a0c7f619bab123dad",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "mpl-2.0",
+                "score": 100,
+                "name": "Mozilla Public License 2.0",
+                "short_name": "MPL 2.0",
+                "category": "Copyleft Limited",
+                "is_exception": false,
+                "owner": "Mozilla",
+                "homepage_url": "http://mpl.mozilla.org/2012/01/03/announcing-mpl-2-0/",
+                "text_url": "http://www.mozilla.com/MPL/2.0/",
+                "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mpl-2.0",
+                "spdx_license_key": "MPL-2.0",
+                "spdx_url": "https://spdx.org/licenses/MPL-2.0",
+                "start_line": 1,
+                "end_line": 373,
+                "matched_rule": {
+                  "identifier": "mpl-2.0.LICENSE",
+                  "license_expression": "mpl-2.0",
+                  "licenses": [
+                    "mpl-2.0"
+                  ],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "matcher": "1-hash",
+                  "rule_length": 2426,
+                  "matched_length": 2426,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "Mozilla Public License Version 2.0\n==================================\n\n1. Definitions\n--------------\n\n1.1. \"Contributor\"\n    means each individual or legal entity that creates, contributes to\n    the creation of, or owns Covered Software.\n\n1.2. \"Contributor Version\"\n    means the combination of the Contributions of others (if any) used\n    by a Contributor and that particular Contributor's Contribution.\n\n1.3. \"Contribution\"\n    means Covered Software of a particular Contributor.\n\n1.4. \"Covered Software\"\n    means Source Code Form to which the initial Contributor has attached\n    the notice in Exhibit A, the Executable Form of such Source Code\n    Form, and Modifications of such Source Code Form, in each case\n    including portions thereof.\n\n1.5. \"Incompatible With Secondary Licenses\"\n    means\n\n    (a) that the initial Contributor has attached the notice described\n        in Exhibit B to the Covered Software; or\n\n    (b) that the Covered Software was made available under the terms of\n        version 1.1 or earlier of the License, but not also under the\n        terms of a Secondary License.\n\n1.6. \"Executable Form\"\n    means any form of the work other than Source Code Form.\n\n1.7. \"Larger Work\"\n    means a work that combines Covered Software with other material, in \n    a separate file or files, that is not Covered Software.\n\n1.8. \"License\"\n    means this document.\n\n1.9. \"Licensable\"\n    means having the right to grant, to the maximum extent possible,\n    whether at the time of the initial grant or subsequently, any and\n    all of the rights conveyed by this License.\n\n1.10. \"Modifications\"\n    means any of the following:\n\n    (a) any file in Source Code Form that results from an addition to,\n        deletion from, or modification of the contents of Covered\n        Software; or\n\n    (b) any new file in Source Code Form that contains any Covered\n        Software.\n\n1.11. \"Patent Claims\" of a Contributor\n    means any patent claim(s), including without limitation, method,\n    process, and apparatus claims, in any patent Licensable by such\n    Contributor that would be infringed, but for the grant of the\n    License, by the making, using, selling, offering for sale, having\n    made, import, or transfer of either its Contributions or its\n    Contributor Version.\n\n1.12. \"Secondary License\"\n    means either the GNU General Public License, Version 2.0, the GNU\n    Lesser General Public License, Version 2.1, the GNU Affero General\n    Public License, Version 3.0, or any later versions of those\n    licenses.\n\n1.13. \"Source Code Form\"\n    means the form of the work preferred for making modifications.\n\n1.14. \"You\" (or \"Your\")\n    means an individual or a legal entity exercising rights under this\n    License. For legal entities, \"You\" includes any entity that\n    controls, is controlled by, or is under common control with You. For\n    purposes of this definition, \"control\" means (a) the power, direct\n    or indirect, to cause the direction or management of such entity,\n    whether by contract or otherwise, or (b) ownership of more than\n    fifty percent (50%) of the outstanding shares or beneficial\n    ownership of such entity.\n\n2. License Grants and Conditions\n--------------------------------\n\n2.1. Grants\n\nEach Contributor hereby grants You a world-wide, royalty-free,\nnon-exclusive license:\n\n(a) under intellectual property rights (other than patent or trademark)\n    Licensable by such Contributor to use, reproduce, make available,\n    modify, display, perform, distribute, and otherwise exploit its\n    Contributions, either on an unmodified basis, with Modifications, or\n    as part of a Larger Work; and\n\n(b) under Patent Claims of such Contributor to make, use, sell, offer\n    for sale, have made, import, and otherwise transfer either its\n    Contributions or its Contributor Version.\n\n2.2. Effective Date\n\nThe licenses granted in Section 2.1 with respect to any Contribution\nbecome effective for each Contribution on the date the Contributor first\ndistributes such Contribution.\n\n2.3. Limitations on Grant Scope\n\nThe licenses granted in this Section 2 are the only rights granted under\nthis License. No additional rights or licenses will be implied from the\ndistribution or licensing of Covered Software under this License.\nNotwithstanding Section 2.1(b) above, no patent license is granted by a\nContributor:\n\n(a) for any code that a Contributor has removed from Covered Software;\n    or\n\n(b) for infringements caused by: (i) Your and any other third party's\n    modifications of Covered Software, or (ii) the combination of its\n    Contributions with other software (except as part of its Contributor\n    Version); or\n\n(c) under Patent Claims infringed by Covered Software in the absence of\n    its Contributions.\n\nThis License does not grant any rights in the trademarks, service marks,\nor logos of any Contributor (except as may be necessary to comply with\nthe notice requirements in Section 3.4).\n\n2.4. Subsequent Licenses\n\nNo Contributor makes additional grants as a result of Your choice to\ndistribute the Covered Software under a subsequent version of this\nLicense (see Section 10.2) or under the terms of a Secondary License (if\npermitted under the terms of Section 3.3).\n\n2.5. Representation\n\nEach Contributor represents that the Contributor believes its\nContributions are its original creation(s) or it has sufficient rights\nto grant the rights to its Contributions conveyed by this License.\n\n2.6. Fair Use\n\nThis License is not intended to limit any rights You have under\napplicable copyright doctrines of fair use, fair dealing, or other\nequivalents.\n\n2.7. Conditions\n\nSections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted\nin Section 2.1.\n\n3. Responsibilities\n-------------------\n\n3.1. Distribution of Source Form\n\nAll distribution of Covered Software in Source Code Form, including any\nModifications that You create or to which You contribute, must be under\nthe terms of this License. You must inform recipients that the Source\nCode Form of the Covered Software is governed by the terms of this\nLicense, and how they can obtain a copy of this License. You may not\nattempt to alter or restrict the recipients' rights in the Source Code\nForm.\n\n3.2. Distribution of Executable Form\n\nIf You distribute Covered Software in Executable Form then:\n\n(a) such Covered Software must also be made available in Source Code\n    Form, as described in Section 3.1, and You must inform recipients of\n    the Executable Form how they can obtain a copy of such Source Code\n    Form by reasonable means in a timely manner, at a charge no more\n    than the cost of distribution to the recipient; and\n\n(b) You may distribute such Executable Form under the terms of this\n    License, or sublicense it under different terms, provided that the\n    license for the Executable Form does not attempt to limit or alter\n    the recipients' rights in the Source Code Form under this License.\n\n3.3. Distribution of a Larger Work\n\nYou may create and distribute a Larger Work under terms of Your choice,\nprovided that You also comply with the requirements of this License for\nthe Covered Software. If the Larger Work is a combination of Covered\nSoftware with a work governed by one or more Secondary Licenses, and the\nCovered Software is not Incompatible With Secondary Licenses, this\nLicense permits You to additionally distribute such Covered Software\nunder the terms of such Secondary License(s), so that the recipient of\nthe Larger Work may, at their option, further distribute the Covered\nSoftware under the terms of either this License or such Secondary\nLicense(s).\n\n3.4. Notices\n\nYou may not remove or alter the substance of any license notices\n(including copyright notices, patent notices, disclaimers of warranty,\nor limitations of liability) contained within the Source Code Form of\nthe Covered Software, except that You may alter any license notices to\nthe extent required to remedy known factual inaccuracies.\n\n3.5. Application of Additional Terms\n\nYou may choose to offer, and to charge a fee for, warranty, support,\nindemnity or liability obligations to one or more recipients of Covered\nSoftware. However, You may do so only on Your own behalf, and not on\nbehalf of any Contributor. You must make it absolutely clear that any\nsuch warranty, support, indemnity, or liability obligation is offered by\nYou alone, and You hereby agree to indemnify every Contributor for any\nliability incurred by such Contributor as a result of warranty, support,\nindemnity or liability terms You offer. You may include additional\ndisclaimers of warranty and limitations of liability specific to any\njurisdiction.\n\n4. Inability to Comply Due to Statute or Regulation\n---------------------------------------------------\n\nIf it is impossible for You to comply with any of the terms of this\nLicense with respect to some or all of the Covered Software due to\nstatute, judicial order, or regulation then You must: (a) comply with\nthe terms of this License to the maximum extent possible; and (b)\ndescribe the limitations and the code they affect. Such description must\nbe placed in a text file included with all distributions of the Covered\nSoftware under this License. Except to the extent prohibited by statute\nor regulation, such description must be sufficiently detailed for a\nrecipient of ordinary skill to be able to understand it.\n\n5. Termination\n--------------\n\n5.1. The rights granted under this License will terminate automatically\nif You fail to comply with any of its terms. However, if You become\ncompliant, then the rights granted under this License from a particular\nContributor are reinstated (a) provisionally, unless and until such\nContributor explicitly and finally terminates Your grants, and (b) on an\nongoing basis, if such Contributor fails to notify You of the\nnon-compliance by some reasonable means prior to 60 days after You have\ncome back into compliance. Moreover, Your grants from a particular\nContributor are reinstated on an ongoing basis if such Contributor\nnotifies You of the non-compliance by some reasonable means, this is the\nfirst time You have received notice of non-compliance with this License\nfrom such Contributor, and You become compliant prior to 30 days after\nYour receipt of the notice.\n\n5.2. If You initiate litigation against any entity by asserting a patent\ninfringement claim (excluding declaratory judgment actions,\ncounter-claims, and cross-claims) alleging that a Contributor Version\ndirectly or indirectly infringes any patent, then the rights granted to\nYou by any and all Contributors for the Covered Software under Section\n2.1 of this License shall terminate.\n\n5.3. In the event of termination under Sections 5.1 or 5.2 above, all\nend user license agreements (excluding distributors and resellers) which\nhave been validly granted by You or Your distributors under this License\nprior to termination shall survive termination.\n\n************************************************************************\n*                                                                      *\n*  6. Disclaimer of Warranty                                           *\n*  -------------------------                                           *\n*                                                                      *\n*  Covered Software is provided under this License on an \"as is\"       *\n*  basis, without warranty of any kind, either expressed, implied, or  *\n*  statutory, including, without limitation, warranties that the       *\n*  Covered Software is free of defects, merchantable, fit for a        *\n*  particular purpose or non-infringing. The entire risk as to the     *\n*  quality and performance of the Covered Software is with You.        *\n*  Should any Covered Software prove defective in any respect, You     *\n*  (not any Contributor) assume the cost of any necessary servicing,   *\n*  repair, or correction. This disclaimer of warranty constitutes an   *\n*  essential part of this License. No use of any Covered Software is   *\n*  authorized under this License except under this disclaimer.         *\n*                                                                      *\n************************************************************************\n\n************************************************************************\n*                                                                      *\n*  7. Limitation of Liability                                          *\n*  --------------------------                                          *\n*                                                                      *\n*  Under no circumstances and under no legal theory, whether tort      *\n*  (including negligence), contract, or otherwise, shall any           *\n*  Contributor, or anyone who distributes Covered Software as          *\n*  permitted above, be liable to You for any direct, indirect,         *\n*  special, incidental, or consequential damages of any character      *\n*  including, without limitation, damages for lost profits, loss of    *\n*  goodwill, work stoppage, computer failure or malfunction, or any    *\n*  and all other commercial damages or losses, even if such party      *\n*  shall have been informed of the possibility of such damages. This   *\n*  limitation of liability shall not apply to liability for death or   *\n*  personal injury resulting from such party's negligence to the       *\n*  extent applicable law prohibits such limitation. Some               *\n*  jurisdictions do not allow the exclusion or limitation of           *\n*  incidental or consequential damages, so this exclusion and          *\n*  limitation may not apply to You.                                    *\n*                                                                      *\n************************************************************************\n\n8. Litigation\n-------------\n\nAny litigation relating to this License may be brought only in the\ncourts of a jurisdiction where the defendant maintains its principal\nplace of business and such litigation shall be governed by laws of that\njurisdiction, without reference to its conflict-of-law provisions.\nNothing in this Section shall prevent a party's ability to bring\ncross-claims or counter-claims.\n\n9. Miscellaneous\n----------------\n\nThis License represents the complete agreement concerning the subject\nmatter hereof. If any provision of this License is held to be\nunenforceable, such provision shall be reformed only to the extent\nnecessary to make it enforceable. Any law or regulation which provides\nthat the language of a contract shall be construed against the drafter\nshall not be used to construe this License against a Contributor.\n\n10. Versions of the License\n---------------------------\n\n10.1. New Versions\n\nMozilla Foundation is the license steward. Except as provided in Section\n10.3, no one other than the license steward has the right to modify or\npublish new versions of this License. Each version will be given a\ndistinguishing version number.\n\n10.2. Effect of New Versions\n\nYou may distribute the Covered Software under the terms of the version\nof the License under which You originally received the Covered Software,\nor under the terms of any subsequent version published by the license\nsteward.\n\n10.3. Modified Versions\n\nIf you create software not governed by this License, and you want to\ncreate a new license for such software, you may create and use a\nmodified version of this License if you rename the license and remove\nany references to the name of the license steward (except to note that\nsuch modified license differs from this License).\n\n10.4. Distributing Source Code Form that is Incompatible With Secondary\nLicenses\n\nIf You choose to distribute Source Code Form that is Incompatible With\nSecondary Licenses under the terms of this version of the License, the\nnotice described in Exhibit B of this License must be attached.\n\nExhibit A - Source Code Form License Notice\n-------------------------------------------\n\n  This Source Code Form is subject to the terms of the Mozilla Public\n  License, v. 2.0. If a copy of the MPL was not distributed with this\n  file, You can obtain one at http://mozilla.org/MPL/2.0/.\n\nIf it is not possible or desirable to put the notice in a particular\nfile, then You may include the notice in a location (such as a LICENSE\nfile in a relevant directory) where a recipient would be likely to look\nfor such a notice.\n\nYou may add additional accurate notices of copyright ownership.\n\nExhibit B - \"Incompatible With Secondary Licenses\" Notice\n---------------------------------------------------------\n\n  This Source Code Form is \"Incompatible With Secondary Licenses\", as\n  defined by the Mozilla Public License, v. 2.0."
+              }
+            ],
+            "license_expressions": [
+              "mpl-2.0"
+            ],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://mozilla.org/MPL/2.0",
+                "start_line": 360,
+                "end_line": 360
+              }
+            ],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "Makefile",
+            "type": "file",
+            "name": "Makefile",
+            "base_name": "Makefile",
+            "extension": "",
+            "size": 1624,
+            "date": "2019-07-11",
+            "sha1": "291da9e1767a3a679aa1fb9124f9f418ea875719",
+            "md5": "200d9e4921707c7cf349db272bb1e8b0",
+            "mime_type": "text/x-makefile",
+            "file_type": "makefile script, ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "README.md",
+            "type": "file",
+            "name": "README.md",
+            "base_name": "README",
+            "extension": ".md",
+            "size": 4783,
+            "date": "2020-11-30",
+            "sha1": "ff6225f438038d0b9bc62b8b2460eb35122e8766",
+            "md5": "c0c0df087969dbd5a14232176329779e",
+            "mime_type": "text/html",
+            "file_type": "HTML document, UTF-8 Unicode text",
+            "programming_language": "Objective-C",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/slog-rs/slog",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "https://cdn.rawgit.com/slog-rs/misc/master/media/slog.svg",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "url": "https://travis-ci.org/slog-rs/slog",
+                "start_line": 8,
+                "end_line": 8
+              },
+              {
+                "url": "https://img.shields.io/travis/slog-rs/slog/master.svg",
+                "start_line": 9,
+                "end_line": 9
+              },
+              {
+                "url": "https://crates.io/crates/slog",
+                "start_line": 12,
+                "end_line": 12
+              },
+              {
+                "url": "https://img.shields.io/crates/d/slog.svg",
+                "start_line": 13,
+                "end_line": 13
+              },
+              {
+                "url": "https://gitter.im/slog-rs/slog",
+                "start_line": 16,
+                "end_line": 16
+              },
+              {
+                "url": "https://img.shields.io/gitter/room/slog-rs/slog.svg",
+                "start_line": 17,
+                "end_line": 17
+              },
+              {
+                "url": "https://docs.rs/releases/search?query=slog",
+                "start_line": 20,
+                "end_line": 20
+              },
+              {
+                "url": "https://docs.rs/slog/badge.svg",
+                "start_line": 21,
+                "end_line": 21
+              },
+              {
+                "url": "https://github.com/slog-rs/slog/wiki/Getting-started",
+                "start_line": 24,
+                "end_line": 24
+              },
+              {
+                "url": "https://crates.io/search?q=slog",
+                "start_line": 28,
+                "end_line": 28
+              },
+              {
+                "url": "https://docs.rs/sloggers",
+                "start_line": 45,
+                "end_line": 45
+              },
+              {
+                "url": "https://docs.rs/",
+                "start_line": 52,
+                "end_line": 52
+              },
+              {
+                "url": "https://docs.rs/slog",
+                "start_line": 52,
+                "end_line": 52
+              },
+              {
+                "url": "https://docs.rs/slog-term",
+                "start_line": 60,
+                "end_line": 60
+              },
+              {
+                "url": "https://docs.rs/slog-async",
+                "start_line": 61,
+                "end_line": 61
+              },
+              {
+                "url": "https://docs.rs/slog-json",
+                "start_line": 62,
+                "end_line": 62
+              },
+              {
+                "url": "https://docs.rs/slog-syslog",
+                "start_line": 63,
+                "end_line": 63
+              },
+              {
+                "url": "https://github.com/sile/sloggers",
+                "start_line": 64,
+                "end_line": 64
+              },
+              {
+                "url": "https://crates.io/crates/slog/reverse_dependencies",
+                "start_line": 69,
+                "end_line": 69
+              },
+              {
+                "url": "https://github.com/slog-rs/misc/blob/master/examples/features.rs",
+                "start_line": 86,
+                "end_line": 86
+              },
+              {
+                "url": "https://github.com/slog-rs/slog/wiki/FAQ",
+                "start_line": 93,
+                "end_line": 93
+              },
+              {
+                "url": "https://github.com/slog-rs/slog/wiki/",
+                "start_line": 94,
+                "end_line": 94
+              },
+              {
+                "url": "http://rust-lang.org/",
+                "start_line": 95,
+                "end_line": 95
+              },
+              {
+                "url": "https://github.com/slog-rs",
+                "start_line": 102,
+                "end_line": 102
+              },
+              {
+                "url": "https://github.com/dpc/public/blob/master/COC.md",
+                "start_line": 107,
+                "end_line": 107
+              },
+              {
+                "url": "https://github.com/crev-dev/cargo-crev",
+                "start_line": 116,
+                "end_line": 116
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": true,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": ".cargo",
+            "type": "directory",
+            "name": ".cargo",
+            "base_name": ".cargo",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 1,
+            "dirs_count": 0,
+            "size_count": 16,
+            "scan_errors": []
+          },
+          {
+            "path": ".cargo/config",
+            "type": "file",
+            "name": "config",
+            "base_name": "config",
+            "extension": "",
+            "size": 16,
+            "date": "2018-07-21",
+            "sha1": "5d39cb708d5a0427fb26d94a30a5b07156330861",
+            "md5": "22646562eba8b37fcbb37f5e1181c946",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": ".github",
+            "type": "directory",
+            "name": ".github",
+            "base_name": ".github",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 2,
+            "dirs_count": 0,
+            "size_count": 318,
+            "scan_errors": []
+          },
+          {
+            "path": ".github/ISSUE_TEMPLATE.md",
+            "type": "file",
+            "name": "ISSUE_TEMPLATE.md",
+            "base_name": "ISSUE_TEMPLATE",
+            "extension": ".md",
+            "size": 252,
+            "date": "2018-06-21",
+            "sha1": "b865c4d12c6d833b8213a57acd40b4c26642b108",
+            "md5": "0f428be0e927c636416d9bbea53f72a4",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://gitter.im/slog-rs/slog",
+                "start_line": 6,
+                "end_line": 6
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": ".github/pull_request_template.md",
+            "type": "file",
+            "name": "pull_request_template.md",
+            "base_name": "pull_request_template",
+            "extension": ".md",
+            "size": 66,
+            "date": "2019-07-11",
+            "sha1": "28f7b270c8906808a3495a883bc00eb17ee50145",
+            "md5": "df01797452284fa8595f38616a5b1536",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples",
+            "type": "directory",
+            "name": "examples",
+            "base_name": "examples",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 5,
+            "dirs_count": 1,
+            "size_count": 4850,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/named.rs",
+            "type": "file",
+            "name": "named.rs",
+            "base_name": "named",
+            "extension": ".rs",
+            "size": 857,
+            "date": "2018-11-28",
+            "sha1": "8232f5de9b54aae23aba733d4c3798789b5a2a3e",
+            "md5": "93a08834f4b6fbbadfb2ccba7e2b52e4",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/README.md",
+            "type": "file",
+            "name": "README.md",
+            "base_name": "README",
+            "extension": ".md",
+            "size": 249,
+            "date": "2018-02-12",
+            "sha1": "19011e76c7b85ec1bade882e2f104e3d99d6de3d",
+            "md5": "2bd3a8c19dc1be9af26a1481e47e8f96",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/slog-rs/misc/tree/master/examples",
+                "start_line": 3,
+                "end_line": 3
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": true,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/singlethread.rs",
+            "type": "file",
+            "name": "singlethread.rs",
+            "base_name": "singlethread",
+            "extension": ".rs",
+            "size": 660,
+            "date": "2019-07-11",
+            "sha1": "84dc12c5df67953b413f5c906cfaf8224de92183",
+            "md5": "9abe21aea39225aa4bf2d1e4b0c29cf8",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/struct-log-self.rs",
+            "type": "file",
+            "name": "struct-log-self.rs",
+            "base_name": "struct-log-self",
+            "extension": ".rs",
+            "size": 2352,
+            "date": "2019-07-11",
+            "sha1": "5e3a825bf62d00e54143100077adcd167e654295",
+            "md5": "2d08770709829eee7d65d1d5831733be",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/common",
+            "type": "directory",
+            "name": "common",
+            "base_name": "common",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 1,
+            "dirs_count": 0,
+            "size_count": 732,
+            "scan_errors": []
+          },
+          {
+            "path": "examples/common/mod.rs",
+            "type": "file",
+            "name": "mod.rs",
+            "base_name": "mod",
+            "extension": ".rs",
+            "size": 732,
+            "date": "2018-06-21",
+            "sha1": "d2eda06edbabd3a9c56e775ef1757f635119b910",
+            "md5": "d1ce96811954eefc115f2df66f06a146",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src",
+            "type": "directory",
+            "name": "src",
+            "base_name": "src",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 6,
+            "dirs_count": 1,
+            "size_count": 131010,
+            "scan_errors": []
+          },
+          {
+            "path": "src/lib.rs",
+            "type": "file",
+            "name": "lib.rs",
+            "base_name": "lib",
+            "extension": ".rs",
+            "size": 110976,
+            "date": "2020-11-30",
+            "sha1": "2f7bb444d81d767e1f003eb9c3a0e75f49aca66e",
+            "md5": "1e81262b19acc4da53d2d0f6f0af1681",
+            "mime_type": "text/x-c",
+            "file_type": "C source, ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://github.com/slog-rs/slog",
+                "start_line": 11,
+                "end_line": 11
+              },
+              {
+                "url": "https://github.com/slog-rs/slog/wiki/What-makes-slog-fast",
+                "start_line": 39,
+                "end_line": 39
+              },
+              {
+                "url": "https://github.com/dpc/slog-rs/wiki/Bench-log",
+                "start_line": 40,
+                "end_line": 40
+              },
+              {
+                "url": "https://docs.rs/slog-async",
+                "start_line": 43,
+                "end_line": 43
+              },
+              {
+                "url": "https://github.com/slog-rs/example-lib",
+                "start_line": 53,
+                "end_line": 53
+              },
+              {
+                "url": "https://docs.rs/slog-stdlog",
+                "start_line": 55,
+                "end_line": 55
+              },
+              {
+                "url": "https://docs.rs/slog-scope",
+                "start_line": 58,
+                "end_line": 58
+              },
+              {
+                "url": "https://github.com/slog-rs/envlogger",
+                "start_line": 65,
+                "end_line": 65
+              },
+              {
+                "url": "https://docs.rs/slog-term",
+                "start_line": 68,
+                "end_line": 68
+              },
+              {
+                "url": "https://docs.rs/slog-json",
+                "start_line": 69,
+                "end_line": 69
+              },
+              {
+                "url": "https://docs.rs/slog-bunyan",
+                "start_line": 70,
+                "end_line": 70
+              },
+              {
+                "url": "https://docs.rs/slog-syslog",
+                "start_line": 71,
+                "end_line": 71
+              },
+              {
+                "url": "https://docs.rs/slog-journald",
+                "start_line": 72,
+                "end_line": 72
+              },
+              {
+                "url": "https://docs.rs/slog-atomic",
+                "start_line": 75,
+                "end_line": 75
+              },
+              {
+                "url": "https://docs.rs/slog-config",
+                "start_line": 77,
+                "end_line": 77
+              },
+              {
+                "url": "https://crates.io/crates/env_logger",
+                "start_line": 80,
+                "end_line": 80
+              },
+              {
+                "url": "https://github.com/dpc/slog-rs/wiki/Functional-overview",
+                "start_line": 101,
+                "end_line": 101
+              },
+              {
+                "url": "https://docs.rs/slog-atomic/",
+                "start_line": 102,
+                "end_line": 102
+              },
+              {
+                "url": "https://github.com/slog-rs/term/tree/master/examples",
+                "start_line": 245,
+                "end_line": 245
+              },
+              {
+                "url": "https://github.com/slog-rs/slog/wiki",
+                "start_line": 247,
+                "end_line": 247
+              },
+              {
+                "url": "https://crates.io/crates/slog/reverse_dependencies",
+                "start_line": 251,
+                "end_line": 251
+              },
+              {
+                "url": "https://gitter.im/slog-rs/slog",
+                "start_line": 254,
+                "end_line": 254
+              },
+              {
+                "url": "https://github.com/rust-lang/rust/issues/29661",
+                "start_line": 1333,
+                "end_line": 1333
+              },
+              {
+                "url": "https://github.com/rust-lang/rust/issues/34511",
+                "start_line": 1800,
+                "end_line": 1800
+              },
+              {
+                "url": "https://docs.rs/slog-async/latest/slog_async/struct.Async.html",
+                "start_line": 2478,
+                "end_line": 2478
+              },
+              {
+                "url": "https://docs.rs/serde/1/serde/trait.Serialize.html",
+                "start_line": 2700,
+                "end_line": 2700
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": true,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/tests.rs",
+            "type": "file",
+            "name": "tests.rs",
+            "base_name": "tests",
+            "extension": ".rs",
+            "size": 11324,
+            "date": "2020-11-30",
+            "sha1": "58b1356e3f4383e97cb93747e8be0842ad0b7797",
+            "md5": "40ace5b685861981d972f95f4c64c71f",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/key",
+            "type": "directory",
+            "name": "key",
+            "base_name": "key",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 4,
+            "dirs_count": 0,
+            "size_count": 8710,
+            "scan_errors": []
+          },
+          {
+            "path": "src/key/dynamic.rs",
+            "type": "file",
+            "name": "dynamic.rs",
+            "base_name": "dynamic",
+            "extension": ".rs",
+            "size": 4657,
+            "date": "2020-11-30",
+            "sha1": "9bec0fef29f03a3ecfc68faad3436f546d428fb3",
+            "md5": "6937387df058755aaae2ac83d0d6f6cc",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/key/dynamic_nostd.rs",
+            "type": "file",
+            "name": "dynamic_nostd.rs",
+            "base_name": "dynamic_nostd",
+            "extension": ".rs",
+            "size": 3764,
+            "date": "2020-11-30",
+            "sha1": "8f0a97a9f643224be1d1ee67ea845ba84c66af6f",
+            "md5": "adf6e82e0950f7fa74e228bd75f4e4f6",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/key/mod.rs",
+            "type": "file",
+            "name": "mod.rs",
+            "base_name": "mod",
+            "extension": ".rs",
+            "size": 247,
+            "date": "2018-11-28",
+            "sha1": "d2e3c3267ffbfbe8e4ddfea5db8b00f58ac209d0",
+            "md5": "0de0fd0684cce9cc068f54a1c67476db",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "src/key/static.rs",
+            "type": "file",
+            "name": "static.rs",
+            "base_name": "static",
+            "extension": ".rs",
+            "size": 42,
+            "date": "2018-07-26",
+            "sha1": "73d116633ba81dbae661af896ae14c67862e69ad",
+            "md5": "e9d9c736485e8e017b47b725e1237753",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "Rust",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "holders": [],
+            "copyrights": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -95,9 +95,19 @@ describe('ClearlyDescribedSummarizer addCrateData', () => {
     assert.strictEqual(get(result, 'licensed.declared'), 'MIT')
   })
 
-  it('declares dual license from registryData', () => {
+  it('declares dual license from registryData with SPDX expression', () => {
     let result = {}
-    summarizer.addCrateData(result, { registryData: { license: 'MIT/Apache-2.0' } }, crateTestCoordinates)
+    let data = setup([{ path: 'LICENSE-MIT', license: 'MIT' }, { path: 'LICENSE-APACHE', license: 'Apache-2.0' }])
+    data.registryData = { license: 'MIT OR Apache-2.0' }
+    summarizer.addCrateData(result, data, crateTestCoordinates)
+    assert.strictEqual(get(result, 'licensed.declared'), 'MIT OR Apache-2.0')
+  })
+
+  it('declares dual license from registryData with slash-separated licenses', () => {
+    let result = {}
+    let data = setup([{ path: 'LICENSE-MIT', license: 'MIT' }, { path: 'LICENSE-APACHE', license: 'Apache-2.0' }])
+    data.registryData = { license: 'MIT/Apache-2.0' }
+    summarizer.addCrateData(result, data, crateTestCoordinates)
     assert.strictEqual(get(result, 'licensed.declared'), 'MIT OR Apache-2.0')
   })
 
@@ -710,3 +720,14 @@ describe('ClearlyDescribedSummarizer addGitData', () => {
     }
   })
 })
+
+function setup(files, attachments) {
+  const matched_files = files.map(file => {
+    return {
+      filename: file.path,
+      matcher: { name: file.matcher || 'exact', confidence: file.confidence || '100' },
+      matched_license: file.license
+    }
+  })
+  return { licensee: { version: '1.2.3', output: { content: { matched_files } } }, attachments }
+}


### PR DESCRIPTION
Added some Rust multi-licensing tests to help diagnose https://github.com/clearlydefined/service/issues/856
* A couple of tests of the `clearlydefined` scanner, which show that it is correctly declaring the Rust licenses
* Another test that runs some real raw data through the multiple scanners and aggregrator.  This demonstrates that Rust multi-licenses are declared incorrectly, and is useful to run under a debugger with breakpoints to view/understand the operation.

The latter test should possibly be moved into a separate "functional" test, as it is testing real data through multiple components.  I plan to clean it up to run through multiple example data files to confirm that they are all declared as expected.

I'm not sure whether the raw data files should be in an `evidence` directory, or a `fixtures` directory, or somewhere else - I used `evidence` as there was a similar example that used this structure.
