### PR TITLE
Go component could not find declared license

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -284,7 +284,7 @@ function buildSourceUrl(spec) {
 }
 
 function deCodeSlashes(namespace) {
-  return `${namespace.replace(/%2f/g, '/')}`
+  return `${namespace.replace(/%2f/ig, '/')}`
 }
 
 // migrate the format of the source location to the current norm
@@ -343,7 +343,7 @@ function getLicenseLocations(coordinates) {
 }
 
 function goLicenseLocations(coordinates) {
-  if (coordinates.namespace && coordinates.namespace.includes('%2f')) {
+  if (coordinates.namespace && coordinates.namespace.toLowerCase().includes('%2f')) {
     return `${deCodeSlashes(coordinates.namespace)}/${coordinates.name}@${coordinates.revision}/`
   } else {
     return `${coordinates.namespace}/${coordinates.name}@${coordinates.revision}/`

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -596,12 +596,28 @@ describe('Utils getLicenseLocations', () => {
       expect(result).to.deep.include('go.uber.org/fx@1.14.2/')
     })
 
-    it('finds the correct license location for complex namespaces', async () => {
+    it('finds the correct license location for complex namespaces with lower case %2f', async () => {
       const complexNamespaceRequest = {
         params: {
           type: 'go',
           provider: 'golang',
           namespace: 'github.com%2fconcourse',
+          name: 'github-release-resource',
+          revision: 'v1.6.4'
+        }
+      }
+
+      const coordinates = await utils.toEntityCoordinatesFromRequest(complexNamespaceRequest)
+      const result = utils.getLicenseLocations(coordinates)
+      expect(result).to.deep.include('github.com/concourse/github-release-resource@v1.6.4/')
+    })
+
+    it('finds the correct license location for complex namespaces with upper case %2F', async () => {
+      const complexNamespaceRequest = {
+        params: {
+          type: 'go',
+          provider: 'golang',
+          namespace: 'github.com%2Fconcourse',
           name: 'github-release-resource',
           revision: 'v1.6.4'
         }


### PR DESCRIPTION
Even though Scancode and Licensee could find the license file, 74% of Go Component could not find the declared license. The issue is that the root directory for Scancode and the licensee for Go component are wrong. '%2F' should also be replaced with '/'.