### PR TITLE
Cache curation-data source code file tree to improve perf

### DIFF
--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -16,7 +16,7 @@ const semver = require('semver')
 const { LicenseMatcher } = require('../../lib/licenseMatcher')
 const { Cache } = require('memory-cache')
 
-const hourInMS = 60 * 60 * 1000;
+const hourInMS = 60 * 60 * 1000
 
 // Responsible for managing curation patches in a store
 //

--- a/providers/curation/process.js
+++ b/providers/curation/process.js
@@ -7,6 +7,9 @@ async function work(once) {
   try {
     let message = await queue.dequeue()
     if (!get(message, 'data.pull_request') || !get(message, 'data.action')) return
+    // Wait for ten seconds because GitHub use eventual consistency so that
+    // later may not able to get PRs when event happened.
+    await new Promise(resolve => setTimeout(resolve, 10 * 1000))
     const pr = message.data.pull_request
     const action = message.data.action
     switch (action) {

--- a/providers/curation/process.js
+++ b/providers/curation/process.js
@@ -7,20 +7,21 @@ async function work(once) {
   try {
     let message = await queue.dequeue()
     if (!get(message, 'data.pull_request') || !get(message, 'data.action')) return
-    // Wait for ten seconds because GitHub use eventual consistency so that
-    // later may not able to get PRs when event happened.
-    await new Promise(resolve => setTimeout(resolve, 10 * 1000))
     const pr = message.data.pull_request
     const action = message.data.action
     switch (action) {
       case 'opened':
       case 'synchronize': {
+        // Wait for ten seconds because GitHub use eventual consistency so that
+        // later may not able to get PRs when event happened.
+        await new Promise(resolve => setTimeout(resolve, 10 * 1000))
         const curations = await curationService.getContributedCurations(pr.number, pr.head.sha)
         await curationService.validateContributions(pr.number, pr.head.sha, curations)
         await curationService.updateContribution(pr, curations)
         break
       }
       case 'closed': {
+        await new Promise(resolve => setTimeout(resolve, 10 * 1000))
         await curationService.addByMergedCuration(pr)
         await curationService.updateContribution(pr)
         break

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -25,21 +25,22 @@ function handlePost(request, response) {
 async function handleGitHubCall(request, response) {
   const body = validateGitHubCall(request, response)
   if (!body) return
-  // Wait for ten seconds because GitHub use eventual consistency so that
-  // later may not able to get PRs when event happened.
-  await new Promise(resolve => setTimeout(resolve, 10 * 1000))
   const pr = body.pull_request
   try {
     switch (body.action) {
       case 'opened':
       case 'reopened':
       case 'synchronize': {
+        // Wait for ten seconds because GitHub use eventual consistency so that
+        // later may not able to get PRs when event happened.
+        await new Promise(resolve => setTimeout(resolve, 10 * 1000))
         const curations = await curationService.getContributedCurations(pr.number, pr.head.sha)
         await curationService.validateContributions(pr.number, pr.head.sha, curations)
         await curationService.updateContribution(pr, curations)
         break
       }
       case 'closed': {
+        await new Promise(resolve => setTimeout(resolve, 10 * 1000))
         await curationService.addByMergedCuration(pr)
         await curationService.updateContribution(pr)
         break

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -25,6 +25,9 @@ function handlePost(request, response) {
 async function handleGitHubCall(request, response) {
   const body = validateGitHubCall(request, response)
   if (!body) return
+  // Wait for ten seconds because GitHub use eventual consistency so that
+  // later may not able to get PRs when event happened.
+  await new Promise(resolve => setTimeout(resolve, 10 * 1000))
   const pr = body.pull_request
   try {
     switch (body.action) {

--- a/test/providers/curation/processTest.js
+++ b/test/providers/curation/processTest.js
@@ -7,7 +7,8 @@ const memoryQueue = require('../../../providers/queueing/memoryQueue')
 const sinon = require('sinon')
 
 describe('Curation queue processing', () => {
-  it('handles opened message', async () => {
+  it('handles opened message', async function () {
+    this.timeout(12000)
     const { queue, curationService, logger } = setup({ action: 'opened' })
     await process(queue, curationService, logger, true)
 
@@ -19,7 +20,8 @@ describe('Curation queue processing', () => {
     expect(queue.data.length).to.eq(0)
   })
 
-  it('handles synchronize message', async () => {
+  it('handles synchronize message', async function () {
+    this.timeout(12000)
     const { queue, curationService, logger } = setup({ action: 'synchronize' })
     await process(queue, curationService, logger, true)
 
@@ -31,7 +33,8 @@ describe('Curation queue processing', () => {
     expect(queue.data.length).to.eq(0)
   })
 
-  it('handles closed message', async () => {
+  it('handles closed message', async function () {
+    this.timeout(12000)
     const { queue, curationService, logger } = setup({ action: 'closed' })
     await process(queue, curationService, logger, true)
 

--- a/test/routes/webhookGitHubTests.js
+++ b/test/routes/webhookGitHubTests.js
@@ -64,7 +64,8 @@ describe('Webhook Route for GitHub calls', () => {
   //   expect(definitionService.computeAndStore.getCall(0).args[0]).to.be.eq(simpleCoords)
   // })
 
-  it('skips closed event that is not merged', async () => {
+  it('skips closed event that is not merged', async function () {
+    this.timeout(12000)
     const request = createRequest('closed', false)
     const response = httpMocks.createResponse()
     const logger = createLogger()
@@ -80,7 +81,8 @@ describe('Webhook Route for GitHub calls', () => {
     expect(logger.error.notCalled).to.be.true
   })
 
-  it('calls valid for PR changes', async () => {
+  it('calls valid for PR changes', async function () {
+    this.timeout(12000)
     const request = createRequest('opened')
     const response = httpMocks.createResponse()
     const logger = createLogger()
@@ -94,7 +96,8 @@ describe('Webhook Route for GitHub calls', () => {
     expect(logger.error.notCalled).to.be.true
   })
 
-  it('calls missing for PR changes', async () => {
+  it('calls missing for PR changes', async function () {
+    this.timeout(12000)
     const request = createRequest('opened')
     const response = httpMocks.createResponse()
     const logger = createLogger()
@@ -108,7 +111,8 @@ describe('Webhook Route for GitHub calls', () => {
     expect(logger.error.notCalled).to.be.true
   })
 
-  it('validates the curation when a PR is opened', async () => {
+  it('validates the curation when a PR is opened', async function () {
+    this.timeout(12000)
     const request = createRequest('opened')
     const response = httpMocks.createResponse()
     const logger = createLogger()
@@ -118,7 +122,8 @@ describe('Webhook Route for GitHub calls', () => {
     expect(service.validateContributions.calledOnce).to.be.true
   })
 
-  it('validates the curation when a PR is reopened', async () => {
+  it('validates the curation when a PR is reopened', async function () {
+    this.timeout(12000)
     const request = createRequest('reopened')
     const response = httpMocks.createResponse()
     const logger = createLogger()


### PR DESCRIPTION
When the `GET /definitions` request is as slow as 100s, there are many times that logs show around 1 minutes run time when getting the `curations-data` repo source code file tree. After dig into the `geit` npm package, I found that in order to get the file tree, there are one Github calls and 836 iterations when processing file blobs. What's more, the number of iterations will grow with the growth of curation-data repo. While the curation tree is not changed very often, cache it would help improve the perf of those slow API calls.