### PR TITLE
updates Dockerfile to use Node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # FROM node:8-alpine
-FROM node:12
+FROM node:14
 ENV APPDIR=/opt/service
 # RUN apk update && apk upgrade && \
 #    apk add --no-cache bash git openssh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pool:
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '12.x'
+      versionSpec: '14.x'
     displayName: 'Install Node.js'
 
   - script: |


### PR DESCRIPTION
# Proposal - Update to Node 14

When testing #893, I noticed that the [Optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) was not working in our builds. This is because our Docker image is based on Node 12, rather than Node 14.

Node 12 is technically still supported, but [will be EOL'd in April 30, 2022](https://nodejs.org/en/about/releases/). It's worth looking into upgrading to Node 14 (no, there is not a Node 13), rather than continuing to use Node 12.

I've done a local build of Node 14 and run tests (all passed) and done a quick click through of the API. It *seems* to work fine.

Anyone have ideas on how else we should test this? (And we should definitely not deploy this on a Friday).

Signed-off-by: Nell Shamrell <nells@microsoft.com>