### PR TITLE
adds a few logging enhancements

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -131,9 +131,9 @@ class DefinitionService {
     const result = {}
     const promises = coordinatesList.map(
       throat(10, async coordinates => {
-        this.logger.info('1:1:notice_generate:get_single_start', { ts: new Date().toISOString() })
+        this.logger.info(`1:1:notice_generate:get_single_start:${coordinates}`, { ts: new Date().toISOString() })
         const definition = await this.get(coordinates, null, force, expand)
-        this.logger.info('1:1:notice_generate:get_single_end', { ts: new Date().toISOString() })
+        this.logger.info(`1:1:notice_generate:get_single_end:${coordinates}`, { ts: new Date().toISOString() })
         if (!definition) return
         const key = definition.coordinates.toString()
         result[key] = definition

--- a/business/noticeService.js
+++ b/business/noticeService.js
@@ -22,6 +22,7 @@ class NoticeService {
     options = options || {}
     this.logger.info('1:notice_generate:get_definitions:start', { ts: new Date().toISOString(), cnt: coordinates.length })
     const definitions = await this.definitionService.getAll(coordinates)
+    this.logger.info('1:notice_generate:get_definitions:end', { ts: new Date().toISOString(), cnt: coordinates.length })
     this.logger.info('2:notice_generate:get_blobs:start', { ts: new Date().toISOString(), cnt: coordinates.length })
     const packages = await this._getPackages(definitions)
     this.logger.info('2:notice_generate:get_blobs:end', { ts: new Date().toISOString(), cnt: coordinates.length })


### PR DESCRIPTION
We saw 3 time out errors this morning around the use of the notices API. While not widespread, it's still something we need to solve. This adds some additions to logging to enhance searching and parsing of our logs for calls to /notices.

Signed-off-by: Nell Shamrell <nells@microsoft.com>