### PR TITLE
lowers the limit of how many definitions can be requested at once

### DIFF
--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -110,7 +110,7 @@ router.post(
 router.post('/', asyncMiddleware(listDefinitions))
 async function listDefinitions(request, response) {
   const coordinatesList = request.body.map(entry => EntityCoordinates.fromString(entry))
-  if (coordinatesList.length > 1000)
+  if (coordinatesList.length > 500)
     return response.status(400).send(`Body contains too many coordinates: ${coordinatesList.length}`)
   const normalizedCoordinatesList = await Promise.all(coordinatesList.map(utils.toNormalizedEntityCoordinates))
 


### PR DESCRIPTION
Over the past month we have seen a massive increase in calls to this batch definition API. Unfortunately, that has been causing some service availability issues. This pull request halves the limit of how many definitions can be requested at once. We will see if this increases the availability of our service. If anyone sees issues as a result of this, please reach out to me.

Signed-off-by: Nell Shamrell <nells@microsoft.com>