### PR TITLE
Retrieve closed pull requests from oldest to newest during syncAllContributions

### DIFF
--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -54,12 +54,15 @@ class GitHubCurationService {
   async syncAllContributions(client) {
     const states = ['open', 'closed']
     for (let state of states) {
-      let response = await client.pullRequests.getAll({
+      let prOptions = {
         owner: this.options.owner,
         repo: this.options.repo,
         per_page: 100,
         state
-      })
+      }
+      //See https://docs.github.com/en/rest/reference/pulls#list-pull-requests
+      if (state === 'closed') prOptions = { ...prOptions, sort: 'updated', direction: 'asc' }
+      let response = await client.pullRequests.getAll(prOptions)
       this._processContributions(response.data)
       while (this.github.hasNextPage(response)) {
         response = await this.github.getNextPage(response)


### PR DESCRIPTION
This is to ensure when the merged pull requests are used to update
curation db sequentially, older data will be correctly overwritten
by newer data.

Tasks: https://github.com/clearlydefined/service/issues/901