### PR TITLE
Bugfix: some Go component don't have namespace

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -269,7 +269,7 @@ function buildSourceUrl(spec) {
       return `https://maven.google.com/web/index.html#${spec.namespace}:${spec.name}:${spec.revision}`
     }
     case 'golang': {
-      return `https://pkg.go.dev/${deCodeSlashes(spec.namespace)}/${spec.name}@${spec.revision}`
+      return `https://pkg.go.dev/${spec.namespace ? `${deCodeSlashes(spec.namespace)}/` : ''}${spec.name}@${spec.revision}`
     }
     case 'pypi': {
       return `https://pypi.org/project/${spec.name}/${spec.revision}/`


### PR DESCRIPTION
Some component don't have namespace. Therefore, deCodeSlashes will throw error because namespace is undefined. Here is the issue associate with it. https://github.com/clearlydefined/service/issues/927