### PR TITLE
Fixed coordinates parsing for some go components in preview definitions API

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,6 +51,28 @@ function toEntityCoordinatesFromArgs(args) {
   )
 }
 
+function parseParamsFromPath(coordinatesPaths) {
+  const splitString = coordinatesPaths.split('/')
+  if (splitString.length < 5) return null
+
+  // First is type
+  const type = splitString.shift()
+
+  // Next in front is the provider
+  const provider = splitString.shift()
+
+  // Pull off the last part of the string as the revision
+  const revision = splitString.pop()
+
+  // Pull of next part of the string as the name
+  const name = splitString.pop()
+
+  // Join the rest of the string as the namespace
+  const namespace = splitString.join('/')
+
+  return { type, provider, namespace, name, revision }
+}
+
 // When someone requests a component with a slash in the namespace
 // They encode that slash as %2f
 // For example: https://clearlydefined.io/definitions/go/golang/rsc.io%2fquote/v3/v3.1.0
@@ -522,5 +544,6 @@ module.exports = {
   simplifyAttributions,
   isDeclaredLicense,
   parseUrn,
-  parseNamespaceNameRevision
+  parseNamespaceNameRevision,
+  parseParamsFromPath
 }

--- a/middleware/pathToParams.js
+++ b/middleware/pathToParams.js
@@ -1,0 +1,13 @@
+// (c) Copyright 2022, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { parseParamsFromPath } = require('../lib/utils')
+
+module.exports = (request, response, next) => {
+  if (request.params[0]) {
+    const params = parseParamsFromPath(request.params[0])
+    if (!params) return response.status(400).send('Need to provide type, provider, namespace, name and revision')
+    request.params = { ...params, ...request.params }
+  }
+  next()
+}

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -12,7 +12,7 @@ const pathToParams = require('../middleware/pathToParams')
 
 // Gets the definition for a component with any applicable patches. This is the main
 // API for serving consumers and API
-router.get('/:type/:provider/:namespace/:name/:revision/pr/:pr', asyncMiddleware(getDefinition))
+router.get('/*/pr/:pr', pathToParams, asyncMiddleware(getDefinition))
 router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(getDefinition))
 
 // When a request for a component with slashes in the namespace comes in
@@ -144,7 +144,7 @@ function adaptResultKeys(result, requestedKeys, coordinatesLookup, matchCase) {
 
 // Previews the definition for a component aggregated and with the POST'd curation applied.
 // Typically used by a UI to preview the effect of a patch
-router.post('/*', [pathToParams, asyncMiddleware(previewWithCoordinatesParams)])
+router.post('/*', pathToParams, asyncMiddleware(previewWithCoordinatesParams))
 async function previewWithCoordinatesParams(request, response) {
   if (!request.query.preview)
     return response.status(400).send('Only valid for previews. Use the "preview" query parameter')

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -554,6 +554,40 @@ describe('Utils parseNamespaceNameRevision', () => {
   })
 })
 
+describe('Utils parseParamsFromPath', () => {
+  it('should parse path into params for go', () => {
+    const result = utils.parseParamsFromPath('go/golang/rsc.io/quote/v3/v3.1.0')
+    expect(result.type).to.eq('go')
+    expect(result.provider).to.eq('golang')
+    expect(result.namespace).to.eq('rsc.io/quote')
+    expect(result.name).to.eq('v3')
+    expect(result.revision).to.eq('v3.1.0')
+  })
+
+  it('should parse path into params for npm', () => {
+    const result = utils.parseParamsFromPath('npm/npmjs/-/javascriptproperties/0.8.1')
+    expect(result.type).to.eq('npm')
+    expect(result.provider).to.eq('npmjs')
+    expect(result.namespace).to.eq('-')
+    expect(result.name).to.eq('javascriptproperties')
+    expect(result.revision).to.eq('0.8.1')
+  })
+
+  it('should parse path into params for gitlab', () => {
+    const result = utils.parseParamsFromPath('git/gitlab/gitlab-org/frontend/playground/batch-issue-creator/fc20856ee7113cea9ffab37e1e3bc65d35c3948f')
+    expect(result.type).to.eq('git')
+    expect(result.provider).to.eq('gitlab')
+    expect(result.namespace).to.eq('gitlab-org/frontend/playground')
+    expect(result.name).to.eq('batch-issue-creator')
+    expect(result.revision).to.eq('fc20856ee7113cea9ffab37e1e3bc65d35c3948f')
+  })
+
+  it('rejects invalid path', () => {
+    const result = utils.parseParamsFromPath('npm/npmjs/javascriptproperties/0.8.1')
+    expect(result).not.to.ok
+  })
+})
+
 describe('Utils getLicenseLocations', () => {
   const npmRequest = {
     params: {

--- a/test/middleware/pathToParamsTest.js
+++ b/test/middleware/pathToParamsTest.js
@@ -1,0 +1,35 @@
+// (c) Copyright 2022, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const httpMocks = require('node-mocks-http')
+const middleware = require('../../middleware/pathToParams')
+
+describe('pathToParams middleware', () => {
+  it('should parse request.params[0]', () => {
+    const request = { params : { '0': 'crate/cratesio/-/syn/1.0.14' } }
+    middleware(request, null, () => {
+      const  { params } = request
+      expect(params.type).to.be.equal('crate')
+      expect(params.provider).to.be.equal('cratesio')
+      expect(params.namespace).to.be.equal('-')
+      expect(params.name).to.be.equal('syn')
+      expect(params.revision).to.be.equal('1.0.14')
+    })
+  })
+
+  it('should reject invalid coordinates', () => {
+    const request = { params : { '0': 'crate/cratesio/syn/1.0.14' } }
+    const response = httpMocks.createResponse()
+    middleware(request, response, null)
+    expect(response.statusCode).to.be.equal(400)
+  })
+
+  it('does nothing if request.params[0] is falsy', () => {
+    const params = {}
+    const request = { params }
+    middleware(request, null, () => {
+      expect(request.params).to.be.equal(params)
+    })
+  })
+})


### PR DESCRIPTION
The existing preview definition post API:
https://api.clearlydefined.io/api-docs/#/definitions/post_definitions__type___provider___namespace___name___revision_
does not work well for certain go components on the dev and production
systems.  For example, the following call failed on dev and production
deployments:
Post to, https://dev-api.clearlydefined.io/definitions/go/golang/github.com%2fdgrijalva/jwt-go/v3.2.0+incompatible?matchCasing=false&preview=true
Post body, {described: {releaseDate: "2022-06-04"}}

In those systems, the Cloudfare reportedly translates %2f
in the URL to /. Therefore, the existing preview definition post API
is not matched, resulting in 404 status.

The coordinates are the identifiers for the definitions resource.  Fixed parsing of the coordinates to allow for '/' present in the namespace for go components.

Task: https://github.com/clearlydefined/website/issues/920