### PR TITLE
Add user-agent header to orignCrate

### DIFF
--- a/routes/originCrate.js
+++ b/routes/originCrate.js
@@ -3,7 +3,7 @@
 
 const asyncMiddleware = require('../middleware/asyncMiddleware')
 const router = require('express').Router()
-const requestPromise = require('request-promise-native')
+const requestPromise = require('request-promise-native').defaults({ headers: { 'user-agent': 'clearlydefined.io' } })
 const { uniq } = require('lodash')
 
 // crates.io API https://github.com/rust-lang/crates.io/blob/03666dd7e35d5985504087f7bf0553fa16380fac/src/router.rs


### PR DESCRIPTION
When calling crate search api:
'https://crates.io/api/v1/crates?per_page=100&q=bitflags',
403 status code is returned with an error message of "We require that all
requests include a `User-Agent` header..."

Add the required user-agent in headers.

Task: https://github.com/clearlydefined/service/issues/938