### PR TITLE
Propose to change NOASSERTION to OTHER for Google PATENTS file

### DIFF
--- a/lib/scancodeMap.js
+++ b/lib/scancodeMap.js
@@ -391,5 +391,6 @@ module.exports = new Map([
   ['zlib', 'Zlib'],
   ['zpl-2.0', 'ZPL-2.0'],
   ['zpl-1.1', 'ZPL-1.1'],
-  ['zpl-2.1', 'ZPL-2.1']
+  ['zpl-2.1', 'ZPL-2.1'],
+  ['google-patent-license-golang', 'OTHER']
 ])


### PR DESCRIPTION
All Go components start with "golang.org/x" and have this [PATENT](https://cs.opensource.google/go/x/tools/+/master:PATENTS) file, Scancode could detect it as `google-patent-license-golang` file. Instead of convert `google-patent-license-golang` to NOASSERTION, I propose to change it to OTHER since it's a patent file.