### PR TITLE
Added user-agent to request headers for maven cental

### DIFF
--- a/routes/originMaven.js
+++ b/routes/originMaven.js
@@ -3,7 +3,7 @@
 
 const asyncMiddleware = require('../middleware/asyncMiddleware')
 const router = require('express').Router()
-const requestPromise = require('request-promise-native')
+const requestPromise = require('request-promise-native').defaults({ headers: { 'user-agent': 'clearlydefined.io' } })
 const { uniq } = require('lodash')
 
 // maven.org API documentation https://search.maven.org/classic/#api


### PR DESCRIPTION
Without user-agent in request headers, requests to maven central now fail.  Fixed this by adding user-agent to request headers for maven central.

Tasks: https://github.com/clearlydefined/website/issues/923