### PR TITLE
Upgrade eslint to ^7.5

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
   },
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 9,
+    "ecmaVersion": 2020,
     "sourceType": "module"
   },
   "rules": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "deep-equal-in-any-order": "^1.0.10",
-    "eslint": "^6.0.0",
+    "eslint": "^7.5",
     "mocha": "^8.2.1",
     "node-mocks-http": "^1.6.7",
     "nodemon": "^2.0.3",


### PR DESCRIPTION
eslint@^7.5 supports optional chanining.  Update eslint to avoid optional chaining error.