### PR TITLE
Fix go namespace slashes

### DIFF
--- a/app.js
+++ b/app.js
@@ -156,6 +156,7 @@ function createApp(config) {
   // catch 404 and forward to error handler
   const requestHandler = (req, res, next) => {
     logger.info('Error when handling a request', { rawUrl: req._parsedUrl._raw, baseUrl: req.baseUrl, originalUrl: req.originalUrl, params: req.params, route: req.route, url: req.url })
+    logger.info('Route not found', { route: req.url })
     const err = new Error('Not Found')
     err.status = 404
     next(err)

--- a/app.js
+++ b/app.js
@@ -156,7 +156,6 @@ function createApp(config) {
   // catch 404 and forward to error handler
   const requestHandler = (req, res, next) => {
     logger.info('Error when handling a request', { rawUrl: req._parsedUrl._raw, baseUrl: req.baseUrl, originalUrl: req.originalUrl, params: req.params, route: req.route, url: req.url })
-    logger.info('Route not found', { route: req.url })
     const err = new Error('Not Found')
     err.status = 404
     next(err)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,6 +53,24 @@ function reEncodeSlashes(namespace) {
   return `${namespace.replace(/\//g, '%2f')}`
 }
 
+function parseNamespaceNameRevision(request) {
+  let namespaceNameRevision = `${request.params.namespace}/${request.params.name}/${request.params.revision}`
+
+  if (request.params.extra1) {
+    namespaceNameRevision += `/${request.params.extra1}`
+  }
+
+  if (request.params.extra2) {
+    namespaceNameRevision += `/${request.params.extra2}`
+  }
+
+  if (request.params.extra3) {
+    namespaceNameRevision += `/${request.params.extra3}`
+  }
+
+  return namespaceNameRevision
+}
+
 function getLatestVersion(versions) {
   if (!Array.isArray(versions)) return versions
   if (versions.length === 0) return null
@@ -467,5 +485,6 @@ module.exports = {
   isLicenseFile,
   simplifyAttributions,
   isDeclaredLicense,
-  parseUrn
+  parseUrn,
+  parseNamespaceNameRevision
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,6 +32,16 @@ function toEntityCoordinatesFromRequest(request) {
   )
 }
 
+function toEntityCoordinatesFromArgs(args) {
+  return new EntityCoordinates(
+    args['type'],
+    args['provider'],
+    args['namespace'] === '-' ? null : reEncodeSlashes(args['namespace']),
+    args['name'],
+    args['revision']
+  )
+}
+
 // When someone requests a component with a slash in the namespace
 // They encode that slash as %2f
 // For example: https://clearlydefined.io/definitions/go/golang/rsc.io%2fquote/v3/v3.1.0
@@ -442,6 +452,7 @@ const _licenseUrlOverrides = [
 module.exports = {
   toEntityCoordinatesFromRequest,
   toResultCoordinatesFromRequest,
+  toEntityCoordinatesFromArgs,
   getLatestVersion,
   extractDate,
   setIfValue,

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -26,12 +26,14 @@ async function getDefinition(request, response) {
   const log = logger()
   log.info('getDefinition route hit', { ts: new Date().toISOString(), requestParams: request.params })
 
+  let coordinates
+
   // Painful way of handling go namespaces with multiple slashes
   // Unfortunately, it seems the best option without doing a massive
   // rearchitecture of the entire coordinate system
-  if (request.params.type == "go" && request.params.provider == "golang") {
+  if (request.params.type == 'go' && request.params.provider == 'golang') {
     let namespaceNameRevision = utils.parseNamespaceNameRevision(request)
-    let splitString = namespaceNameRevision.split("/")
+    let splitString = namespaceNameRevision.split('/')
 
     // Pull off the last part of the string as the revision
     const revision = splitString.pop()

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -31,7 +31,7 @@ async function getDefinition(request, response) {
   // Painful way of handling go namespaces with multiple slashes
   // Unfortunately, it seems the best option without doing a massive
   // rearchitecture of the entire coordinate system
-  if (request.params.type == 'go' && request.params.provider == 'golang') {
+  if (request.params.type === 'go' && request.params.provider === 'golang') {
     let namespaceNameRevision = utils.parseNamespaceNameRevision(request)
     let splitString = namespaceNameRevision.split('/')
 

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -13,6 +13,7 @@ const logger = require('../providers/logging/logger')
 // API for serving consumers and API
 router.get('/:type/:provider/:namespace/:name/:revision/pr/:pr', asyncMiddleware(getDefinition))
 router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(getDefinition))
+router.get('/:type/:provider/:namespace/:name/:revision/:extra', asyncMiddleware(getDefinition))
 
 async function getDefinition(request, response) {
   const log = logger()

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -30,26 +30,16 @@ async function getDefinition(request, response) {
   // Unfortunately, it seems the best option without doing a massive
   // rearchitecture of the entire coordinate system
   if (request.params.type == "go" && request.params.provider == "golang") {
-    let namespaceNameRevision = `${request.params.namespace}/${request.params.name}/${request.params.revision}`
-
-    if (request.params.extra1) {
-      namespaceNameRevision += `/${request.params.extra1}`
-    }
-
-    if (request.params.extra2) {
-      namespaceNameRevision += `/${request.params.extra2}`
-    }
-
-    if (request.params.extra3) {
-      namespaceNameRevision += `/${request.params.extra3}`
-    }
-
+    let namespaceNameRevision = utils.parseNamespaceNameRevision(request)
     let splitString = namespaceNameRevision.split("/")
 
     // Pull off the last part of the string as the revision
     const revision = splitString.pop()
+
+    // Pull of next part of the string as the name
     const name = splitString.pop()
 
+    // Join the rest of the string as the namespace
     const nameSpace = splitString.join('/')
 
     coordinates = utils.toEntityCoordinatesFromArgs(

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -19,7 +19,7 @@ router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(getDef
 // However, when it comes through a load balancer, the load balancer sometimes decodes the encoding to
 // go/golang/github.com/gorilla/mux/v1.7.3
 // which causes routing errors unless we allow for additional fields
-// We currently allow up to one extra field
+// We currently allow up to three extra fields (that means up to three slashes in the namespace)
 router.get('/:type/:provider/:namespace/:name/:revision/:extra1?/:extra2?/:extra3?', asyncMiddleware(getDefinition))
 
 async function getDefinition(request, response) {

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -44,8 +44,6 @@ async function getDefinition(request, response) {
       namespaceNameRevision += `/${request.params.extra3}`
     }
 
-    console.log(namespaceNameRevision)
-
     let splitString = namespaceNameRevision.split("/")
 
     // Pull off the last part of the string as the revision
@@ -54,15 +52,15 @@ async function getDefinition(request, response) {
 
     const nameSpace = splitString.join('/')
 
-    console.log(revision)
-    console.log(name)
-    console.log(nameSpace)
-
-    request.params.namespace = nameSpace
-    request.params.name = name
-    request.params.revision = revision
-
-    coordinates = utils.toEntityCoordinatesFromRequest(request)
+    coordinates = utils.toEntityCoordinatesFromArgs(
+      {
+        'type': request.params.type,
+        'provider': request.params.provider,
+        'namespace': nameSpace,
+        'name': name,
+        'revision': revision
+      }
+    )
   } else {
     coordinates = utils.toEntityCoordinatesFromRequest(request)
   }

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -488,6 +488,25 @@ describe('Utils toEntityCoordinatesFromRequest', () => {
   })
 })
 
+describe('Utils toEntityCoordinatesFromArgs', () => {
+  const args = {
+    type: 'go',
+    provider: 'golang',
+    namespace: 'rsc.io/quote',
+    name: 'v3',
+    revision: 'v3.1.0'
+  }
+
+  it('should turn the args into entity coordinates', () => {
+    const result = utils.toEntityCoordinatesFromArgs(args)
+    expect(result.type).to.eq('go')
+    expect(result.provider).to.eq('golang')
+    expect(result.namespace).to.eq('rsc.io%2fquote')
+    expect(result.name).to.eq('v3')
+    expect(result.revision).to.eq('v3.1.0')
+  })
+})
+
 describe('Utils getLicenseLocations', () => {
   const npmRequest = {
     params: {

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -507,6 +507,26 @@ describe('Utils toEntityCoordinatesFromArgs', () => {
   })
 })
 
+describe('Utils parseNamespaceNameRevision', () => {
+  const fakeSlashNamespaceRequest = {
+    params: {
+      type: 'go',
+      provider: 'golang',
+      namespace: 'rsc.io/quote',
+      name: 'v3',
+      revision: 'foo',
+      extra1: 'bar',
+      extra2: 'bah',
+      extra3: 'v3.1.0',
+    }
+  }
+
+  it('parses the args into one string', () => {
+    const result = utils.parseNamespaceNameRevision(fakeSlashNamespaceRequest)
+    expect(result).to.eq('rsc.io/quote/v3/foo/bar/bah/v3.1.0')
+  })
+})
+
 describe('Utils getLicenseLocations', () => {
   const npmRequest = {
     params: {


### PR DESCRIPTION
# Fix go namespace slashes

## Background

This is a fix for #884 

When go support was deployed to staging and production, I discovered that when someone requests a definition with url encoded slashes, such as:

```
definitions/go/golang/github.com%2fgorilla/mux/v1.7.3
```

The load balancer decodes the slashes before the request is passed to the service, which means the coordinates requested are:

```
definitions/go/golang/github.com/gorilla/mux/v1.7.3
```

Which results in a 404 not found, as there are more parameters in the url than the route expect.

## Implementation

This fix is a bit brute force, but it does work. It allows for up to three additional parameters in the URL and, for go components only, strings the relevant arguments together, then parses the revision, name, and namespace out of that string.