### PR TITLE
Use pypi link for source

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -561,7 +561,8 @@ class DefinitionService {
     switch (coordinates.provider) {
       case 'golang':
       case 'gitlab':
-      case 'github': {
+      case 'github':
+      case 'pypi': {
         const url = buildSourceUrl(coordinates)
         if (!url) return
         this._ensureDescribed(definition)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -271,6 +271,9 @@ function buildSourceUrl(spec) {
     case 'golang': {
       return `https://pkg.go.dev/${deCodeSlashes(spec.namespace)}/${spec.name}@${spec.revision}`
     }
+    case 'pypi': {
+      return `https://pypi.org/project/${spec.name}/${spec.revision}/`
+    }
     default:
       return null
   }

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -716,4 +716,19 @@ describe('Utils buildSourceUrl', () => {
       expect(result).to.eq('https://pkg.go.dev/clearlydefined/foo/service@v1.2.3')
     })
   })
+
+  it('returns the correct pypi source url', () => {
+    const args = {
+      type: 'pypi',
+      provider: 'pypi',
+      namespace: '-',
+      name: 'zuul',
+      revision: '3.3.0'
+    }
+
+    const coordinates = utils.toEntityCoordinatesFromArgs(args)
+    const result = utils.buildSourceUrl(coordinates)
+
+    expect(result).to.eq('https://pypi.org/project/zuul/3.3.0/')
+  })
 })

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -637,48 +637,83 @@ describe('Utils buildSourceUrl', () => {
     expect(result).to.eq('https://gitlab.com/clearlydefined/service/-/tree/123abc')
   })
 
-  it('returns the correct mavencentral source url', () => {
-    const args = {
-      type: 'maven',
-      provider: 'mavencentral',
-      namespace: 'clearlydefined',
-      name: 'service',
-      revision: '1.2.3'
-    }
+  describe('maven urls', () => {
+    it('returns the correct mavencentral source url', () => {
+      const args = {
+        type: 'maven',
+        provider: 'mavencentral',
+        namespace: 'clearlydefined',
+        name: 'service',
+        revision: '1.2.3'
+      }
 
-    const coordinates = utils.toEntityCoordinatesFromArgs(args)
-    const result = utils.buildSourceUrl(coordinates)
+      const coordinates = utils.toEntityCoordinatesFromArgs(args)
+      const result = utils.buildSourceUrl(coordinates)
 
-    expect(result).to.eq('https://search.maven.org/remotecontent?filepath=clearlydefined/service/1.2.3/service-1.2.3-sources.jar')
+      expect(result).to.eq('https://search.maven.org/remotecontent?filepath=clearlydefined/service/1.2.3/service-1.2.3-sources.jar')
+    })
+
+    it('returns the correct mavencentral source url with dots in the namespace', () => {
+      const args = {
+        type: 'maven',
+        provider: 'mavencentral',
+        namespace: 'clearlydefined.foo',
+        name: 'service',
+        revision: '1.2.3'
+      }
+
+      const coordinates = utils.toEntityCoordinatesFromArgs(args)
+      const result = utils.buildSourceUrl(coordinates)
+
+      expect(result).to.eq('https://search.maven.org/remotecontent?filepath=clearlydefined/foo/service/1.2.3/service-1.2.3-sources.jar')
+
+    })
+
+    it('returns the correct mavengoogle source url', () => {
+      const args = {
+        type: 'maven',
+        provider: 'mavengoogle',
+        namespace: 'clearlydefined',
+        name: 'service',
+        revision: '1.2.3'
+      }
+
+      const coordinates = utils.toEntityCoordinatesFromArgs(args)
+      const result = utils.buildSourceUrl(coordinates)
+
+      expect(result).to.eq('https://maven.google.com/web/index.html#clearlydefined:service:1.2.3')
+    })
   })
 
-  it('returns the correct mavengoogle source url', () => {
-    const args = {
-      type: 'maven',
-      provider: 'mavengoogle',
-      namespace: 'clearlydefined',
-      name: 'service',
-      revision: '1.2.3'
-    }
+  describe('go urls', () => {
+    it('returns the correct golang source url', () => {
+      const args = {
+        type: 'go',
+        provider: 'golang',
+        namespace: 'clearlydefined',
+        name: 'service',
+        revision: 'v1.2.3'
+      }
 
-    const coordinates = utils.toEntityCoordinatesFromArgs(args)
-    const result = utils.buildSourceUrl(coordinates)
+      const coordinates = utils.toEntityCoordinatesFromArgs(args)
+      const result = utils.buildSourceUrl(coordinates)
 
-    expect(result).to.eq('https://maven.google.com/web/index.html#clearlydefined:service:1.2.3')
-  })
+      expect(result).to.eq('https://pkg.go.dev/clearlydefined/service@v1.2.3')
+    })
 
-  it('returns the correct golang source url', () => {
-    const args = {
-      type: 'go',
-      provider: 'golang',
-      namespace: 'clearlydefined',
-      name: 'service',
-      revision: 'v1.2.3'
-    }
+    it('returns the correct golang source url with slashes in the namespace', () => {
+      const args = {
+        type: 'go',
+        provider: 'golang',
+        namespace: 'clearlydefined%2ffoo',
+        name: 'service',
+        revision: 'v1.2.3'
+      }
 
-    const coordinates = utils.toEntityCoordinatesFromArgs(args)
-    const result = utils.buildSourceUrl(coordinates)
+      const coordinates = utils.toEntityCoordinatesFromArgs(args)
+      const result = utils.buildSourceUrl(coordinates)
 
-    expect(result).to.eq('https://pkg.go.dev/clearlydefined/service@v1.2.3')
+      expect(result).to.eq('https://pkg.go.dev/clearlydefined/foo/service@v1.2.3')
+    })
   })
 })

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -605,3 +605,80 @@ describe('Utils getLicenseLocations', () => {
     })
   })
 })
+
+describe('Utils buildSourceUrl', () => {
+  it('returns the correct github source url', () => {
+    const args = {
+      type: 'git',
+      provider: 'github',
+      namespace: 'clearlydefined',
+      name: 'service',
+      revision: '123abc'
+    }
+
+    const coordinates = utils.toEntityCoordinatesFromArgs(args)
+    const result = utils.buildSourceUrl(coordinates)
+
+    expect(result).to.eq('https://github.com/clearlydefined/service/tree/123abc')
+  })
+
+  it('returns the correct gitlab source url', () => {
+    const args = {
+      type: 'git',
+      provider: 'gitlab',
+      namespace: 'clearlydefined',
+      name: 'service',
+      revision: '123abc'
+    }
+
+    const coordinates = utils.toEntityCoordinatesFromArgs(args)
+    const result = utils.buildSourceUrl(coordinates)
+
+    expect(result).to.eq('https://gitlab.com/clearlydefined/service/-/tree/123abc')
+  })
+
+  it('returns the correct mavencentral source url', () => {
+    const args = {
+      type: 'maven',
+      provider: 'mavencentral',
+      namespace: 'clearlydefined',
+      name: 'service',
+      revision: '1.2.3'
+    }
+
+    const coordinates = utils.toEntityCoordinatesFromArgs(args)
+    const result = utils.buildSourceUrl(coordinates)
+
+    expect(result).to.eq('https://search.maven.org/remotecontent?filepath=clearlydefined/service/1.2.3/service-1.2.3-sources.jar')
+  })
+
+  it('returns the correct mavengoogle source url', () => {
+    const args = {
+      type: 'maven',
+      provider: 'mavengoogle',
+      namespace: 'clearlydefined',
+      name: 'service',
+      revision: '1.2.3'
+    }
+
+    const coordinates = utils.toEntityCoordinatesFromArgs(args)
+    const result = utils.buildSourceUrl(coordinates)
+
+    expect(result).to.eq('https://maven.google.com/web/index.html#clearlydefined:service:1.2.3')
+  })
+
+  it('returns the correct golang source url', () => {
+    const args = {
+      type: 'go',
+      provider: 'golang',
+      namespace: 'clearlydefined',
+      name: 'service',
+      revision: 'v1.2.3'
+    }
+
+    const coordinates = utils.toEntityCoordinatesFromArgs(args)
+    const result = utils.buildSourceUrl(coordinates)
+
+    expect(result).to.eq('https://pkg.go.dev/clearlydefined/service@v1.2.3')
+  })
+})


### PR DESCRIPTION
A community member brought these two definitions to my attention:

* https://clearlydefined.io/definitions/pypi/pypi/-/python-openstackclient/5.5.1
* https://clearlydefined.io/definitions/pypi/pypi/-/zuul/3.3.0

Because a source url is not found when these definitions are harvested, they have very low scores.

This is in part because pypi does not include source urls in its metadata (at least, not in a consistent way). 

This pull request adds a default source location for pypi definitions - the package's page on the central pypi registry (which allows for downloading of the source code and (in the project's README) often also has a link to the package's source code repo. We do something similar with go packages, since the go ecosystem also does not have a consistent way to identify source urls.

Currently, the ClearlyDefined crawler does search for a source on GitHub at harvest. If a pypi package's source is stored publicly on GitHub, ClearlyDefined can often find it. This pull request does not change that behavior - if ClearlyDefined finds a source repo on GitHub, that will overwrite the pypi page as the source url.

Ideally, the ClearlyDefined crawler would be able to find source repos in other places (such as GitLab, BitBucket, etc.). I've [opened an issue on the crawler repo](https://github.com/clearlydefined/crawler/issues/448) documenting the need for this.

Additionally, in the ClearlyDefined UI as it is now, there is no way to add a source url unless it is a GitHub repo. I've [opened an issue on the website repo](https://github.com/clearlydefined/website/issues/921) documenting the need for other options.