### PR TITLE
Fixed incorrect continuation token when searching with sort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,1025 @@
 {
   "name": "service",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.254.0.tgz",
+      "integrity": "sha512-ZBJFCCU7mIXGLk5GFXrSReyUR/kOBju0kzd7nVAAQQlfkmHZEuFhKFFMXkfJZG0SC0ezCbmR/EzIqJ2mTI+pRA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.254.0.tgz",
+      "integrity": "sha512-FZlTQqgY7v3A2SPq0wR+W1ApJ5hSB0qYezDfaDofpdZbHFKLKyQQr14n5PBrT57/I9Wo75rrgPLENhAqOu3TfQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.254.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/credential-provider-node": "3.254.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-signing": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.254.0.tgz",
+      "integrity": "sha512-Ih80wJpGHa4nwxtTQvmSTT1UXQeHweYk+A6y779H1dtczr8h9Y2lXZa0C0TGcd1LEpL0nYHw0kJE3ZBw1/0nhw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.254.0.tgz",
+      "integrity": "sha512-KRF/hBysJgrZpjRgg47Fa7YzC10Ypqf/FSeesJkN6l2lULosO+o0N+RD4t5LLWXrD10c9by6m1ueC6077z0fGQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.254.0.tgz",
+      "integrity": "sha512-up+u5ik1pZ9Vo2MtcMCZ6pNAFhrePbH/IBFSgSsJlCU4AsGxPBsm59CE3/n/e84pFzhwVmFEUdavysIM+aP8LA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/credential-provider-node": "3.254.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-sdk-sts": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-signing": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.254.0.tgz",
+      "integrity": "sha512-+t5mi/SrZdAbSgg/5b/q3zVZsNQSyty2XX+znaRvBdANtIWIBdFLEMQp/L5NA+PSiW6VUXu9eXcsj0kJlAhTgQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.254.0.tgz",
+      "integrity": "sha512-aZgGDn7lutcLcYp8z6z3PvfoGvrudv5mYj7mf/HDcEiHwpHGu+1t5qUw7VVD4e5yd3OCGJ2Rttohw9EIvXgcmg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.254.0.tgz",
+      "integrity": "sha512-2CDwb7L1XGTY7Y8N3EsE1xqas0zNvrs4aOEv5XZNrKqE+9bvs8CiUwV4SB6VwSD+EPcOSm3QYEURUmj5EyLEZQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.254.0.tgz",
+      "integrity": "sha512-sM3N7FLz+svRGjTgwAybKBmu5tVfCJmd5HPEfKR0jfBWB1uq0u0J+65JiO/wfqn/ix+3ZyFfacSJDFjnSPu/KA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.254.0.tgz",
+      "integrity": "sha512-cqzrvuniurfiKmJsOlGyagUUwrZuOnEAxGDL0Olg5Ac3XByAO5AWH/mjy9P7u31j3vxybMz/Uw5kR7lV1q5sXQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.254.0",
+        "@aws-sdk/credential-provider-imds": "3.254.0",
+        "@aws-sdk/credential-provider-process": "3.254.0",
+        "@aws-sdk/credential-provider-sso": "3.254.0",
+        "@aws-sdk/credential-provider-web-identity": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.254.0.tgz",
+      "integrity": "sha512-jjR/qLn0lwDJmeWwTMwWG2zk5GpjCdKts1Taxd5GFHHSzkH/FZG8Vr8u5yWRtoE/x876n+ItiRfcSrLTTwqkUQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.254.0",
+        "@aws-sdk/credential-provider-imds": "3.254.0",
+        "@aws-sdk/credential-provider-ini": "3.254.0",
+        "@aws-sdk/credential-provider-process": "3.254.0",
+        "@aws-sdk/credential-provider-sso": "3.254.0",
+        "@aws-sdk/credential-provider-web-identity": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.254.0.tgz",
+      "integrity": "sha512-vNm1AHMu5Lg1kOMk4ucWgaNO4zNAD7aeRssdBMnC7WqRT2xB8CUEWi+zJGNjbxzEeTLXQZuMa1VeRT3nPjYrzg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.254.0.tgz",
+      "integrity": "sha512-uFfAQ/sIWreDA79HpJqdL+LkVp/yGkdBrDhjbiXIyeVWy/NmQNKu8l0j+wGazk1r562TJbzZ0Gz6+wTsdUSPgA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/token-providers": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.254.0.tgz",
+      "integrity": "sha512-R/5qjAoCHEe7xmY5j0vges4xKpFpTgrwzdST822JVNWUobZmiDUqnn+1Xw4Qmomst625NOpgzsV4JuHsA4a8Ig==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.254.0.tgz",
+      "integrity": "sha512-HoBfuSGU7cJ/My1gDLLePLlNjI/bAHQV+Ch8yqkipesfVuiO6aRaB7ipJYZS5OFJffkY9oJkZmGtqmrpfpziMQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.254.0",
+        "@aws-sdk/client-sso": "3.254.0",
+        "@aws-sdk/client-sts": "3.254.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.254.0",
+        "@aws-sdk/credential-provider-env": "3.254.0",
+        "@aws-sdk/credential-provider-imds": "3.254.0",
+        "@aws-sdk/credential-provider-ini": "3.254.0",
+        "@aws-sdk/credential-provider-node": "3.254.0",
+        "@aws-sdk/credential-provider-process": "3.254.0",
+        "@aws-sdk/credential-provider-sso": "3.254.0",
+        "@aws-sdk/credential-provider-web-identity": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.254.0.tgz",
+      "integrity": "sha512-/bbtNHe5JHFdKnCVr3Zx55sqs4c0F+7f1CC5cvTgH3O46wgIRM/6/rvE0YieXmfm3ho/GOhxBUzy59A0haKQGg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/querystring-builder": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.254.0.tgz",
+      "integrity": "sha512-7FoB6BVbO+Z/NEOHeOAoUTyj8q+Pcdn4QpKvA4epRDrzMNcXy7MUNzzt148nkDssES09rgsN+KM8Zo2qgRYngg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.254.0.tgz",
+      "integrity": "sha512-ueV0tXyGndCTZXnEv+AMeTfu+IqV2QzmGMXcakiwxDjg48H9X/bLnj+C96Sexond8jD8K0ub9HWhkBrvvAXlPA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.254.0.tgz",
+      "integrity": "sha512-IT7nDZA6WsaZSNp9M79xfkk/us4kGV4SIZ2R9gHT9MFqdmpmbr3EGhFLKXUHcAZfCcOdw+JNV/wHJiiN1JD/hg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.254.0.tgz",
+      "integrity": "sha512-9fkDtSJdhEr91tWp4zLyKhHDGVyvUA0gDK+6wGYyorKCae2qX2TL+Fl6vsqY4PxrdTpXRBJDlJnEly9i48YKxg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.254.0.tgz",
+      "integrity": "sha512-JG+OoyCMivnqTYiPZxRF+sgYEyQG68+PMl2843owvSxQQ25nH2Ih6DzLqH10c/uAN0PsiA8s/FfJBzhw9Xf0KA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.254.0.tgz",
+      "integrity": "sha512-h3jEw58VUJkfqrwWMmp3Qc8293RFo4LMqxNAVsVwYEG6xb/RQ+JamsOx+t6aDsoOdKqhYngWwDGtgUZQ5wQQvg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.254.0.tgz",
+      "integrity": "sha512-/4tTvAXmIIMCs3giPIXN9aVJUGMoBMWw+9WS22u7nYNzwTe/k30DhS91uvwj7TLOOpFN0IBNXPCJ+T1OZn+ZXQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.254.0.tgz",
+      "integrity": "sha512-nHgris8NmtLzsH5iUA8geW6RAT1VRymjlieKFmM3CAYt2h2X8AtAiL/Wod+Pj3+jjRGk9YeGzOOGbzODHiRxnA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/service-error-classification": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.254.0.tgz",
+      "integrity": "sha512-Y074nmTp07thuOI6GePv8IKdL/OvkO1tn2l7QvnwQa3Sy/HyNai1V3MVtq4hRi1dgDjheKPVHPE+TnOmF3w5uA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.254.0.tgz",
+      "integrity": "sha512-YuItb2nlKADTBItcn68eA8amX4quuR1+0GyFRkwssKS/iTjbIk+3gJ2s1zxkUhlyozH3U38Jvvqd+W9+gNpYIg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.254.0.tgz",
+      "integrity": "sha512-HMVGf+yANjlKCUMFZJU2PNzbI9hbCgL+IX/Y4DGuQW9cp7EgZOxQre1LBKpcCqqPVQ4toIdfNH/K8uM2fpO6dg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.254.0.tgz",
+      "integrity": "sha512-yPWRnjeLC0lPAEQbiqbC3+hnqXZ+uCSoSevGndU5KWMMiXLxKZn7Y0B3kG8NAnNNuPid+wYFWWU9rKiBRvWR/w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.254.0.tgz",
+      "integrity": "sha512-hp5UYRg3ysZXMFMv34nYexyom6Z3pdx+OmisJz4w3AMigT8y57Ps30Vg+1QYaGlQkI4vfvcmdZX2Q+kp+mb9gQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.254.0.tgz",
+      "integrity": "sha512-3Bp3Gp2NOY9gab738xf07TysO5iB0Ib9qRNGDlxX8SX8fZDRnxrF2cn+Tjte42wrO54orwhSyuTaIlAqKeii8Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.254.0.tgz",
+      "integrity": "sha512-DX2WJ3pub+3FF9GpoF5doERCn06MxS/UmmbKnIIokWQHjPZVomNh/1P3Cf9Jn9jeIPgh4UOg0uPD8cUm/cwHQw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/abort-controller": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/querystring-builder": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.254.0.tgz",
+      "integrity": "sha512-BLZF/LDFjAgv2ZY0vhThU58k++Aw+SK7qNU7XT0D84q5iWlYRKptQEvSSvIkBSI/rZoppOFhK7W80I8kNNbh+Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.254.0.tgz",
+      "integrity": "sha512-4o/I/qhMUTp70njwWe3ttyRJSAKegnr8l3oVWAf1/q1ZHpcxbRRZEDvrkx4KSunFeXTTGHcff1oyLSRG/cKMsQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.254.0.tgz",
+      "integrity": "sha512-Er+pOGTrPxelrzggibduO+eB1ClaU2BhjA8gd0nORS3kqktQggG3tKmRSIilegi9WOa3awCk6CnnuAf0pBrbUA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.254.0.tgz",
+      "integrity": "sha512-WwRD99dwGo2aIrRjLHUAXaWCZ+3fj88IhIwciWTqrHBS3TQWXllOOQmYo7f+aMBB4Q1K6KdKITNi8L7aUuDv2g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.254.0.tgz",
+      "integrity": "sha512-8GHqMJBBF9yoMBG/Nf9PusUSMFjG8ygps/cSJPlgcG2vbFn8BCdBZVc4ptXqICZUnBB/6lrxy8nCmNUaru48jg==",
+      "dev": true,
+      "optional": true
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.254.0.tgz",
+      "integrity": "sha512-UH4YTXuG+q004vA+jNrVhrD5XQCIAgpL/eriObJnQpKUVef1mkkEDHZs8+8+ZPsk4p/iBrIJ3lXNf7iDA/BFzw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.254.0.tgz",
+      "integrity": "sha512-9FoEnipA9hAgEp6oqIT3+hobF+JgIXIn5QV8kAB7QGxEDqs/pdpEbGc9qbxi0ghdjvqzOSDir9gNI3w0cL8Aug==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.254.0.tgz",
+      "integrity": "sha512-SI0jz9JfWi1IaakDX/26xliKTIMJpzwwDoyQPEfZ/L0KKdpr2gNhljA3sR2pZ2EM1oqOaXpMHAunSzv7EBpBWg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.254.0.tgz",
+      "integrity": "sha512-i3W+YWrMtgdFPDWW/m56xrkBhqrB6beKgQi46oSM/aFZ3ZAkFJLfbsLK99LWzVxtzELTSFjJWY54r+Au/hb2kQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.254.0.tgz",
+      "integrity": "sha512-xDEDk6ZAGFO0URPgB6R2mvQANYlojHLjLC9zzOzl07F+uqYS30yZDIg4UFcqPt/x48v7mxlKZpbaZgYI2ZLgGA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.254.0.tgz",
+      "integrity": "sha512-Za0JGUa9p5GQ8t2tVtKaRSjLUxrmEdnBlUiZ2zKm86wFxgQnjbMwzD3mvyJ5OaVsXScU5vzc3CXHIXSvS7h7Ng==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.254.0.tgz",
+      "integrity": "sha512-vj/s+BuqNKTHN9bsZ/HY7vpBWbo3F+4c3/ZoKSZa5Jc7jAuGCbx3zWwHdJFDgvbqLvsTBw80Q9d/CDy9pKj/tQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "bowser": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+          "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.254.0.tgz",
+      "integrity": "sha512-gvD2+Uf60c2BgUYv2d6R4dSpO/CbvybqblgF8lKZCsHkDWzfEdPv9nlJgUWM1cuMKQ0hBZ3cL3ilOwVKRVPyiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/credential-provider-imds": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.254.0.tgz",
+      "integrity": "sha512-BzBIOnhVrs4RFTpGZErZfAV1VhqWglxn047VYijmCQe8Aejq4mJAaepSwHYar++XC0+pduD5YO8IidW8z/1vQQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.254.0.tgz",
+      "integrity": "sha512-gn7vInNTRBo2QatOB+uU99JwV53wf/zlTUnUK0qOuebtSDLMdiO+msiMi2ctz9vMIrtc2XMXNQro1aE0aUPy4w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-retry": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.254.0.tgz",
+      "integrity": "sha512-IVA4wAOJpVssEIbJmeq1fdDYvrkOqYFK9Pz4tERmMz33003fyY92dU468Lulw8MnsSALYiwWUoWSFg9L5RCTug==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.254.0.tgz",
+      "integrity": "sha512-2HvwH8l7ln4qTDsU3rgH9NvSSo5qhX+2Lenb6XvNnIMkL4r/tPhNIaGKtoQRfpzLH378Mm9XEQnJM5UXFRWuTA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.254.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "bowser": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+          "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.254.0.tgz",
+      "integrity": "sha512-6nc9bmRP+2JqbBJ5oRZZRU8l35X3VcWF5j8XvmamWjIABsanc6Gv6NV4qAa3imPjIyWNiShZn/YkTBYs1exsdg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -362,6 +1378,17 @@
             "spdx-compare": "^1.0.0",
             "spdx-expression-parse": "^3.0.0",
             "spdx-ranges": "^2.0.0"
+          },
+          "dependencies": {
+            "spdx-expression-parse": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+              "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            }
           }
         }
       }
@@ -799,6 +1826,28 @@
         "@types/node": "*"
       }
     },
+    "@types/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
+    },
+    "@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
+      "dev": true
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -845,6 +1894,32 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -1068,6 +2143,15 @@
         "shimmer": "^1.1.0"
       }
     },
+    "async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1173,6 +2257,12 @@
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "base64url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
@@ -1211,6 +2301,51 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
     },
     "body-parser": {
       "version": "1.18.2",
@@ -1396,6 +2531,22 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
       "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true
     },
     "bytes": {
       "version": "3.0.0",
@@ -2814,6 +3965,25 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "feature-policy": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
@@ -3060,6 +4230,12 @@
       "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
       "dev": true
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -3127,6 +4303,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
+    "get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
       "dev": true
     },
     "get-stream": {
@@ -3490,10 +4672,43 @@
         "resolve-alpn": "^1.0.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ienoopen": {
       "version": "1.1.0",
@@ -3563,6 +4778,12 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+      "dev": true
+    },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
     "ipaddr.js": {
@@ -4321,6 +5542,12 @@
         "object-visit": "^1.0.0"
       }
     },
+    "md5-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-5.0.0.tgz",
+      "integrity": "sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==",
+      "dev": true
+    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -4797,6 +6024,16 @@
         }
       }
     },
+    "mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dev": true,
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
     "mongodb-core": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.11.tgz",
@@ -4812,6 +6049,129 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
           "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        }
+      }
+    },
+    "mongodb-memory-server": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-8.11.3.tgz",
+      "integrity": "sha512-DCD2kByVpdSrShgBZjdSDKesF1gyFSDi2RN8I7m/1ZJ6RFdkZyMWfofsQzHiTJ/WoqXLadWJljgg0LPNz31FWg==",
+      "dev": true,
+      "requires": {
+        "mongodb-memory-server-core": "8.11.3",
+        "tslib": "^2.4.1"
+      }
+    },
+    "mongodb-memory-server-core": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-8.11.3.tgz",
+      "integrity": "sha512-DObY45GHxM3O2/6WeRVxiZhoYLnp3vNjrRpq2WdvwNIzatC86Ac28vgqnILTbPD5w58/Fr97kCNBTAC4YL5YzA==",
+      "dev": true,
+      "requires": {
+        "@types/tmp": "^0.2.3",
+        "async-mutex": "^0.3.2",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.4",
+        "find-cache-dir": "^3.3.2",
+        "get-port": "^5.1.1",
+        "https-proxy-agent": "^5.0.1",
+        "md5-file": "^5.0.0",
+        "mongodb": "^4.13.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.3.8",
+        "tar-stream": "^2.1.4",
+        "tmp": "^0.2.1",
+        "tslib": "^2.4.1",
+        "uuid": "^9.0.0",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+          "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0"
+          }
+        },
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "find-cache-dir": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+          "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "mongodb": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
+          "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-providers": "^3.186.0",
+            "bson": "^4.7.0",
+            "mongodb-connection-string-url": "^2.5.4",
+            "saslprep": "^1.0.3",
+            "socks": "^2.7.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+          "dev": true
         }
       }
     },
@@ -4884,6 +6244,32 @@
       "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
       "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g=",
       "dev": true
+    },
+    "new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -5481,6 +6867,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -6299,6 +7691,12 @@
         }
       }
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -6396,6 +7794,16 @@
         }
       }
     },
+    "socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "dev": true,
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      }
+    },
     "sort-any": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-1.1.12.tgz",
@@ -6478,6 +7886,17 @@
         "array-find-index": "^1.0.2",
         "spdx-expression-parse": "^3.0.0",
         "spdx-ranges": "^2.0.0"
+      },
+      "dependencies": {
+        "spdx-expression-parse": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        }
       }
     },
     "spdx-exceptions": {
@@ -6515,6 +7934,17 @@
         "spdx-compare": "^1.0.0",
         "spdx-expression-parse": "^3.0.0",
         "spdx-ranges": "^2.0.0"
+      },
+      "dependencies": {
+        "spdx-expression-parse": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        }
       }
     },
     "split-on-first": {
@@ -6638,6 +8068,13 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true,
+      "optional": true
     },
     "superagent": {
       "version": "4.1.0",
@@ -6804,6 +8241,47 @@
         }
       }
     },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "term-size": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
@@ -6931,6 +8409,29 @@
       "requires": {
         "punycode": "^1.4.1"
       }
+    },
+    "tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+          "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+          "dev": true
+        }
+      }
+    },
+    "tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
     },
     "tunnel": {
       "version": "0.0.4",
@@ -7276,6 +8777,22 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-1.1.1.tgz",
       "integrity": "sha1-DfjRGOMrSyhORDp50jCwBmksrnU="
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "requires": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      }
     },
     "which": {
       "version": "1.3.0",
@@ -7652,6 +9169,16 @@
           "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
           "dev": true
         }
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "deep-equal-in-any-order": "^1.0.10",
     "eslint": "^7.5",
     "mocha": "^8.2.1",
+    "mongodb-memory-server": "^8.11.2",
     "node-mocks-http": "^1.6.7",
     "nodemon": "^2.0.3",
     "nyc": "^15.0.0",

--- a/test/fixtures/store/definitions-paged-no-files
+++ b/test/fixtures/store/definitions-paged-no-files
@@ -1,0 +1,1078 @@
+[{
+  "_id": "npm/npmjs/@sinclair/typebox/0.24.45",
+  "described": {
+    "tools": [
+      "licensee/9.14.0"
+    ],
+    "toolScore": {
+      "total": 0,
+      "date": 0,
+      "source": 0
+    },
+    "score": {
+      "total": 0,
+      "date": 0,
+      "source": 0
+    }
+  },
+  "coordinates": {
+    "type": "npm",
+    "provider": "npmjs",
+    "namespace": "@sinclair",
+    "name": "typebox",
+    "revision": "0.24.45"
+  },
+  "licensed": {
+    "toolScore": {
+      "total": 0,
+      "declared": 0,
+      "discovered": 0,
+      "consistency": 0,
+      "spdx": 0,
+      "texts": 0
+    },
+    "score": {
+      "total": 0,
+      "declared": 0,
+      "discovered": 0,
+      "consistency": 0,
+      "spdx": 0,
+      "texts": 0
+    }
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-04T22:37:58.050Z"
+  },
+  "scores": {
+    "effective": 0,
+    "tool": 0
+  },
+  "_mongo": {
+    "partitionKey": "npm/npmjs/@sinclair/typebox/0.24.45",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "pypi/pypi/-/backports.ssl_match_hostname/3.5.0.1",
+  "described": {
+    "releaseDate": "2015-12-19",
+    "urls": {
+      "registry": "https://pypi.org/project/backports.ssl_match_hostname",
+      "version": "https://pypi.org/project/backports.ssl_match_hostname/3.5.0.1",
+      "download": "https://files.pythonhosted.org/packages/76/21/2dc61178a2038a5cb35d14b61467c6ac632791ed05131dda72c20e7b9e23/backports.ssl_match_hostname-3.5.0.1.tar.gz"
+    },
+    "hashes": {
+      "sha1": "0567c136707a5f53b95aa793b79cc8d5c61d8e22",
+      "sha256": "502ad98707319f4a51fa2ca1c677bd659008d27ded9f6380c79e8932e38dcdf2"
+    },
+    "files": 6,
+    "tools": [
+      "clearlydefined/1.3.1",
+      "reuse/1.2.0",
+      "licensee/9.14.0",
+      "scancode/30.3.0",
+      "curation/322086606063f1d221c47667e18b946c3fe94848"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "sourceLocation": {
+      "type": "pypi",
+      "provider": "pypi",
+      "name": "backports.ssl_match_hostname",
+      "revision": "3.5.0.1",
+      "url": "https://pypi.org/project/backports.ssl_match_hostname/3.5.0.1/"
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "coordinates": {
+    "type": "pypi",
+    "provider": "pypi",
+    "name": "backports.ssl_match_hostname",
+    "revision": "3.5.0.1"
+  },
+  "licensed": {
+    "toolScore": {
+      "total": 19,
+      "declared": 0,
+      "discovered": 4,
+      "consistency": 0,
+      "spdx": 0,
+      "texts": 15
+    },
+    "declared": "Python-2.0",
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 5,
+          "parties": [
+            "Copyright (c) 2001-2013 Python Software Foundation"
+          ]
+        },
+        "discovered": {
+          "unknown": 3,
+          "expressions": [
+            "Python-2.0"
+          ]
+        },
+        "files": 6
+      }
+    },
+    "score": {
+      "total": 79,
+      "declared": 30,
+      "discovered": 4,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    }
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-05T00:30:36.293Z"
+  },
+  "scores": {
+    "effective": 89,
+    "tool": 59
+  },
+  "_mongo": {
+    "partitionKey": "pypi/pypi/-/backports.ssl_match_hostname/3.5.0.1",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca",
+  "described": {
+    "releaseDate": "2016-08-18",
+    "urls": {
+      "registry": "https://github.com/microsoft/redie",
+      "version": "https://github.com/microsoft/redie/tree/194269b5b7010ad6f8dc4ef608c88128615031ca",
+      "download": "https://github.com/microsoft/redie/archive/194269b5b7010ad6f8dc4ef608c88128615031ca.zip"
+    },
+    "hashes": {
+      "gitSha": "194269b5b7010ad6f8dc4ef608c88128615031ca"
+    },
+    "files": 8,
+    "tools": [
+      "clearlydefined/1.3.0",
+      "reuse/1.2.0",
+      "licensee/9.14.0",
+      "scancode/30.3.0"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "sourceLocation": {
+      "type": "git",
+      "provider": "github",
+      "namespace": "microsoft",
+      "name": "redie",
+      "revision": "194269b5b7010ad6f8dc4ef608c88128615031ca",
+      "url": "https://github.com/microsoft/redie/tree/194269b5b7010ad6f8dc4ef608c88128615031ca"
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "licensed": {
+    "declared": "MIT",
+    "toolScore": {
+      "total": 81,
+      "declared": 30,
+      "discovered": 6,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 6,
+          "parties": [
+            "Copyright (c) Microsoft Corporation"
+          ]
+        },
+        "discovered": {
+          "unknown": 5,
+          "expressions": [
+            "MIT"
+          ]
+        },
+        "files": 8
+      }
+    },
+    "score": {
+      "total": 81,
+      "declared": 30,
+      "discovered": 6,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    }
+  },
+  "coordinates": {
+    "type": "git",
+    "provider": "github",
+    "namespace": "microsoft",
+    "name": "redie",
+    "revision": "194269b5b7010ad6f8dc4ef608c88128615031ca"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-05T00:40:37.509Z"
+  },
+  "scores": {
+    "effective": 90,
+    "tool": 90
+  },
+  "_mongo": {
+    "partitionKey": "git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "npm/npmjs/-/redie/0.3.0",
+  "described": {
+    "releaseDate": "2016-08-18",
+    "sourceLocation": {
+      "type": "git",
+      "provider": "github",
+      "namespace": "Microsoft",
+      "name": "redie",
+      "revision": "194269b5b7010ad6f8dc4ef608c88128615031ca",
+      "url": "https://github.com/Microsoft/redie/tree/194269b5b7010ad6f8dc4ef608c88128615031ca"
+    },
+    "urls": {
+      "registry": "https://npmjs.com/package/redie",
+      "version": "https://npmjs.com/package/redie/v/0.3.0",
+      "download": "https://registry.npmjs.com/redie/-/redie-0.3.0.tgz"
+    },
+    "projectWebsite": "https://github.com/Microsoft/redie",
+    "issueTracker": "https://github.com/Microsoft/redie/issues",
+    "hashes": {
+      "sha1": "48581317ac174ac269c398ff946d6c4779145374",
+      "sha256": "66185c319680ee41268217c2467e314019e8ba4ea4d8374335fbe29e64a8d19f"
+    },
+    "files": 4,
+    "tools": [
+      "clearlydefined/1.3.4",
+      "reuse/1.2.0",
+      "licensee/9.14.0",
+      "scancode/30.3.0"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "licensed": {
+    "declared": "MIT",
+    "toolScore": {
+      "total": 88,
+      "declared": 30,
+      "discovered": 13,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 2,
+          "parties": [
+            "Copyright (c) Microsoft Corporation"
+          ]
+        },
+        "discovered": {
+          "unknown": 1,
+          "expressions": [
+            "MIT"
+          ]
+        },
+        "files": 4
+      }
+    },
+    "score": {
+      "total": 88,
+      "declared": 30,
+      "discovered": 13,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    }
+  },
+  "coordinates": {
+    "type": "npm",
+    "provider": "npmjs",
+    "name": "redie",
+    "revision": "0.3.0"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-05T00:41:06.415Z"
+  },
+  "scores": {
+    "effective": 94,
+    "tool": 94
+  },
+  "_mongo": {
+    "partitionKey": "npm/npmjs/-/redie/0.3.0",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "maven/mavencentral/com.azure/azure-storage-blob/12.20.0",
+  "described": {
+    "releaseDate": "2022-10-12",
+    "sourceLocation": {
+      "type": "sourcearchive",
+      "provider": "mavencentral",
+      "namespace": "com.azure",
+      "name": "azure-storage-blob",
+      "revision": "12.20.0",
+      "url": "https://search.maven.org/remotecontent?filepath=com/azure/azure-storage-blob/12.20.0/azure-storage-blob-12.20.0-sources.jar"
+    },
+    "urls": {
+      "registry": "https://repo1.maven.org/maven2/com/azure/azure-storage-blob",
+      "version": "https://repo1.maven.org/maven2/com/azure/azure-storage-blob/12.20.0",
+      "download": "https://repo1.maven.org/maven2/com/azure/azure-storage-blob/12.20.0/azure-storage-blob-12.20.0.jar"
+    },
+    "hashes": {
+      "sha1": "e682920b0e3115433f25d65b0718f8763035357e",
+      "sha256": "f0976b1d76c184da1372d147fc8fff0bf88cb1e8b9cbeb3dcfa7f48f4aec0816"
+    },
+    "files": 352,
+    "tools": [
+      "clearlydefined/1.5.0",
+      "reuse/1.2.0",
+      "licensee/9.14.0",
+      "scancode/30.3.0"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "licensed": {
+    "declared": "MIT",
+    "toolScore": {
+      "total": 60,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 0
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 351,
+          "parties": [
+            "(c) 2008 VeriSign, Inc."
+          ]
+        },
+        "discovered": {
+          "unknown": 352
+        },
+        "files": 352
+      }
+    },
+    "score": {
+      "total": 60,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 0
+    }
+  },
+  "coordinates": {
+    "type": "maven",
+    "provider": "mavencentral",
+    "namespace": "com.azure",
+    "name": "azure-storage-blob",
+    "revision": "12.20.0"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-11T17:55:57.159Z"
+  },
+  "scores": {
+    "effective": 80,
+    "tool": 80
+  },
+  "_mongo": {
+    "partitionKey": "maven/mavencentral/com.azure/azure-storage-blob/12.20.0",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "maven/mavencentral/org.apache.httpcomponents/httpcore/4.0-beta2",
+  "described": {
+    "releaseDate": "2008-06-20",
+    "sourceLocation": {
+      "type": "sourcearchive",
+      "provider": "mavencentral",
+      "namespace": "org.apache.httpcomponents",
+      "name": "httpcore",
+      "revision": "4.0-beta2",
+      "url": "https://search.maven.org/remotecontent?filepath=org/apache/httpcomponents/httpcore/4.0-beta2/httpcore-4.0-beta2-sources.jar"
+    },
+    "urls": {
+      "registry": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore",
+      "version": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.0-beta2",
+      "download": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.0-beta2/httpcore-4.0-beta2.jar"
+    },
+    "hashes": {
+      "sha1": "b704f30ca9bb4c60fb86f43065167dc8331cd624",
+      "sha256": "f6c0b7e5655852f05d4e444d9eef8a56037a2befdadd0e7c2a4cc74567d6500f"
+    },
+    "files": 163,
+    "tools": [
+      "clearlydefined/1.5.0",
+      "reuse/1.2.0",
+      "licensee/9.14.0",
+      "scancode/30.3.0"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "licensed": {
+    "declared": "Apache-2.0",
+    "toolScore": {
+      "total": 75,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 162,
+          "parties": [
+            "Copyright 2006-2008 The Apache Software Foundation"
+          ]
+        },
+        "discovered": {
+          "unknown": 159,
+          "expressions": [
+            "Apache-2.0"
+          ]
+        },
+        "files": 163
+      }
+    },
+    "score": {
+      "total": 75,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    }
+  },
+  "coordinates": {
+    "type": "maven",
+    "provider": "mavencentral",
+    "namespace": "org.apache.httpcomponents",
+    "name": "httpcore",
+    "revision": "4.0-beta2"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-11T17:55:57.195Z"
+  },
+  "scores": {
+    "effective": 87,
+    "tool": 87
+  },
+  "_mongo": {
+    "partitionKey": "maven/mavencentral/org.apache.httpcomponents/httpcore/4.0-beta2",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "maven/mavencentral/io.quarkiverse.cxf/quarkus-cxf/1.5.4",
+  "described": {
+    "releaseDate": "2022-10-16",
+    "sourceLocation": {
+      "type": "git",
+      "provider": "github",
+      "namespace": "quarkiverse",
+      "name": "quarkiverse-cxf",
+      "revision": "1e395bd4bdfb878708b4c81cfcff86da053190ab",
+      "url": "https://github.com/quarkiverse/quarkiverse-cxf/tree/1e395bd4bdfb878708b4c81cfcff86da053190ab"
+    },
+    "urls": {
+      "registry": "https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf",
+      "version": "https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf/1.5.4",
+      "download": "https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf/1.5.4/quarkus-cxf-1.5.4.jar"
+    },
+    "hashes": {
+      "sha1": "c02458b99b176e1dacd0069dbcbd2288d8535820",
+      "sha256": "db0db2b6e6af5d6fb5cc76454e66db92236b86862c1e74e0d0e01ebbaa64ce63"
+    },
+    "files": 52,
+    "tools": [
+      "clearlydefined/1.5.0",
+      "reuse/1.2.0",
+      "licensee/9.14.0",
+      "scancode/30.3.0"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "licensed": {
+    "declared": "Apache-2.0",
+    "toolScore": {
+      "total": 60,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 0
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 52
+        },
+        "discovered": {
+          "unknown": 52
+        },
+        "files": 52
+      }
+    },
+    "score": {
+      "total": 60,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 0
+    }
+  },
+  "coordinates": {
+    "type": "maven",
+    "provider": "mavencentral",
+    "namespace": "io.quarkiverse.cxf",
+    "name": "quarkus-cxf",
+    "revision": "1.5.4"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-11T17:55:57.204Z"
+  },
+  "scores": {
+    "effective": 80,
+    "tool": 80
+  },
+  "_mongo": {
+    "partitionKey": "maven/mavencentral/io.quarkiverse.cxf/quarkus-cxf/1.5.4",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "maven/mavencentral/io.jenetics/jenetics/7.1.1",
+  "described": {
+    "releaseDate": "2022-10-16",
+    "sourceLocation": {
+      "type": "git",
+      "provider": "github",
+      "namespace": "jenetics",
+      "name": "jenetics",
+      "revision": "9b1ac80db54073b2530996f4a9d195b43dc3fd76",
+      "url": "https://github.com/jenetics/jenetics/tree/9b1ac80db54073b2530996f4a9d195b43dc3fd76"
+    },
+    "urls": {
+      "registry": "https://repo1.maven.org/maven2/io/jenetics/jenetics",
+      "version": "https://repo1.maven.org/maven2/io/jenetics/jenetics/7.1.1",
+      "download": "https://repo1.maven.org/maven2/io/jenetics/jenetics/7.1.1/jenetics-7.1.1.jar"
+    },
+    "hashes": {
+      "sha1": "bdd9f990dcdaef7839e108e3dc228b5cc3f4d4f7",
+      "sha256": "91a2e74e64946b5eb324611f4f9da2679b63a46542d99b87779bca67ddb57b0b"
+    },
+    "files": 223,
+    "tools": [
+      "clearlydefined/1.5.0",
+      "reuse/1.2.0",
+      "licensee/9.14.0",
+      "scancode/30.3.0"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "licensed": {
+    "declared": "Apache-2.0",
+    "toolScore": {
+      "total": 60,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 0
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 223
+        },
+        "discovered": {
+          "unknown": 223
+        },
+        "files": 223
+      }
+    },
+    "score": {
+      "total": 60,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 0
+    }
+  },
+  "coordinates": {
+    "type": "maven",
+    "provider": "mavencentral",
+    "namespace": "io.jenetics",
+    "name": "jenetics",
+    "revision": "7.1.1"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-11T17:55:57.226Z"
+  },
+  "scores": {
+    "effective": 80,
+    "tool": 80
+  },
+  "_mongo": {
+    "partitionKey": "maven/mavencentral/io.jenetics/jenetics/7.1.1",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "maven/mavencentral/org.apache.httpcomponents/httpcore/4.0-alpha5",
+  "described": {
+    "sourceLocation": {
+      "type": "sourcearchive",
+      "provider": "mavencentral",
+      "namespace": "org.apache.httpcomponents",
+      "name": "httpcore",
+      "revision": "4.0-alpha5",
+      "url": "https://search.maven.org/remotecontent?filepath=org/apache/httpcomponents/httpcore/4.0-alpha5/httpcore-4.0-alpha5-sources.jar"
+    },
+    "urls": {
+      "registry": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore",
+      "version": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.0-alpha5",
+      "download": "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.0-alpha5/httpcore-4.0-alpha5.jar"
+    },
+    "hashes": {
+      "sha1": "28e2aaaca5231e2a42bbe2bf6843acd33ec033de",
+      "sha256": "384343101920d44bfe9f29c238ad738baa66fe90adc69c391487b43ce78e0b5a"
+    },
+    "files": 130,
+    "tools": [
+      "clearlydefined/1.5.0",
+      "reuse/1.2.0",
+      "licensee/9.14.0",
+      "scancode/30.3.0"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "licensed": {
+    "declared": "Apache-2.0",
+    "toolScore": {
+      "total": 75,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 129,
+          "parties": [
+            "Copyright 2006-2007 The Apache Software Foundation"
+          ]
+        },
+        "discovered": {
+          "unknown": 127,
+          "expressions": [
+            "Apache-2.0"
+          ]
+        },
+        "files": 130
+      }
+    },
+    "score": {
+      "total": 75,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    }
+  },
+  "coordinates": {
+    "type": "maven",
+    "provider": "mavencentral",
+    "namespace": "org.apache.httpcomponents",
+    "name": "httpcore",
+    "revision": "4.0-alpha5"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-11T17:55:57.649Z"
+  },
+  "scores": {
+    "effective": 87,
+    "tool": 87
+  },
+  "_mongo": {
+    "partitionKey": "maven/mavencentral/org.apache.httpcomponents/httpcore/4.0-alpha5",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "maven/mavencentral/org.flywaydb/flyway-maven-plugin/5.0.7",
+  "described": {
+    "sourceLocation": {
+      "type": "sourcearchive",
+      "provider": "mavencentral",
+      "namespace": "org.flywaydb",
+      "name": "flyway-maven-plugin",
+      "revision": "5.0.7",
+      "url": "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-maven-plugin/5.0.7/flyway-maven-plugin-5.0.7-sources.jar"
+    },
+    "urls": {
+      "registry": "https://repo1.maven.org/maven2/org/flywaydb/flyway-maven-plugin",
+      "version": "https://repo1.maven.org/maven2/org/flywaydb/flyway-maven-plugin/5.0.7",
+      "download": "https://repo1.maven.org/maven2/org/flywaydb/flyway-maven-plugin/5.0.7/flyway-maven-plugin-5.0.7.jar"
+    },
+    "hashes": {
+      "sha1": "f4aa5cb11bdbb086015bbe1e5d5769dd6b008546",
+      "sha256": "34a870031a64991337247e4f74e6cc243c93bac50c4514231b7d8a5672d2d873"
+    },
+    "files": 17,
+    "tools": [
+      "clearlydefined/1.5.0",
+      "licensee/9.14.0",
+      "scancode/30.3.0"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "licensed": {
+    "declared": "NOASSERTION",
+    "toolScore": {
+      "total": 19,
+      "declared": 0,
+      "discovered": 4,
+      "consistency": 0,
+      "spdx": 0,
+      "texts": 15
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 14,
+          "parties": [
+            "Copyright 2010-2018 Boxfuse GmbH",
+            "Copyright (c) 2010-2015 Axel Fontaine"
+          ]
+        },
+        "discovered": {
+          "unknown": 14,
+          "expressions": [
+            "Apache-2.0"
+          ]
+        },
+        "files": 17
+      }
+    },
+    "score": {
+      "total": 19,
+      "declared": 0,
+      "discovered": 4,
+      "consistency": 0,
+      "spdx": 0,
+      "texts": 15
+    }
+  },
+  "coordinates": {
+    "type": "maven",
+    "provider": "mavencentral",
+    "namespace": "org.flywaydb",
+    "name": "flyway-maven-plugin",
+    "revision": "5.0.7"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-11T17:55:57.831Z"
+  },
+  "scores": {
+    "effective": 59,
+    "tool": 59
+  },
+  "_mongo": {
+    "partitionKey": "maven/mavencentral/org.flywaydb/flyway-maven-plugin/5.0.7",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "maven/mavencentral/org.springframework.boot/spring-boot-gradle-plugin/2.6.1",
+  "described": {
+    "releaseDate": "2021-11-29",
+    "sourceLocation": {
+      "type": "git",
+      "provider": "github",
+      "namespace": "spring-projects",
+      "name": "spring-boot",
+      "revision": "a7d2ea3583b162ce9ae37423fdc26f11296384ed",
+      "url": "https://github.com/spring-projects/spring-boot/tree/a7d2ea3583b162ce9ae37423fdc26f11296384ed"
+    },
+    "urls": {
+      "registry": "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-gradle-plugin",
+      "version": "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-gradle-plugin/2.6.1",
+      "download": "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-gradle-plugin/2.6.1/spring-boot-gradle-plugin-2.6.1.jar"
+    },
+    "hashes": {
+      "sha1": "f3cd4a8bc7b5905174fa1171f006fb75d582f822",
+      "sha256": "0047b2bb6509ffef288da650ac9c747641b9474d803d3433f22743853a725359"
+    },
+    "files": 68,
+    "tools": [
+      "clearlydefined/1.5.0",
+      "licensee/9.14.0",
+      "scancode/30.3.0"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "licensed": {
+    "declared": "Apache-2.0",
+    "toolScore": {
+      "total": 75,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 67,
+          "parties": [
+            "Copyright (c) 2012-2021 Pivotal, Inc."
+          ]
+        },
+        "discovered": {
+          "unknown": 66,
+          "expressions": [
+            "Apache-2.0"
+          ]
+        },
+        "files": 68
+      }
+    },
+    "score": {
+      "total": 75,
+      "declared": 30,
+      "discovered": 0,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 15
+    }
+  },
+  "coordinates": {
+    "type": "maven",
+    "provider": "mavencentral",
+    "namespace": "org.springframework.boot",
+    "name": "spring-boot-gradle-plugin",
+    "revision": "2.6.1"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.1",
+    "updated": "2023-01-11T17:55:57.837Z"
+  },
+  "scores": {
+    "effective": 87,
+    "tool": 87
+  },
+  "_mongo": {
+    "partitionKey": "maven/mavencentral/org.springframework.boot/spring-boot-gradle-plugin/2.6.1",
+    "page": 1,
+    "totalPages": 1
+  }
+},{
+  "_id": "npm/npmjs/-/angular/1.6.9",
+  "described": {
+    "releaseDate": "2018-02-02",
+    "sourceLocation": {
+      "type": "git",
+      "provider": "github",
+      "url": "https://github.com/angular/angular.js/tree/c3c5c5eea2eeff82b1ae6c855a4508f8ff51cedc",
+      "revision": "c3c5c5eea2eeff82b1ae6c855a4508f8ff51cedc",
+      "namespace": "angular",
+      "name": "angular.js"
+    },
+    "urls": {
+      "registry": "https://npmjs.com/package/angular",
+      "version": "https://npmjs.com/package/angular/v/1.6.9",
+      "download": "https://registry.npmjs.com/angular/-/angular-1.6.9.tgz"
+    },
+    "projectWebsite": "http://angularjs.org",
+    "issueTracker": "https://github.com/angular/angular.js/issues",
+    "tools": [
+      "clearlydefined/1",
+      "scancode/2.2.1"
+    ],
+    "toolScore": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    },
+    "score": {
+      "total": 100,
+      "date": 30,
+      "source": 70
+    }
+  },
+  "licensed": {
+    "declared": "MIT",
+    "toolScore": {
+      "total": 68,
+      "declared": 30,
+      "discovered": 8,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 0
+    },
+    "facets": {
+      "core": {
+        "attribution": {
+          "unknown": 2,
+          "parties": [
+            "Copyright (c) 2016 Angular",
+            "(c) 2010-2018 Google, Inc. http://angularjs.org",
+            "Copyright (c) 2010-2015 Google, Inc. http://angularjs.org"
+          ]
+        },
+        "discovered": {
+          "unknown": 3,
+          "expressions": [
+            "MIT"
+          ]
+        },
+        "files": 6
+      }
+    },
+    "score": {
+      "total": 68,
+      "declared": 30,
+      "discovered": 8,
+      "consistency": 15,
+      "spdx": 15,
+      "texts": 0
+    }
+  },
+  "coordinates": {
+    "type": "npm",
+    "provider": "npmjs",
+    "name": "angular",
+    "revision": "1.6.9"
+  },
+  "_meta": {
+    "schemaVersion": "1.6.0",
+    "updated": "2019-03-11T14:25:35.991Z"
+  },
+  "scores": {
+    "effective": 84,
+    "tool": 84
+  },
+  "_mongo": {
+    "partitionKey": "npm/npmjs/-/angular/1.6.9",
+    "page": 1,
+    "totalPages": 1
+  }
+}]

--- a/test/providers/store/mongoDefinitionPagination.js
+++ b/test/providers/store/mongoDefinitionPagination.js
@@ -1,0 +1,302 @@
+// (c) Copyright 2023, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const Store = require('../../../providers/stores/mongo')
+const EntityCoordinates = require('../../../lib/entityCoordinates')
+const { MongoMemoryServer } = require('mongodb-memory-server')
+const fsPromise = require('fs/promises')
+const path = require('path')
+const { uniq } = require('lodash')
+
+const dbOptions = {
+  dbName: 'clearlydefined',
+  collectionName: 'definitions-paged',
+  logger: {
+    debug: () => {}
+  }
+}
+
+describe('Mongo Definition store: search pagination', () => {
+  const mongoServer = new MongoMemoryServer()
+  let mongoStore
+
+  before('setup database', async () => {
+    await mongoServer.start()
+    const uri = await mongoServer.getUri()
+    const options = {
+      ...dbOptions,
+      connectionString: uri
+    }
+    mongoStore = Store(options)
+    await mongoStore.initialize()
+
+    await setupStore(mongoStore)
+  })
+
+  after('cleanup database', async () => {
+    await mongoStore.collection.drop()
+    await mongoStore.close()
+    await mongoServer.stop()
+  })
+
+  it('should fetch records without sort continuously', async function() {
+    //filter: {'_mongo.page': 1}
+    //sort: {'_mongo.partitionKey': 1}
+    const expected = [
+      'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca', 
+      'maven/mavencentral/com.azure/azure-storage-blob/12.20.0', 
+      'maven/mavencentral/io.jenetics/jenetics/7.1.1',
+      'maven/mavencentral/io.quarkiverse.cxf/quarkus-cxf/1.5.4',
+      'maven/mavencentral/org.apache.httpcomponents/httpcore/4.0-alpha5'
+    ]
+    const query = {}
+    const defs = await fetchAll(mongoStore, query, 5)
+    expect(defs.length).to.be.equal(12)
+    const coordinates = verifyUniqueCoordinates(defs)
+    verifyExpectedCoordinates(coordinates, expected)
+  })
+
+  it('should sort ascending on releaseDate and find 1 page of records', async function() {
+    //filter: {'_mongo.page': 1}
+    //sort: {'described.releaseDate': 1,'_mongo.partitionKey': 1}
+    const expected = ['maven/mavencentral/org.apache.httpcomponents/httpcore/4.0-alpha5']
+    const query = {
+      sort: 'releaseDate',
+      sortDesc: false
+    }
+    const defs = await fetchUpToNTimes(mongoStore, query, 1)
+    expect(defs.length).to.be.equal(1)
+    const coordinates = verifyUniqueCoordinates(defs)
+    verifyExpectedCoordinates(coordinates, expected)
+  })
+
+  it('should sort ascending on releaseDate and handle null and non null values in continuation', async function() {
+    //filter: {'_mongo.page': 1}
+    //sort: {'described.releaseDate': 1, '_mongo.partitionKey': 1}
+    const expected = [
+      'maven/mavencentral/org.apache.httpcomponents/httpcore/4.0-alpha5', 
+      'maven/mavencentral/org.flywaydb/flyway-maven-plugin/5.0.7', 
+      'npm/npmjs/@sinclair/typebox/0.24.45', 
+      'maven/mavencentral/org.apache.httpcomponents/httpcore/4.0-beta2',
+      'pypi/pypi/-/backports.ssl_match_hostname/3.5.0.1']
+
+    const query = {
+      sort: 'releaseDate',
+      sortDesc: false
+    }
+    const defs = await fetchAll(mongoStore, query)
+    expect(defs[0].described.releaseDate).not.to.be.ok
+    expect(defs[3].described.releaseDate).to.be.ok
+
+    expect(defs.length).to.be.equal(12)
+    const coordinates = verifyUniqueCoordinates(defs)
+    verifyExpectedCoordinates(coordinates, expected)
+  })
+  
+  it('should sort descending on releaseDate and handle null and non null values in continuation', async function() {
+    const query = {
+      sort: 'releaseDate',
+      sortDesc: true
+    }
+    const defs = await fetchAll(mongoStore, query)
+    expect(defs.length).to.be.equal(12)
+    verifyUniqueCoordinates(defs)
+  })
+
+  it('should sort ascending on license and handle null and non null values in continuation ', async function() {
+    //filter: {'_mongo.page': 1}
+    //sort: {'licensed.declared': 1, '_mongo.partitionKey': 1}
+    const expected = [
+      'npm/npmjs/@sinclair/typebox/0.24.45', 
+      'maven/mavencentral/io.jenetics/jenetics/7.1.1', 
+      'maven/mavencentral/io.quarkiverse.cxf/quarkus-cxf/1.5.4', 
+      'maven/mavencentral/org.apache.httpcomponents/httpcore/4.0-alpha5', 
+      'maven/mavencentral/org.apache.httpcomponents/httpcore/4.0-beta2']
+
+    const query = {
+      sort: 'license',
+      sortDesc: false
+    }
+    const defs = await fetchAll(mongoStore, query)
+    expect(defs[0].described.releaseDate).not.to.be.ok
+    expect(defs[1].described.releaseDate).to.be.ok
+    expect(defs.length).to.be.equal(12)
+    const coordinates = verifyUniqueCoordinates(defs)
+    verifyExpectedCoordinates(coordinates, expected)
+  })
+
+  it('should sort descending on license and handle null and non null values in continuation ', async function() {
+    const query = {
+      sort: 'license',
+      sortDesc: true
+    }
+    const defs = await fetchAll(mongoStore, query)
+    expect(defs.length).to.be.equal(12)
+    verifyUniqueCoordinates(defs)
+  })
+
+  it('should filter and sort ascending on multiple keys and handle null and non null namespace in continuation', async function() {
+    //filter: {'licensed.declared': 'MIT', '_mongo.page': 1}
+    //sort: {'coordinates.namespace': 1, 'coordinates.name':1, 'coordinates.revision': 1, '_mongo.partitionKey': 1}
+    const expected = [
+      'npm/npmjs/-/angular/1.6.9', 
+      'npm/npmjs/-/redie/0.3.0', 
+      'maven/mavencentral/com.azure/azure-storage-blob/12.20.0', 
+      'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca']
+   
+    const query = {
+      license: 'MIT',
+      sort: 'namespace',
+      sortDesc: false
+    }
+    const defs = await fetchAll(mongoStore, query)
+    expect(defs[0].coordinates.namespace).not.to.be.ok
+    expect(defs[2].coordinates.namespace).to.be.ok
+    expect(defs.length).to.be.equal(4)
+    const coordinates = verifyUniqueCoordinates(defs)
+    verifyExpectedCoordinates(coordinates, expected)
+  })
+
+  it('should filter and sort descending on multiple keys in continuation', async function() {
+    //filter: {'licensed.declared': 'MIT', '_mongo.page': 1}
+    //sort: {'coordinates.namespace': -1, 'coordinates.name':-1, 'coordinates.revision': -1, '_mongo.partitionKey': 1}
+    const expected = [
+      'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca',
+      'maven/mavencentral/com.azure/azure-storage-blob/12.20.0', 
+      'npm/npmjs/-/redie/0.3.0', 
+      'npm/npmjs/-/angular/1.6.9']
+   
+    const query = {
+      license: 'MIT',
+      sort: 'namespace',
+      sortDesc: true
+    }
+    const defs = await fetchAll(mongoStore, query)
+    expect(defs.length).to.be.equal(4)
+    const coordinates = verifyUniqueCoordinates(defs)
+    verifyExpectedCoordinates(coordinates, expected)
+  })
+
+  it('should filter and sort on numerical scores and fetch continuously', async function() {
+    //filter: {'licensed.declared': 'MIT', '_mongo.page': 1}
+    //sort: {'scores.tool': 1, '_mongo.partitionKey': 1}
+    const expected = [
+      'maven/mavencentral/com.azure/azure-storage-blob/12.20.0', 
+      'npm/npmjs/-/angular/1.6.9', 
+      'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca', 
+      'npm/npmjs/-/redie/0.3.0']
+  
+    const query = {
+      license: 'MIT',
+      sort: 'toolScore',
+      sortDesc: false
+    }
+    const defs = await fetchAll(mongoStore, query)
+    expect(defs.length).to.be.equal(4)
+    expect(defs[0].scores.tool).to.be.equal(80)
+    expect(defs[1].scores.tool).to.be.equal(84)
+    expect(defs[2].scores.tool).to.be.equal(90)
+    expect(defs[3].scores.tool).to.be.equal(94)
+    const coordinates = verifyUniqueCoordinates(defs)
+    verifyExpectedCoordinates(coordinates, expected)
+  })
+
+  it('should filter and sort descending on numerical scores and fetch continuously', async function() {
+    //filter: {'licensed.declared': 'MIT', '_mongo.page': 1}
+    //sort: {'scores.tool': -1, '_mongo.partitionKey': 1}
+    const expected = [
+      'npm/npmjs/-/redie/0.3.0',
+      'git/github/microsoft/redie/194269b5b7010ad6f8dc4ef608c88128615031ca', 
+      'npm/npmjs/-/angular/1.6.9', 
+      'maven/mavencentral/com.azure/azure-storage-blob/12.20.0'
+    ]
+  
+    const query = {
+      license: 'MIT',
+      sort: 'toolScore',
+      sortDesc: true
+    }
+    const defs = await fetchAll(mongoStore, query)
+    expect(defs.length).to.be.equal(4)
+    const coordinates = verifyUniqueCoordinates(defs)
+    verifyExpectedCoordinates(coordinates, expected)
+  })
+
+})
+
+async function setupStore(mongoStore) {
+  const fileName = path.join(__dirname, '../../fixtures/store/definitions-paged-no-files')
+  const content = await fsPromise.readFile(fileName)
+  const defDump =  JSON.parse(content.toString())
+  await mongoStore.collection.createIndex({ '_mongo.partitionKey': 1 })
+  await mongoStore.collection.insertMany(defDump)
+}
+
+function verifyExpectedCoordinates(allCoordinates, expected) {
+  const firstCoordinates = allCoordinates.slice(0, expected.length)
+  expect(firstCoordinates).to.be.deep.equal(expected)
+}
+
+function verifyUniqueCoordinates(defs) {
+  const allCoordinates = defs.map(e => EntityCoordinates.fromObject(e.coordinates).toString())
+  const uniqTokens = uniq(allCoordinates)
+  expect(uniqTokens.length).to.be.equal(allCoordinates.length)
+  return allCoordinates
+}
+
+async function fetchAll(mongoStore, query, pageSize) {
+  return fetchUpToNTimes(mongoStore, query, Number.MAX_SAFE_INTEGER, pageSize)
+}
+
+//Default pageSize set to 1 to verify null value handling
+async function fetchUpToNTimes(mongoStore, query, nTimes, pageSize = 1) {
+  const allData = []
+  const fetchOperation = async (params) => {
+    const { continuationToken, ...query } = params
+    const result = await mongoStore.find(query, continuationToken, pageSize)
+    allData.push(...result.data)
+    return result
+  }
+  await new ContinousFetch(fetchOperation).fetchUpToNtimes(query, nTimes)
+  return allData
+}
+
+class ContinousFetch {
+  constructor(fetchOperation, delay = 0) {
+    this._fetchOperation = fetchOperation
+    this._delay = delay
+  }
+
+  async fetchBatch(params) {
+    const { data, continuationToken } = await this._fetchOperation(params)
+    return { continuationToken, count: data.length }
+  }
+
+  _delayedFetch(params) {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        this.fetchBatch(params)
+          .then(retrieved => resolve(retrieved))
+          .catch(error => reject(error))
+      }, this._delay)
+    })
+  }
+
+  async fetchUpToNtimes(params, nTime) {
+    let dispatchCounter = 0, fetchedCounter = 0
+    let retrieved = {}
+
+    while (dispatchCounter < nTime) {
+      retrieved = await this._delayedFetch({
+        ...params,
+        continuationToken: retrieved.continuationToken })
+
+      fetchedCounter += retrieved.count
+      dispatchCounter ++
+
+      if (!retrieved.continuationToken) break
+    }
+    return fetchedCounter
+  }
+}


### PR DESCRIPTION
The continuation token was generated based on _mongo.partitionKey. This is correct when _mongo.partitionKey is the only sort field.  When there are other sort fields in the query, the sequence of records are influenced by those fields. Continuation token based on only _mongo.partitionKey value does not produce the correct results for next pages.

There is a npm package on "cursor based pagination": https://www.npmjs.com/package/mongo-cursor-pagination The library supports one "paginatedField".  The ClearlyDefined api supports sort resulting in multiple sort fields. For example: sort on namespace sorts on three fields: ['coordinates.namespace', 'coordinates.name', 'coordinates.revision'].  So the library is not sufficient for CD's need.

To generate the correct next page, the continuation token needs to record all the values for sort fields. As an extension of existing logic, _mongo.partitionKey will always be included to the sort fields as a tie breaker. Also added logic to generate pagination query based on multiple sort values.

Task: https://github.com/clearlydefined/service/issues/670