### PR TITLE
updates go architecture doc based on what was found in implementation

### DIFF
--- a/docs/architecture/go_components.md
+++ b/docs/architecture/go_components.md
@@ -6,7 +6,7 @@ This drafts an architecture document for adding support for Go components to Cle
 
 * Add a new "go" type to ClearlyDefined
 * Only support go modules as components (which were added in Go 1.11). [According to the Go documentation](https://blog.golang.org/using-go-modules), modules are a dependency management system that makes dependency version information explicit and easier to manage. There were other, more complicated ways of managing go dependencies prior to this, but we should only focus on modules in our first iteration. We can revisit other ways of managing go dependencies later if necessary.
-* Support "proxy.golang.org" as the first go component provider, add other providers later if needed.
+* Use the import path as the provider for the component. 
 
 ## Prior work
 
@@ -28,7 +28,7 @@ As of Go 1.13, the go command by default downloads and authenticates modules usi
 
 This allows users to download module source zips and is used by default in the Go CLI tooling.
 
-It would make sense for us to use proxy.golang.org as our (first) provider for harvesting go modules.
+It would make sense for us to use proxy.golang.org to download zips of go components (this would be done in the crawler).
 
 ### Go paths
 
@@ -48,7 +48,7 @@ And let's look at a few of the ways that this package's dependencies are defined
 	modernc.org/sqlite v1.10.8
 ```
 
-Notice the variety in paths? Google allows "vanity" package names (like `go.uber.org/multierr` - which are automatically redirected to the source by Google's proxy service.
+Notice the variety in paths? Google allows "vanity" package names (like `go.uber.org/multierr`). These point to html pages which point to the source repo for the module. It's important to understand that these paths must be valid urls. See [Vanity import paths in Go](https://sagikazarmark.hu/blog/vanity-import-paths-in-go/) for an overview of how they work.
 
 ## Constructing coordinates
 
@@ -92,27 +92,21 @@ A Go component's coordinates will also need to consist of a type, provider, name
 Go's support of vanity package names makes this a little different than other components. While there are a few different approaches we could take, we should map the coordinates to what go developers know the package as.
 
 * **type** should be go
-* **provider** should be "proxy.golang.org" (we may need to add other providers in the future)
-* **namespace** should be anything that appears before the package name
+* **provider** should be the import path (if any)
+* **namespace** should be anything that appears before the package name (it should be "-" if nothing appears before the package name)
 * **name** should be the name of the package
 * **revision** should be the component revision (note - go components seem to have multiple ways of specifying revisons - sometimes version numbers, sometimes commit hashes)
 
-Like with Maven components, we translate namespaces that have multiple slashes (like `golang.org/x`) into namepaces with periods (`golang.org.x`).
+Like with Maven components, we translate namespaces that have multiple slashes (like `Azure/azure-event-hubs-go`) to ones with periods (`Azure.azure-event-hubs-go`).
 
-For example: `go.uber.org/multierr v1.6.0` maps to `go/proxy.golang.org/go.uber.org/multierr/v1.6.0`
+### Examples 
 
-**Examples that seem to work well:**
-
-* `collectd.org v0.5.0` maps to `go/proxy.golang.org/-/collectd.org/v0.5.0`
-* `go.starlark.net v0.0.0-20210406145628-7a1108eaa012` maps to `go/proxy.golang.org/go.starlark.net/v0.0.0-20210406145628-7a1108eaa012`
-* `cloud.google.com/go v0.56.0` maps to `go/proxy.golang.org/cloud.google.com/go/v0.56.0`
-* `code.cloudfoundry.org/clock v1.0.0` maps to `go/proxy.golang.org/code.cloudfoundry.org/clock/v1.0.0`
-* `go.uber.org/multierr v1.6.0` maps to `go/proxy.golang.org/go.uber.org/multierr/v1.6.0`
-* `k8s.io/api v0.20.4` maps to `go/proxy.golang.org/k8s.io/api/v0.20.4`
-* `modernc.org/sqlite v1.10.8` maps to `go/proxy.golang.org/modernc.org/sqlite v1.10.8`
-* `github.com/project/package v1.2.3` maps to `go/proxy.golang.org/github.com.project/package/v1.2.3`
-
-**Examples that seem a little weird:**
-* `github.com/Azure/azure-event-hubs-go/v3 v3.2.0` maps to `go/proxy.golang.org/github.com.Azure.azure-event-hubs-go/v3/v3.2.0`
-* `golang.org/x/net v0.0.0-20210226172049-e18ecbb05110` maps to `go/proxy.golang.org/golang.org.x/net/v0.0.0-20210226172049-e18ecbb05110`
+* `collectd.org v0.5.0` maps to `go/-/-/collectd.org/v0.5.0`
+* `go.starlark.net v0.0.0-20210406145628-7a1108eaa012` maps to `go/-/-/go.starlark.net/v0.0.0-20210406145628-7a1108eaa012`
+* `cloud.google.com/go v0.56.0` maps to `go/cloud.google.com/-/go/v0.56.0`
+* `code.cloudfoundry.org/clock v1.0.0` maps to `go/code.cloudfoundry.org/-/clock/v1.0.0`
+* `go.uber.org/multierr v1.6.0` maps to `go/go.uber.org/-/multierr/v1.6.0`
+* `github.com/project/package v1.2.3` maps to `go/github.com/project/package/v1.2.3`
+* `golang.org/x/net v0.0.0-20210226172049-e18ecbb05110` maps to `go/golang.org.x/net/v0.0.0-20210226172049-e18ecbb05110`
+* `github.com/Azure/azure-event-hubs-go/v3 v3.2.0` maps to `go/github.com/Azure.azure-event-hubs-go/v3/v3.2.0`
 


### PR DESCRIPTION
I found that original proposed structure for coordinates wasn't going to work well with the vanity import paths/urls that Go allows for. This updates the architecture to better accommodate those paths.

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>