### PR TITLE
Make the error message more understandable

### DIFF
--- a/schemas/definitions-get-dto-1.0.json
+++ b/schemas/definitions-get-dto-1.0.json
@@ -32,9 +32,7 @@
           ]
         }
       ],
-      "errorMessage": {
-        "type": "expand only support '-files'"
-      }
+      "errorMessage": "expand only support '-files'"
     }
   }
 }


### PR DESCRIPTION
Before the change when `expand` is not `-files`, the message is `should be equal to one of the allowed values`, which is not very useful.

After the change, the error message becomes `expand only support '-files'`.