### PR TITLE
Fix NoAssertion for some composer components

### DIFF
--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -378,6 +378,20 @@ describe('Aggregation service', () => {
       expect(aggregated.licensed.declared, `${testcase.name}-${testcase.version}`).to.eq(testcase.expected)
     }
   })
+
+  it('should handle composer/packagist components', () => {
+    const tools = [['clearlydefined', 'licensee', 'scancode', 'reuse']]
+    const coordSpec = 'composer/packagist/mmucklo/krumo/0.7.0'
+    const coords = EntityCoordinates.fromString(coordSpec)
+    const raw = require(`./evidence/${coordSpec.replace(/\//g, '-')}.json`)
+
+    const summary_options = {}
+    const summaryService = SummaryService(summary_options)
+    const summaries = summaryService.summarizeAll(coords, raw)
+    const { service } = setupAggregatorWithParams(coordSpec, tools)
+    const aggregated = service.process(summaries, coords)
+    expect(aggregated.licensed.declared).to.be.equal('LGPL-2.1-only')
+  })
 })
 
 function validate(definition) {

--- a/test/business/evidence/composer-packagist-mmucklo-krumo-0.7.0.json
+++ b/test/business/evidence/composer-packagist-mmucklo-krumo-0.7.0.json
@@ -1,0 +1,3386 @@
+{
+  "clearlydefined": {
+    "1.2.0": {
+      "_metadata": {
+        "type": "composer",
+        "url": "cd:/composer/packagist/mmucklo/krumo/0.7.0",
+        "fetchedAt": "2023-01-27T00:48:53.788Z",
+        "links": {
+          "self": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:clearlydefined:1.2.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:clearlydefined",
+            "type": "collection"
+          },
+          "licensee": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:licensee",
+            "type": "collection"
+          },
+          "scancode": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:scancode",
+            "type": "collection"
+          },
+          "reuse": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:reuse",
+            "type": "collection"
+          },
+          "source": {
+            "href": "urn:git:github:mmucklo:krumo:revision:29a6fada283f430bf3a7d87f981da61979c33d2e",
+            "type": "resource"
+          }
+        },
+        "schemaVersion": "1.2.0",
+        "toolVersion": "1.0.0",
+        "processedAt": "2023-01-27T00:48:54.139Z"
+      },
+      "attachments": [
+        {
+          "path": "mmucklo-krumo-29a6fad/LICENSE",
+          "token": "6f679d0555a9a5aad08a4e88cdba552cf62bb46585084572f3cfd1b0c7e6ec4f"
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/composer.json",
+          "token": "8169b7e4284c96202e7ae099134b8e3c4d617b94e47372fcdb5ff57e952e12d3"
+        }
+      ],
+      "summaryInfo": {
+        "k": 176,
+        "count": 33,
+        "hashes": {
+          "sha1": "f5f271e1a2dbc0eeb68dcaf33f68ff1889a6b47b",
+          "sha256": "b64983020c8cf320ac5e5ee2568b75b808dc676742247e03d20d63d9c2146a11"
+        }
+      },
+      "files": [
+        {
+          "path": "mmucklo-krumo-29a6fad/.gitignore",
+          "hashes": {
+            "sha1": "7e0dd40118b594772525831a55766b72986a323c",
+            "sha256": "5b2bcc4a1f948bd580add96cc77838eeee4fb6b187b3864105a698f36c0834c7"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/LICENSE",
+          "hashes": {
+            "sha1": "65c71b7ff77a59a32247d83a528728637263c1b5",
+            "sha256": "6f679d0555a9a5aad08a4e88cdba552cf62bb46585084572f3cfd1b0c7e6ec4f"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/README.md",
+          "hashes": {
+            "sha1": "1126638450470af69b37e6e82cafe632cf13ba51",
+            "sha256": "7d9e2f43195a083f03ffe1f710b45e910a9df3f9202a49f2ec2a7930eb415b6b"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/class.krumo.php",
+          "hashes": {
+            "sha1": "c2abce21f9e4eab6cf3b09c8151a50558b215afd",
+            "sha256": "3931aa89881e51284faa4551030e87aa61996dcf5c228a049640801c30be9859"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/composer.json",
+          "hashes": {
+            "sha1": "6cb2bbdcf3523410605775a8f28983bfcbb54bee",
+            "sha256": "8169b7e4284c96202e7ae099134b8e3c4d617b94e47372fcdb5ff57e952e12d3"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/icons/information.png",
+          "hashes": {
+            "sha1": "04b482344d75d0732275727bd73cceb9b049d276",
+            "sha256": "ff9c48d8c2d063932c7aadd5e15ddfdc76b7111bf0715f3a192bba26df2c531c"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/js/krumo.js",
+          "hashes": {
+            "sha1": "e65b0abbf6120699980dce4abcda17cdd6f72ff6",
+            "sha256": "11f3082f82dd86b8d8651cb9fb3f4011d08c2be76bc76e20517f5fd21e4bfaae"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/js/krumo.min.js",
+          "hashes": {
+            "sha1": "c30c745f5ca221304ff6185d3b1f73c173f03ce7",
+            "sha256": "c82eff828b943a618df4b09cbe00662609e525b3175e49fea586bec4e8408fd6"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/krumo.sample.ini",
+          "hashes": {
+            "sha1": "d6d23e621e217e2cac70538cc32ba9a6ac95777a",
+            "sha256": "03ecb74995c0403469dddbd82804c305d2f33021cc730197d472683bebca11e0"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/phpmd.xml",
+          "hashes": {
+            "sha1": "09f0a2ef79f4618d2e5a43908e92c901259a3617",
+            "sha256": "2e028da54f110e28d1cc5bb8287800a90098d0c01dac6cbefc2f0aef6aadc591"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/blue/bg.gif",
+          "hashes": {
+            "sha1": "30f5b4191609bfadea746b20fede640887b0f1bc",
+            "sha256": "4e5e9c025a77eb3bceb3e80daf49d9a66edd9005e4a7bf13e5fa394adcc0888c"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/blue/skin.css",
+          "hashes": {
+            "sha1": "7f7cf673d89ee1c808d7b1cb2f4908552505da29",
+            "sha256": "d62f98929f2060fed0177539a19ffaf16ea50b1db1e53ed5ce6f20381f8ebfb1"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/blue/skin.unminified.css",
+          "hashes": {
+            "sha1": "ed0d30ae326cc206aad55fd879d9f28e7bcef4da",
+            "sha256": "ed2ec5160598346de4b5754719fd2d3d0329367e8b8920464df8add0c10ff36b"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/default/bg.gif",
+          "hashes": {
+            "sha1": "700e1fbb731a8b21cd5513a1f632136f53fe7f17",
+            "sha256": "7d4af4e005c3b2a9a63e2505e62ee352eb49c6256a1adc4cd21463d7c0c147f6"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/default/skin.css",
+          "hashes": {
+            "sha1": "a19b6f8338339bdc72b45ef97edd19613480e5ad",
+            "sha256": "f508e46b7c7ab5c733bdbabf605e840fddfcedd256fcfb693d18a1e6f49749cd"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/green/bg.gif",
+          "hashes": {
+            "sha1": "870a05ac94ea9b6a81eadeeffb6a54680c62162e",
+            "sha256": "c37c6336daf3abf58f22e3c599334920e7af1e5893245a34b174c8250fea7de8"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/green/skin.css",
+          "hashes": {
+            "sha1": "87b056e0a132f3fd9603c98f7eb5910a38d6c7b7",
+            "sha256": "bd4f23575265fb0fa8b247a4e63ae2e3267b3c5145586b58a43b7e5209e447db"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/green/skin.unminified.css",
+          "hashes": {
+            "sha1": "4452511b4031d4f6e093f166a2e8052378f8a00e",
+            "sha256": "15404cbcb453b7dc09e5c6fd30615e99ec84d265b74e3d10979a2ed9522e6d70"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/modern/skin.css",
+          "hashes": {
+            "sha1": "f4b62b610f5477acc5483414d891dce8be8a1006",
+            "sha256": "9e0981c666743fcd4db419d1bce9f0fc1af145dd0fb483dcbc748e6b5ecdbd99"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/modern/skin.unminified.css",
+          "hashes": {
+            "sha1": "cd632c9004147618b44e97fb51b04428504e6156",
+            "sha256": "ff935913d5b998f12a0c867dc43c024e0997a1d499331a6d2b80b4b4d863266e"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/orange/skin.css",
+          "hashes": {
+            "sha1": "09cbcad13a75be23825ef997b321be796ac495ed",
+            "sha256": "f9e4205f13b5da3224ffd5a3c91089647b16c84ff7f4fa97585da221e98fff75"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/orange/skin.unminified.css",
+          "hashes": {
+            "sha1": "80ee31914e76fa3cd728680228ba5040927dab1b",
+            "sha256": "0a55c29ca7b1e0186bfd12d4c66e56e97d9ec04bcc1b68bfd60bfec283fff879"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/schablon.com/collapsed.gif",
+          "hashes": {
+            "sha1": "a57040f6ca02950fd2bac6b25a4f97df88a2c25c",
+            "sha256": "f5caf9ab93ea5b7a328398cfbc21260bbc0cc9f26148cd18bc09c11943b345eb"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/schablon.com/dotted.gif",
+          "hashes": {
+            "sha1": "ee2e3cdf195f2f9649882576dd2c1717f0dd4352",
+            "sha256": "57c3396301215899e29335076f0a76ed3cb75c2f26c0ef88dc2d5bccbe35d4ae"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/schablon.com/empty.gif",
+          "hashes": {
+            "sha1": "3f7e39397fdd90196619d5dd3831c086e81650f6",
+            "sha256": "318d344eba97116021d42482f2c2cebe3d6f6a5fba7b459f7e914751584a6eef"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/schablon.com/expanded.gif",
+          "hashes": {
+            "sha1": "c3b94c2c4ee2bf215d2c518d629bd573442d3514",
+            "sha256": "7aed071622594189ded0d863a585429f3a24e7c930cc97e393ed5dd78943f5ce"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/schablon.com/skin.css",
+          "hashes": {
+            "sha1": "2e7234cdac65f7cc4f39e716d8349e6594e33cd4",
+            "sha256": "05786fbbc52ddb3f5159a8734dc5316fb29360946ae8a36461d6d42f0c682238"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/schablon.com/skin.unminified.css",
+          "hashes": {
+            "sha1": "b6f72c9ba70633c95cf14dd9182b90ef51bab974",
+            "sha256": "a1e2885f62b4ca08ceb426b10940a73fd0dcc1f569971277f114e3b73f63fa7e"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/stylish/skin.css",
+          "hashes": {
+            "sha1": "83fbbed368302d10d561d0d76259ef36f9c73e45",
+            "sha256": "bcbb3113c9fdea76edb0dd0f8710ded3b9b771e49587f5b42714353b41947485"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/skins/stylish/skin.unminified.css",
+          "hashes": {
+            "sha1": "e8ef5085ed7b5ecd87d126b406e099bdcf4b1e51",
+            "sha256": "1a1eec29232dc59e57b2325b0975cae3f818a462f4e42987e581c31dd8725e6b"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/tests/php/class.php",
+          "hashes": {
+            "sha1": "92a0f2004cbb650cfccfbb7e9e0a1b38ff083f81",
+            "sha256": "8eac035934010deb6cc7b79e6c452349cc16a50ae85fcf6277442f94bbf1e51b"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/tests/php/misc.php",
+          "hashes": {
+            "sha1": "06e641ceeee54fcf825c8a45ae2dfdf9b406b96b",
+            "sha256": "7da49a4e5d07fa9fb18ad3dcfd660455edf680478617a002003efaa7252a9334"
+          }
+        },
+        {
+          "path": "mmucklo-krumo-29a6fad/tests/php/object.php",
+          "hashes": {
+            "sha1": "fc0ff74960198bc2bd2f8411bfe6a93363ffe041",
+            "sha256": "693b991939f1b3658f4d57cbf66e25fa314e7b5818a1becfd6a3ed561f2340dc"
+          }
+        }
+      ],
+      "composer.json": {
+        "name": "mmucklo/krumo",
+        "type": "library",
+        "description": "KRUMO - version 2.0 of print_r(); and var_dump(); (with new updates)",
+        "license": "LGPL",
+        "keywords": [
+          "debug",
+          "debugging",
+          "pretty",
+          "print",
+          "print_r",
+          "var_dump",
+          "krumo"
+        ],
+        "authors": [
+          {
+            "name": "Kaloyan K. Tsvetkov",
+            "email": "kaloyan@kaloyan.info"
+          },
+          {
+            "name": "Matthew J. Mucklo",
+            "email": "mmucklo@gmail.com"
+          },
+          {
+            "name": "Stefan Thomas",
+            "email": "moon@justmoon.de"
+          },
+          {
+            "name": "Scott Baker",
+            "email": "scott@perturb.org"
+          }
+        ],
+        "require": {
+          "php": ">=7.0"
+        },
+        "require-dev": {
+          "fabpot/php-cs-fixer": "dev-master",
+          "phpmd/phpmd": "dev-master"
+        },
+        "autoload": {
+          "files": [
+            "class.krumo.php"
+          ]
+        }
+      },
+      "registryData": {
+        "manifest": {
+          "name": "mmucklo/krumo",
+          "description": "KRUMO - version 2.0 of print_r(); and var_dump(); (with new updates)",
+          "keywords": [
+            "debug",
+            "debugging",
+            "pretty",
+            "print",
+            "print_r",
+            "var_dump",
+            "krumo"
+          ],
+          "homepage": "",
+          "version": "v0.7.0",
+          "version_normalized": "0.7.0.0",
+          "license": [
+            "LGPL"
+          ],
+          "authors": [
+            {
+              "name": "Kaloyan K. Tsvetkov",
+              "email": "kaloyan@kaloyan.info"
+            },
+            {
+              "name": "Matthew J. Mucklo",
+              "email": "mmucklo@gmail.com"
+            },
+            {
+              "name": "Stefan Thomas",
+              "email": "moon@justmoon.de"
+            },
+            {
+              "name": "Scott Baker",
+              "email": "scott@perturb.org"
+            }
+          ],
+          "source": {
+            "url": "https://github.com/mmucklo/krumo.git",
+            "type": "git",
+            "reference": "29a6fada283f430bf3a7d87f981da61979c33d2e"
+          },
+          "dist": {
+            "url": "https://api.github.com/repos/mmucklo/krumo/zipball/29a6fada283f430bf3a7d87f981da61979c33d2e",
+            "type": "zip",
+            "shasum": "",
+            "reference": "29a6fada283f430bf3a7d87f981da61979c33d2e"
+          },
+          "type": "library",
+          "time": "2022-08-07T01:49:32+00:00",
+          "autoload": {
+            "files": [
+              "class.krumo.php"
+            ]
+          },
+          "require": {
+            "php": ">=7.0"
+          },
+          "require-dev": {
+            "fabpot/php-cs-fixer": "dev-master",
+            "phpmd/phpmd": "dev-master"
+          },
+          "uid": 6475248
+        },
+        "releaseDate": "2022-08-07T01:49:32+00:00"
+      },
+      "sourceInfo": {
+        "type": "git",
+        "provider": "github",
+        "namespace": "mmucklo",
+        "name": "krumo",
+        "revision": "29a6fada283f430bf3a7d87f981da61979c33d2e",
+        "url": null,
+        "path": null
+      }
+    }
+  },
+  "licensee": {
+    "9.14.0": {
+      "_metadata": {
+        "type": "licensee",
+        "url": "cd:/composer/packagist/mmucklo/krumo/0.7.0",
+        "fetchedAt": "2023-01-27T00:48:54.732Z",
+        "links": {
+          "self": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:licensee:9.14.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:licensee",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "9.14.0",
+        "toolVersion": "9.12.0",
+        "processedAt": "2023-01-27T00:48:55.218Z"
+      },
+      "licensee": {
+        "version": "9.12.0",
+        "parameters": [
+          "--json",
+          "--no-readme"
+        ],
+        "output": {
+          "contentType": "application/json",
+          "content": {
+            "licenses": [
+              {
+                "key": "lgpl-2.1",
+                "spdx_id": "LGPL-2.1",
+                "meta": {
+                  "title": "GNU Lesser General Public License v2.1",
+                  "source": "https://spdx.org/licenses/LGPL-2.1.html",
+                  "description": "Primarily used for software libraries, the GNU LGPL requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction. There are two commonly used versions of the GNU LGPL.",
+                  "how": "Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.",
+                  "using": null,
+                  "featured": false,
+                  "hidden": false,
+                  "nickname": "GNU LGPLv2.1",
+                  "note": "The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license."
+                },
+                "url": "http://choosealicense.com/licenses/lgpl-2.1/",
+                "rules": {
+                  "permissions": [
+                    {
+                      "tag": "commercial-use",
+                      "label": "Commercial use",
+                      "description": "This software and derivatives may be used for commercial purposes."
+                    },
+                    {
+                      "tag": "modifications",
+                      "label": "Modification",
+                      "description": "This software may be modified."
+                    },
+                    {
+                      "tag": "distribution",
+                      "label": "Distribution",
+                      "description": "This software may be distributed."
+                    },
+                    {
+                      "tag": "private-use",
+                      "label": "Private use",
+                      "description": "This software may be used and modified in private."
+                    }
+                  ],
+                  "conditions": [
+                    {
+                      "tag": "include-copyright",
+                      "label": "License and copyright notice",
+                      "description": "A copy of the license and copyright notice must be included with the software."
+                    },
+                    {
+                      "tag": "disclose-source",
+                      "label": "Disclose source",
+                      "description": "Source code must be made available when the software is distributed."
+                    },
+                    {
+                      "tag": "document-changes",
+                      "label": "State changes",
+                      "description": "Changes made to the code must be documented."
+                    },
+                    {
+                      "tag": "same-license--library",
+                      "label": "Same license (library)",
+                      "description": "Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used, or this condition may not apply to works that use the software as a library."
+                    }
+                  ],
+                  "limitations": [
+                    {
+                      "tag": "liability",
+                      "label": "Liability",
+                      "description": "This license includes a limitation of liability."
+                    },
+                    {
+                      "tag": "warranty",
+                      "label": "Warranty",
+                      "description": "The license explicitly states that it does NOT provide any warranty."
+                    }
+                  ]
+                },
+                "fields": [],
+                "other": false,
+                "gpl": false,
+                "lgpl": true,
+                "cc": false
+              }
+            ],
+            "matched_files": [
+              {
+                "filename": "mmucklo-krumo-29a6fad/LICENSE",
+                "content": "\t\t  GNU LESSER GENERAL PUBLIC LICENSE\n\t\t       Version 2.1, February 1999\n\n Copyright (C) 1991, 1999 Free Software Foundation, Inc.\n     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA\n Everyone is permitted to copy and distribute verbatim copies\n of this license document, but changing it is not allowed.\n\n[This is the first released version of the Lesser GPL.  It also counts\n as the successor of the GNU Library Public License, version 2, hence\n the version number 2.1.]\n\n\t\t\t    Preamble\n\n  The licenses for most software are designed to take away your\nfreedom to share and change it.  By contrast, the GNU General Public\nLicenses are intended to guarantee your freedom to share and change\nfree software--to make sure the software is free for all its users.\n\n  This license, the Lesser General Public License, applies to some\nspecially designated software packages--typically libraries--of the\nFree Software Foundation and other authors who decide to use it.  You\ncan use it too, but we suggest you first think carefully about whether\nthis license or the ordinary General Public License is the better\nstrategy to use in any particular case, based on the explanations below.\n\n  When we speak of free software, we are referring to freedom of use,\nnot price.  Our General Public Licenses are designed to make sure that\nyou have the freedom to distribute copies of free software (and charge\nfor this service if you wish); that you receive source code or can get\nit if you want it; that you can change the software and use pieces of\nit in new free programs; and that you are informed that you can do\nthese things.\n\n  To protect your rights, we need to make restrictions that forbid\ndistributors to deny you these rights or to ask you to surrender these\nrights.  These restrictions translate to certain responsibilities for\nyou if you distribute copies of the library or if you modify it.\n\n  For example, if you distribute copies of the library, whether gratis\nor for a fee, you must give the recipients all the rights that we gave\nyou.  You must make sure that they, too, receive or can get the source\ncode.  If you link other code with the library, you must provide\ncomplete object files to the recipients, so that they can relink them\nwith the library after making changes to the library and recompiling\nit.  And you must show them these terms so they know their rights.\n\n  We protect your rights with a two-step method: (1) we copyright the\nlibrary, and (2) we offer you this license, which gives you legal\npermission to copy, distribute and/or modify the library.\n\n  To protect each distributor, we want to make it very clear that\nthere is no warranty for the free library.  Also, if the library is\nmodified by someone else and passed on, the recipients should know\nthat what they have is not the original version, so that the original\nauthor's reputation will not be affected by problems that might be\nintroduced by others.\n\n  Finally, software patents pose a constant threat to the existence of\nany free program.  We wish to make sure that a company cannot\neffectively restrict the users of a free program by obtaining a\nrestrictive license from a patent holder.  Therefore, we insist that\nany patent license obtained for a version of the library must be\nconsistent with the full freedom of use specified in this license.\n\n  Most GNU software, including some libraries, is covered by the\nordinary GNU General Public License.  This license, the GNU Lesser\nGeneral Public License, applies to certain designated libraries, and\nis quite different from the ordinary General Public License.  We use\nthis license for certain libraries in order to permit linking those\nlibraries into non-free programs.\n\n  When a program is linked with a library, whether statically or using\na shared library, the combination of the two is legally speaking a\ncombined work, a derivative of the original library.  The ordinary\nGeneral Public License therefore permits such linking only if the\nentire combination fits its criteria of freedom.  The Lesser General\nPublic License permits more lax criteria for linking other code with\nthe library.\n\n  We call this license the \"Lesser\" General Public License because it\ndoes Less to protect the user's freedom than the ordinary General\nPublic License.  It also provides other free software developers Less\nof an advantage over competing non-free programs.  These disadvantages\nare the reason we use the ordinary General Public License for many\nlibraries.  However, the Lesser license provides advantages in certain\nspecial circumstances.\n\n  For example, on rare occasions, there may be a special need to\nencourage the widest possible use of a certain library, so that it becomes\na de-facto standard.  To achieve this, non-free programs must be\nallowed to use the library.  A more frequent case is that a free\nlibrary does the same job as widely used non-free libraries.  In this\ncase, there is little to gain by limiting the free library to free\nsoftware only, so we use the Lesser General Public License.\n\n  In other cases, permission to use a particular library in non-free\nprograms enables a greater number of people to use a large body of\nfree software.  For example, permission to use the GNU C Library in\nnon-free programs enables many more people to use the whole GNU\noperating system, as well as its variant, the GNU/Linux operating\nsystem.\n\n  Although the Lesser General Public License is Less protective of the\nusers' freedom, it does ensure that the user of a program that is\nlinked with the Library has the freedom and the wherewithal to run\nthat program using a modified version of the Library.\n\n  The precise terms and conditions for copying, distribution and\nmodification follow.  Pay close attention to the difference between a\n\"work based on the library\" and a \"work that uses the library\".  The\nformer contains code derived from the library, whereas the latter must\nbe combined with the library in order to run.\n\n\t\t  GNU LESSER GENERAL PUBLIC LICENSE\n   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION\n\n  0. This License Agreement applies to any software library or other\nprogram which contains a notice placed by the copyright holder or\nother authorized party saying it may be distributed under the terms of\nthis Lesser General Public License (also called \"this License\").\nEach licensee is addressed as \"you\".\n\n  A \"library\" means a collection of software functions and/or data\nprepared so as to be conveniently linked with application programs\n(which use some of those functions and data) to form executables.\n\n  The \"Library\", below, refers to any such software library or work\nwhich has been distributed under these terms.  A \"work based on the\nLibrary\" means either the Library or any derivative work under\ncopyright law: that is to say, a work containing the Library or a\nportion of it, either verbatim or with modifications and/or translated\nstraightforwardly into another language.  (Hereinafter, translation is\nincluded without limitation in the term \"modification\".)\n\n  \"Source code\" for a work means the preferred form of the work for\nmaking modifications to it.  For a library, complete source code means\nall the source code for all modules it contains, plus any associated\ninterface definition files, plus the scripts used to control compilation\nand installation of the library.\n\n  Activities other than copying, distribution and modification are not\ncovered by this License; they are outside its scope.  The act of\nrunning a program using the Library is not restricted, and output from\nsuch a program is covered only if its contents constitute a work based\non the Library (independent of the use of the Library in a tool for\nwriting it).  Whether that is true depends on what the Library does\nand what the program that uses the Library does.\n  \n  1. You may copy and distribute verbatim copies of the Library's\ncomplete source code as you receive it, in any medium, provided that\nyou conspicuously and appropriately publish on each copy an\nappropriate copyright notice and disclaimer of warranty; keep intact\nall the notices that refer to this License and to the absence of any\nwarranty; and distribute a copy of this License along with the\nLibrary.\n\n  You may charge a fee for the physical act of transferring a copy,\nand you may at your option offer warranty protection in exchange for a\nfee.\n\n  2. You may modify your copy or copies of the Library or any portion\nof it, thus forming a work based on the Library, and copy and\ndistribute such modifications or work under the terms of Section 1\nabove, provided that you also meet all of these conditions:\n\n    a) The modified work must itself be a software library.\n\n    b) You must cause the files modified to carry prominent notices\n    stating that you changed the files and the date of any change.\n\n    c) You must cause the whole of the work to be licensed at no\n    charge to all third parties under the terms of this License.\n\n    d) If a facility in the modified Library refers to a function or a\n    table of data to be supplied by an application program that uses\n    the facility, other than as an argument passed when the facility\n    is invoked, then you must make a good faith effort to ensure that,\n    in the event an application does not supply such function or\n    table, the facility still operates, and performs whatever part of\n    its purpose remains meaningful.\n\n    (For example, a function in a library to compute square roots has\n    a purpose that is entirely well-defined independent of the\n    application.  Therefore, Subsection 2d requires that any\n    application-supplied function or table used by this function must\n    be optional: if the application does not supply it, the square\n    root function must still compute square roots.)\n\nThese requirements apply to the modified work as a whole.  If\nidentifiable sections of that work are not derived from the Library,\nand can be reasonably considered independent and separate works in\nthemselves, then this License, and its terms, do not apply to those\nsections when you distribute them as separate works.  But when you\ndistribute the same sections as part of a whole which is a work based\non the Library, the distribution of the whole must be on the terms of\nthis License, whose permissions for other licensees extend to the\nentire whole, and thus to each and every part regardless of who wrote\nit.\n\nThus, it is not the intent of this section to claim rights or contest\nyour rights to work written entirely by you; rather, the intent is to\nexercise the right to control the distribution of derivative or\ncollective works based on the Library.\n\nIn addition, mere aggregation of another work not based on the Library\nwith the Library (or with a work based on the Library) on a volume of\na storage or distribution medium does not bring the other work under\nthe scope of this License.\n\n  3. You may opt to apply the terms of the ordinary GNU General Public\nLicense instead of this License to a given copy of the Library.  To do\nthis, you must alter all the notices that refer to this License, so\nthat they refer to the ordinary GNU General Public License, version 2,\ninstead of to this License.  (If a newer version than version 2 of the\nordinary GNU General Public License has appeared, then you can specify\nthat version instead if you wish.)  Do not make any other change in\nthese notices.\n\n  Once this change is made in a given copy, it is irreversible for\nthat copy, so the ordinary GNU General Public License applies to all\nsubsequent copies and derivative works made from that copy.\n\n  This option is useful when you wish to copy part of the code of\nthe Library into a program that is not a library.\n\n  4. You may copy and distribute the Library (or a portion or\nderivative of it, under Section 2) in object code or executable form\nunder the terms of Sections 1 and 2 above provided that you accompany\nit with the complete corresponding machine-readable source code, which\nmust be distributed under the terms of Sections 1 and 2 above on a\nmedium customarily used for software interchange.\n\n  If distribution of object code is made by offering access to copy\nfrom a designated place, then offering equivalent access to copy the\nsource code from the same place satisfies the requirement to\ndistribute the source code, even though third parties are not\ncompelled to copy the source along with the object code.\n\n  5. A program that contains no derivative of any portion of the\nLibrary, but is designed to work with the Library by being compiled or\nlinked with it, is called a \"work that uses the Library\".  Such a\nwork, in isolation, is not a derivative work of the Library, and\ntherefore falls outside the scope of this License.\n\n  However, linking a \"work that uses the Library\" with the Library\ncreates an executable that is a derivative of the Library (because it\ncontains portions of the Library), rather than a \"work that uses the\nlibrary\".  The executable is therefore covered by this License.\nSection 6 states terms for distribution of such executables.\n\n  When a \"work that uses the Library\" uses material from a header file\nthat is part of the Library, the object code for the work may be a\nderivative work of the Library even though the source code is not.\nWhether this is true is especially significant if the work can be\nlinked without the Library, or if the work is itself a library.  The\nthreshold for this to be true is not precisely defined by law.\n\n  If such an object file uses only numerical parameters, data\nstructure layouts and accessors, and small macros and small inline\nfunctions (ten lines or less in length), then the use of the object\nfile is unrestricted, regardless of whether it is legally a derivative\nwork.  (Executables containing this object code plus portions of the\nLibrary will still fall under Section 6.)\n\n  Otherwise, if the work is a derivative of the Library, you may\ndistribute the object code for the work under the terms of Section 6.\nAny executables containing that work also fall under Section 6,\nwhether or not they are linked directly with the Library itself.\n\n  6. As an exception to the Sections above, you may also combine or\nlink a \"work that uses the Library\" with the Library to produce a\nwork containing portions of the Library, and distribute that work\nunder terms of your choice, provided that the terms permit\nmodification of the work for the customer's own use and reverse\nengineering for debugging such modifications.\n\n  You must give prominent notice with each copy of the work that the\nLibrary is used in it and that the Library and its use are covered by\nthis License.  You must supply a copy of this License.  If the work\nduring execution displays copyright notices, you must include the\ncopyright notice for the Library among them, as well as a reference\ndirecting the user to the copy of this License.  Also, you must do one\nof these things:\n\n    a) Accompany the work with the complete corresponding\n    machine-readable source code for the Library including whatever\n    changes were used in the work (which must be distributed under\n    Sections 1 and 2 above); and, if the work is an executable linked\n    with the Library, with the complete machine-readable \"work that\n    uses the Library\", as object code and/or source code, so that the\n    user can modify the Library and then relink to produce a modified\n    executable containing the modified Library.  (It is understood\n    that the user who changes the contents of definitions files in the\n    Library will not necessarily be able to recompile the application\n    to use the modified definitions.)\n\n    b) Use a suitable shared library mechanism for linking with the\n    Library.  A suitable mechanism is one that (1) uses at run time a\n    copy of the library already present on the user's computer system,\n    rather than copying library functions into the executable, and (2)\n    will operate properly with a modified version of the library, if\n    the user installs one, as long as the modified version is\n    interface-compatible with the version that the work was made with.\n\n    c) Accompany the work with a written offer, valid for at\n    least three years, to give the same user the materials\n    specified in Subsection 6a, above, for a charge no more\n    than the cost of performing this distribution.\n\n    d) If distribution of the work is made by offering access to copy\n    from a designated place, offer equivalent access to copy the above\n    specified materials from the same place.\n\n    e) Verify that the user has already received a copy of these\n    materials or that you have already sent this user a copy.\n\n  For an executable, the required form of the \"work that uses the\nLibrary\" must include any data and utility programs needed for\nreproducing the executable from it.  However, as a special exception,\nthe materials to be distributed need not include anything that is\nnormally distributed (in either source or binary form) with the major\ncomponents (compiler, kernel, and so on) of the operating system on\nwhich the executable runs, unless that component itself accompanies\nthe executable.\n\n  It may happen that this requirement contradicts the license\nrestrictions of other proprietary libraries that do not normally\naccompany the operating system.  Such a contradiction means you cannot\nuse both them and the Library together in an executable that you\ndistribute.\n\n  7. You may place library facilities that are a work based on the\nLibrary side-by-side in a single library together with other library\nfacilities not covered by this License, and distribute such a combined\nlibrary, provided that the separate distribution of the work based on\nthe Library and of the other library facilities is otherwise\npermitted, and provided that you do these two things:\n\n    a) Accompany the combined library with a copy of the same work\n    based on the Library, uncombined with any other library\n    facilities.  This must be distributed under the terms of the\n    Sections above.\n\n    b) Give prominent notice with the combined library of the fact\n    that part of it is a work based on the Library, and explaining\n    where to find the accompanying uncombined form of the same work.\n\n  8. You may not copy, modify, sublicense, link with, or distribute\nthe Library except as expressly provided under this License.  Any\nattempt otherwise to copy, modify, sublicense, link with, or\ndistribute the Library is void, and will automatically terminate your\nrights under this License.  However, parties who have received copies,\nor rights, from you under this License will not have their licenses\nterminated so long as such parties remain in full compliance.\n\n  9. You are not required to accept this License, since you have not\nsigned it.  However, nothing else grants you permission to modify or\ndistribute the Library or its derivative works.  These actions are\nprohibited by law if you do not accept this License.  Therefore, by\nmodifying or distributing the Library (or any work based on the\nLibrary), you indicate your acceptance of this License to do so, and\nall its terms and conditions for copying, distributing or modifying\nthe Library or works based on it.\n\n  10. Each time you redistribute the Library (or any work based on the\nLibrary), the recipient automatically receives a license from the\noriginal licensor to copy, distribute, link with or modify the Library\nsubject to these terms and conditions.  You may not impose any further\nrestrictions on the recipients' exercise of the rights granted herein.\nYou are not responsible for enforcing compliance by third parties with\nthis License.\n\n  11. If, as a consequence of a court judgment or allegation of patent\ninfringement or for any other reason (not limited to patent issues),\nconditions are imposed on you (whether by court order, agreement or\notherwise) that contradict the conditions of this License, they do not\nexcuse you from the conditions of this License.  If you cannot\ndistribute so as to satisfy simultaneously your obligations under this\nLicense and any other pertinent obligations, then as a consequence you\nmay not distribute the Library at all.  For example, if a patent\nlicense would not permit royalty-free redistribution of the Library by\nall those who receive copies directly or indirectly through you, then\nthe only way you could satisfy both it and this License would be to\nrefrain entirely from distribution of the Library.\n\nIf any portion of this section is held invalid or unenforceable under any\nparticular circumstance, the balance of the section is intended to apply,\nand the section as a whole is intended to apply in other circumstances.\n\nIt is not the purpose of this section to induce you to infringe any\npatents or other property right claims or to contest validity of any\nsuch claims; this section has the sole purpose of protecting the\nintegrity of the free software distribution system which is\nimplemented by public license practices.  Many people have made\ngenerous contributions to the wide range of software distributed\nthrough that system in reliance on consistent application of that\nsystem; it is up to the author/donor to decide if he or she is willing\nto distribute software through any other system and a licensee cannot\nimpose that choice.\n\nThis section is intended to make thoroughly clear what is believed to\nbe a consequence of the rest of this License.\n\n  12. If the distribution and/or use of the Library is restricted in\ncertain countries either by patents or by copyrighted interfaces, the\noriginal copyright holder who places the Library under this License may add\nan explicit geographical distribution limitation excluding those countries,\nso that distribution is permitted only in or among countries not thus\nexcluded.  In such case, this License incorporates the limitation as if\nwritten in the body of this License.\n\n  13. The Free Software Foundation may publish revised and/or new\nversions of the Lesser General Public License from time to time.\nSuch new versions will be similar in spirit to the present version,\nbut may differ in detail to address new problems or concerns.\n\nEach version is given a distinguishing version number.  If the Library\nspecifies a version number of this License which applies to it and\n\"any later version\", you have the option of following the terms and\nconditions either of that version or of any later version published by\nthe Free Software Foundation.  If the Library does not specify a\nlicense version number, you may choose any version ever published by\nthe Free Software Foundation.\n\n  14. If you wish to incorporate parts of the Library into other free\nprograms whose distribution conditions are incompatible with these,\nwrite to the author to ask for permission.  For software which is\ncopyrighted by the Free Software Foundation, write to the Free\nSoftware Foundation; we sometimes make exceptions for this.  Our\ndecision will be guided by the two goals of preserving the free status\nof all derivatives of our free software and of promoting the sharing\nand reuse of software generally.\n\n\t\t\t    NO WARRANTY\n\n  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO\nWARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.\nEXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR\nOTHER PARTIES PROVIDE THE LIBRARY \"AS IS\" WITHOUT WARRANTY OF ANY\nKIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE\nIMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\nPURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE\nLIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME\nTHE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\n\n  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN\nWRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY\nAND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU\nFOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR\nCONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE\nLIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING\nRENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A\nFAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF\nSUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH\nDAMAGES.\n\n\t\t     END OF TERMS AND CONDITIONS\n\n           How to Apply These Terms to Your New Libraries\n\n  If you develop a new library, and you want it to be of the greatest\npossible use to the public, we recommend making it free software that\neveryone can redistribute and change.  You can do so by permitting\nredistribution under these terms (or, alternatively, under the terms of the\nordinary General Public License).\n\n  To apply these terms, attach the following notices to the library.  It is\nsafest to attach them to the start of each source file to most effectively\nconvey the exclusion of warranty; and each file should have at least the\n\"copyright\" line and a pointer to where the full notice is found.\n\n    <one line to give the library's name and a brief idea of what it does.>\n    Copyright (C) <year>  <name of author>\n\n    This library is free software; you can redistribute it and/or\n    modify it under the terms of the GNU Lesser General Public\n    License as published by the Free Software Foundation; either\n    version 2.1 of the License, or (at your option) any later version.\n\n    This library is distributed in the hope that it will be useful,\n    but WITHOUT ANY WARRANTY; without even the implied warranty of\n    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU\n    Lesser General Public License for more details.\n\n    You should have received a copy of the GNU Lesser General Public\n    License along with this library; if not, write to the Free Software\n    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA\n\nAlso add information on how to contact you by electronic and paper mail.\n\nYou should also get your employer (if you work as a programmer) or your\nschool, if any, to sign a \"copyright disclaimer\" for the library, if\nnecessary.  Here is a sample; alter the names:\n\n  Yoyodyne, Inc., hereby disclaims all copyright interest in the\n  library `Frob' (a library for tweaking knobs) written by James Random Hacker.\n\n  <signature of Ty Coon>, 1 April 1990\n  Ty Coon, President of Vice\n\nThat's all there is to it!\n\n\n",
+                "content_hash": "caef7da6811e121cc24513af110b1812317b73ba",
+                "content_normalized": "59 temple place, suite 330, boston, ma 02111-1307 usa everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed. [this is the first released version of the lesser gpl. it also counts as the successor of the gnu library public license, version 2, hence the version number 2.1.] preamble the licenses for most software are designed to take away your freedom to share and change it. by contrast, the gnu general public licenses are intended to guarantee your freedom to share and change free software-to make sure the software is free for all its users. this license, the lesser general public license, applies to some specially designated software packages-typically libraries-of the free software foundation and other authors who decide to use it. you can use it too, but we suggest you first think carefully about whether this license or the ordinary general public license is the better strategy to use in any particular case, based on the explanations below. when we speak of free software, we are referring to freedom of use, not price. our general public licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things. to protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. these restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it. for example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. you must make sure that they, too, receive or can get the source code. if you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. and you must show them these terms so they know their rights. we protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this license, which gives you legal permission to copy, distribute and/or modify the library. to protect each distributor, we want to make it very clear that there is no warranty for the free library. also, if the library is modified by someone else and passed on, the recipients should know that what they have is not the original version, so that the original author's reputation will not be affected by problems that might be introduced by others. finally, software patents pose a constant threat to the existence of any free program. we wish to make sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a patent holder. therefore, we insist that any patent license obtained for a version of the library must be consistent with the full freedom of use specified in this license. most gnu software, including some libraries, is covered by the ordinary gnu general public license. this license, the gnu lesser general public license, applies to certain designated libraries, and is quite different from the ordinary general public license. we use this license for certain libraries in order to permit linking those libraries into non-free programs. when a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. the ordinary general public license therefore permits such linking only if the entire combination fits its criteria of freedom. the lesser general public license permits more lax criteria for linking other code with the library. we call this license the \"lesser\" general public license because it does less to protect the user's freedom than the ordinary general public license. it also provides other free software developers less of an advantage over competing non-free programs. these disadvantages are the reason we use the ordinary general public license for many libraries. however, the lesser license provides advantages in certain special circumstances. for example, on rare occasions, there may be a special need to encourage the widest possible use of a certain library, so that it becomes a de-facto standard. to achieve this, non-free programs must be allowed to use the library. a more frequent case is that a free library does the same job as widely used non-free libraries. in this case, there is little to gain by limiting the free library to free software only, so we use the lesser general public license. in other cases, permission to use a particular library in non-free programs enables a greater number of people to use a large body of free software. for example, permission to use the gnu c library in non-free programs enables many more people to use the whole gnu operating system, as well as its variant, the gnu/linux operating system. although the lesser general public license is less protective of the users' freedom, it does ensure that the user of a program that is linked with the library has the freedom and the wherewithal to run that program using a modified version of the library. the precise terms and conditions for copying, distribution and modification follow. pay close attention to the difference between a \"work based on the library\" and a \"work that uses the library\". the former contains code derived from the library, whereas the latter must be combined with the library in order to run. gnu lesser general public license terms and conditions for copying, distribution and modification - this license agreement applies to any software library or other program which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this lesser general public license (also called \"this license\"). each licensee is addressed as \"you\". a \"library\" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables. the \"library\", below, refers to any such software library or work which has been distributed under these terms. a \"work based on the library\" means either the library or any derivative work under copyright law: that is to say, a work containing the library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (hereinafter, translation is included without limitation in the term \"modification\".) \"source code\" for a work means the preferred form of the work for making modifications to it. for a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library. activities other than copying, distribution and modification are not covered by this license; they are outside its scope. the act of running a program using the library is not restricted, and output from such a program is covered only if its contents constitute a work based on the library (independent of the use of the library in a tool for writing it). whether that is true depends on what the library does and what the program that uses the library does. - you may copy and distribute verbatim copies of the library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this license and to the absence of any warranty; and distribute a copy of this license along with the library. you may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee. - you may modify your copy or copies of the library or any portion of it, thus forming a work based on the library, and copy and distribute such modifications or work under the terms of section 1 above, provided that you also meet all of these conditions: * the modified work must itself be a software library. * you must cause the files modified to carry prominent notices stating that you changed the files and the date of any change. * you must cause the whole of the work to be licensed at no charge to all third parties under the terms of this license. * if a facility in the modified library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful. (for example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. therefore, subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.) these requirements apply to the modified work as a whole. if identifiable sections of that work are not derived from the library, and can be reasonably considered independent and separate works in themselves, then this license, and its terms, do not apply to those sections when you distribute them as separate works. but when you distribute the same sections as part of a whole which is a work based on the library, the distribution of the whole must be on the terms of this license, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it. thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the library. in addition, mere aggregation of another work not based on the library with the library (or with a work based on the library) on a volume of a storage or distribution medium does not bring the other work under the scope of this license. - you may opt to apply the terms of the ordinary gnu general public license instead of this license to a given copy of the library. to do this, you must alter all the notices that refer to this license, so that they refer to the ordinary gnu general public license, version 2, instead of to this license. (if a newer version than version 2 of the ordinary gnu general public license has appeared, then you can specify that version instead if you wish.) do not make any other change in these notices. once this change is made in a given copy, it is irreversible for that copy, so the ordinary gnu general public license applies to all subsequent copies and derivative works made from that copy. this option is useful when you wish to copy part of the code of the library into a program that is not a library. - you may copy and distribute the library (or a portion or derivative of it, under section 2) in object code or executable form under the terms of sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of sections 1 and 2 above on a medium customarily used for software interchange. if distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code. - a program that contains no derivative of any portion of the library, but is designed to work with the library by being compiled or linked with it, is called a \"work that uses the library\". such a work, in isolation, is not a derivative work of the library, and therefore falls outside the scope of this license. however, linking a \"work that uses the library\" with the library creates an executable that is a derivative of the library (because it contains portions of the library), rather than a \"work that uses the library\". the executable is therefore covered by this license. section 6 states terms for distribution of such executables. when a \"work that uses the library\" uses material from a header file that is part of the library, the object code for the work may be a derivative work of the library even though the source code is not. whether this is true is especially significant if the work can be linked without the library, or if the work is itself a library. the threshold for this to be true is not precisely defined by law. if such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (executables containing this object code plus portions of the library will still fall under section 6.) otherwise, if the work is a derivative of the library, you may distribute the object code for the work under the terms of section 6. any executables containing that work also fall under section 6, whether or not they are linked directly with the library itself. - as an exception to the sections above, you may also combine or link a \"work that uses the library\" with the library to produce a work containing portions of the library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications. you must give prominent notice with each copy of the work that the library is used in it and that the library and its use are covered by this license. you must supply a copy of this license. if the work during execution displays copyright notices, you must include the copyright notice for the library among them, as well as a reference directing the user to the copy of this license. also, you must do one of these things: * accompany the work with the complete corresponding machine-readable source code for the library including whatever changes were used in the work (which must be distributed under sections 1 and 2 above); and, if the work is an executable linked with the library, with the complete machine-readable \"work that uses the library\", as object code and/or source code, so that the user can modify the library and then relink to produce a modified executable containing the modified library. (it is understood that the user who changes the contents of definitions files in the library will not necessarily be able to recompile the application to use the modified definitions.) * use a suitable shared library mechanism for linking with the library. a suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with. * accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in subsection 6a, above, for a charge no more than the cost of performing this distribution. * if distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place. * verify that the user has already received a copy of these materials or that you have already sent this user a copy. for an executable, the required form of the \"work that uses the library\" must include any data and utility programs needed for reproducing the executable from it. however, as a special exception, the materials to be distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable. it may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. such a contradiction means you cannot use both them and the library together in an executable that you distribute. - you may place library facilities that are a work based on the library side-by-side in a single library together with other library facilities not covered by this license, and distribute such a combined library, provided that the separate distribution of the work based on the library and of the other library facilities is otherwise permitted, and provided that you do these two things: * accompany the combined library with a copy of the same work based on the library, uncombined with any other library facilities. this must be distributed under the terms of the sections above. * give prominent notice with the combined library of the fact that part of it is a work based on the library, and explaining where to find the accompanying uncombined form of the same work. - you may not copy, modify, sublicense, link with, or distribute the library except as expressly provided under this license. any attempt otherwise to copy, modify, sublicense, link with, or distribute the library is void, and will automatically terminate your rights under this license. however, parties who have received copies, or rights, from you under this license will not have their licenses terminated so long as such parties remain in full compliance. - you are not required to accept this license, since you have not signed it. however, nothing else grants you permission to modify or distribute the library or its derivative works. these actions are prohibited by law if you do not accept this license. therefore, by modifying or distributing the library (or any work based on the library), you indicate your acceptance of this license to do so, and all its terms and conditions for copying, distributing or modifying the library or works based on it. * each time you redistribute the library (or any work based on the library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the library subject to these terms and conditions. you may not impose any further restrictions on the recipients' exercise of the rights granted herein. you are not responsible for enforcing compliance by third parties with this license. * if, as a consequence of a court judgement or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this license, they do not excuse you from the conditions of this license. if you cannot distribute so as to satisfy simultaneously your obligations under this license and any other pertinent obligations, then as a consequence you may not distribute the library at all. for example, if a patent license would not permit royalty-free redistribution of the library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this license would be to refrain entirely from distribution of the library. if any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances. it is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice. this section is intended to make thoroughly clear what is believed to be a consequence of the rest of this license. * if the distribution and/or use of the library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the library under this license may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. in such case, this license incorporates the limitation as if written in the body of this license. * the free software foundation may publish revised and/or new versions of the lesser general public license from time to time. such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns. each version is given a distinguishing version number. if the library specifies a version number of this license which applies to it and \"any later version\", you have the option of following the terms and conditions either of that version or of any later version published by the free software foundation. if the library does not specify a license version number, you may choose any version ever published by the free software foundation. * if you wish to incorporate parts of the library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. for software which is copyrighted by the free software foundation, write to the free software foundation; we sometimes make exceptions for this. our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally. no warranty * because the library is licensed free of charge, there is no warranty for the library, to the extent permitted by applicable law. except when otherwise stated in writing the copyright holders and/or other parties provide the library \"as is\" without warranty of any kind, either expressed or implied, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose. the entire risk as to the quality and performance of the library is with you. should the library prove defective, you assume the cost of all necessary servicing, repair or correction. * in no event unless required by applicable law or agreed to in writing will any copyright holder, or any other party who may modify and/or redistribute the library as permitted above, be liable to you for damages, including any general, special, incidental or consequential damages arising out of the use or inability to use the library (including but not limited to loss of data or data being rendered inaccurate or losses sustained by you or third parties or a failure of the library to operate with any other software), even if such holder or other party has been advised of the possibility of such damages.",
+                "matcher": {
+                  "name": "dice",
+                  "confidence": 99.16074887023886
+                },
+                "matched_license": "LGPL-2.1",
+                "attribution": null
+              }
+            ]
+          }
+        }
+      },
+      "attachments": [
+        {
+          "path": "mmucklo-krumo-29a6fad/LICENSE",
+          "token": "6f679d0555a9a5aad08a4e88cdba552cf62bb46585084572f3cfd1b0c7e6ec4f"
+        }
+      ]
+    }
+  },
+  "reuse": {
+    "1.2.0": {
+      "_metadata": {
+        "type": "reuse",
+        "url": "cd:/composer/packagist/mmucklo/krumo/0.7.0",
+        "fetchedAt": "2023-01-27T00:49:01.659Z",
+        "links": {
+          "self": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:reuse:1.2.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:reuse",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "1.2.0",
+        "toolVersion": "1.0.0",
+        "processedAt": "2023-01-27T00:49:02.098Z"
+      },
+      "reuse": {
+        "metadata": {
+          "SPDXVersion": "SPDX-2.1",
+          "DataLicense": "CC0-1.0",
+          "SPDXID": "SPDXRef-DOCUMENT",
+          "DocumentName": "cd-lfdomv",
+          "DocumentNamespace": "http://spdx.org/spdxdocs/spdx-v2.1-067ee88b-c948-4d9b-bfbf-2ef31c0eaca3",
+          "CreatorPerson": "Anonymous ()",
+          "CreatorOrganization": "Anonymous ()",
+          "CreatorTool": "reuse-1.0.0",
+          "Created": "2023-01-27T00:49:02Z",
+          "CreatorComment": "This document was created automatically using available reuse information consistent with REUSE."
+        },
+        "files": [
+          {
+            "FileName": "mmucklo-krumo-29a6fad/.gitignore",
+            "SPDXID": "SPDXRef-bdb319e044eca248ba4f280f89305c2b",
+            "FileChecksumSHA1": "7e0dd40118b594772525831a55766b72986a323c",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/README.md",
+            "SPDXID": "SPDXRef-05a5634373d4f1f4dc867f5c14074558",
+            "FileChecksumSHA1": "1126638450470af69b37e6e82cafe632cf13ba51",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/class.krumo.php",
+            "SPDXID": "SPDXRef-a541be8b1dc161747d0f373d0add5d61",
+            "FileChecksumSHA1": "c2abce21f9e4eab6cf3b09c8151a50558b215afd",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/composer.json",
+            "SPDXID": "SPDXRef-feef84ff35361f8566c15e2683cfcc45",
+            "FileChecksumSHA1": "6cb2bbdcf3523410605775a8f28983bfcbb54bee",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/icons/information.png",
+            "SPDXID": "SPDXRef-67ce4baec39372751e550cf67e607714",
+            "FileChecksumSHA1": "04b482344d75d0732275727bd73cceb9b049d276",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/js/krumo.js",
+            "SPDXID": "SPDXRef-517dabed3647fb723722e64e12699f8e",
+            "FileChecksumSHA1": "e65b0abbf6120699980dce4abcda17cdd6f72ff6",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/js/krumo.min.js",
+            "SPDXID": "SPDXRef-78e878d4fca5967a1615be32561f958e",
+            "FileChecksumSHA1": "c30c745f5ca221304ff6185d3b1f73c173f03ce7",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/krumo.sample.ini",
+            "SPDXID": "SPDXRef-8300e89e10eb69148edd47ca6bf32a2e",
+            "FileChecksumSHA1": "d6d23e621e217e2cac70538cc32ba9a6ac95777a",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/phpmd.xml",
+            "SPDXID": "SPDXRef-54ed1a41a26fb24491dc73fd22d0da81",
+            "FileChecksumSHA1": "09f0a2ef79f4618d2e5a43908e92c901259a3617",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/blue/bg.gif",
+            "SPDXID": "SPDXRef-4624b3f6a6b1a29f3caf9fa7c59e7fd6",
+            "FileChecksumSHA1": "30f5b4191609bfadea746b20fede640887b0f1bc",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/blue/skin.css",
+            "SPDXID": "SPDXRef-5ba03a18edd50536e35eb71878e8b477",
+            "FileChecksumSHA1": "7f7cf673d89ee1c808d7b1cb2f4908552505da29",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/blue/skin.unminified.css",
+            "SPDXID": "SPDXRef-a7152d3e91ea8061317b1858dbc26625",
+            "FileChecksumSHA1": "ed0d30ae326cc206aad55fd879d9f28e7bcef4da",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/default/bg.gif",
+            "SPDXID": "SPDXRef-e9b89b5876b7ede7f099c1f1d4c0538c",
+            "FileChecksumSHA1": "700e1fbb731a8b21cd5513a1f632136f53fe7f17",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/default/skin.css",
+            "SPDXID": "SPDXRef-001e2acc605318ac8d36bab9638f973c",
+            "FileChecksumSHA1": "a19b6f8338339bdc72b45ef97edd19613480e5ad",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/green/bg.gif",
+            "SPDXID": "SPDXRef-613b39e2b644af81a5aec331be77ca61",
+            "FileChecksumSHA1": "870a05ac94ea9b6a81eadeeffb6a54680c62162e",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/green/skin.css",
+            "SPDXID": "SPDXRef-17fb4c7b0822526f2837213a5263108e",
+            "FileChecksumSHA1": "87b056e0a132f3fd9603c98f7eb5910a38d6c7b7",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/green/skin.unminified.css",
+            "SPDXID": "SPDXRef-682847b2e68f84b9c7ef97a9d69d3120",
+            "FileChecksumSHA1": "4452511b4031d4f6e093f166a2e8052378f8a00e",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/modern/skin.css",
+            "SPDXID": "SPDXRef-971dd18b22e92eb4940cc2c932930bfd",
+            "FileChecksumSHA1": "f4b62b610f5477acc5483414d891dce8be8a1006",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/modern/skin.unminified.css",
+            "SPDXID": "SPDXRef-6dfd90ad9cfaae603d53b1a97168c21b",
+            "FileChecksumSHA1": "cd632c9004147618b44e97fb51b04428504e6156",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/orange/skin.css",
+            "SPDXID": "SPDXRef-3765b83a6a320f2043a09189524d09c5",
+            "FileChecksumSHA1": "09cbcad13a75be23825ef997b321be796ac495ed",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/orange/skin.unminified.css",
+            "SPDXID": "SPDXRef-b130769cb7f2b650e27d296212ed3038",
+            "FileChecksumSHA1": "80ee31914e76fa3cd728680228ba5040927dab1b",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/schablon.com/collapsed.gif",
+            "SPDXID": "SPDXRef-a4360c3addc33ff7a363580b7cf57dc6",
+            "FileChecksumSHA1": "a57040f6ca02950fd2bac6b25a4f97df88a2c25c",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/schablon.com/dotted.gif",
+            "SPDXID": "SPDXRef-4553e922e496251bf4ac1ac6cf7bd516",
+            "FileChecksumSHA1": "ee2e3cdf195f2f9649882576dd2c1717f0dd4352",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/schablon.com/empty.gif",
+            "SPDXID": "SPDXRef-e4735956cf0c32b824bfc70f30564b84",
+            "FileChecksumSHA1": "3f7e39397fdd90196619d5dd3831c086e81650f6",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/schablon.com/expanded.gif",
+            "SPDXID": "SPDXRef-97dc8fea8ed2bcea6744d2dce9cd3fec",
+            "FileChecksumSHA1": "c3b94c2c4ee2bf215d2c518d629bd573442d3514",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/schablon.com/skin.css",
+            "SPDXID": "SPDXRef-a7c4204862f6a1e73f4efd46fa798fae",
+            "FileChecksumSHA1": "2e7234cdac65f7cc4f39e716d8349e6594e33cd4",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/schablon.com/skin.unminified.css",
+            "SPDXID": "SPDXRef-4a778938cb87daccf546874f78991792",
+            "FileChecksumSHA1": "b6f72c9ba70633c95cf14dd9182b90ef51bab974",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/stylish/skin.css",
+            "SPDXID": "SPDXRef-63627c397f8d2e5add372b3e6092a4f6",
+            "FileChecksumSHA1": "83fbbed368302d10d561d0d76259ef36f9c73e45",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/skins/stylish/skin.unminified.css",
+            "SPDXID": "SPDXRef-923d0efa9331d2020085a4f10f425d6f",
+            "FileChecksumSHA1": "e8ef5085ed7b5ecd87d126b406e099bdcf4b1e51",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/tests/php/class.php",
+            "SPDXID": "SPDXRef-ab251a257f37a15acbda69b4951dce0a",
+            "FileChecksumSHA1": "92a0f2004cbb650cfccfbb7e9e0a1b38ff083f81",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/tests/php/misc.php",
+            "SPDXID": "SPDXRef-234810b3108ee9dabef49da3804f6bc3",
+            "FileChecksumSHA1": "06e641ceeee54fcf825c8a45ae2dfdf9b406b96b",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          },
+          {
+            "FileName": "mmucklo-krumo-29a6fad/tests/php/object.php",
+            "SPDXID": "SPDXRef-016c94be677449de72b3acac87d3a128",
+            "FileChecksumSHA1": "fc0ff74960198bc2bd2f8411bfe6a93363ffe041",
+            "LicenseConcluded": "NOASSERTION",
+            "FileCopyrightText": "NONE"
+          }
+        ],
+        "licenses": []
+      }
+    }
+  },
+  "scancode": {
+    "30.3.0": {
+      "_metadata": {
+        "type": "scancode",
+        "url": "cd:/composer/packagist/mmucklo/krumo/0.7.0",
+        "fetchedAt": "2023-01-27T00:48:55.223Z",
+        "links": {
+          "self": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:scancode:30.3.0",
+            "type": "resource"
+          },
+          "siblings": {
+            "href": "urn:composer:packagist:mmucklo:krumo:revision:0.7.0:tool:scancode",
+            "type": "collection"
+          }
+        },
+        "schemaVersion": "30.3.0",
+        "toolVersion": "30.1.0",
+        "contentType": "application/json",
+        "releaseDate": "2022-08-07T01:49:32+00:00",
+        "processedAt": "2023-01-27T00:49:03.758Z"
+      },
+      "content": {
+        "headers": [
+          {
+            "tool_name": "scancode-toolkit",
+            "tool_version": "30.1.0",
+            "options": {
+              "input": [
+                "/tmp/cd-lfdomv"
+              ],
+              "--classify": true,
+              "--copyright": true,
+              "--email": true,
+              "--generated": true,
+              "--info": true,
+              "--is-license-text": true,
+              "--json-pp": "/tmp/cd-sRxQJc",
+              "--license": true,
+              "--license-clarity-score": true,
+              "--license-text": true,
+              "--license-text-diagnostics": true,
+              "--package": true,
+              "--processes": "2",
+              "--strip-root": true,
+              "--summary": true,
+              "--summary-key-files": true,
+              "--timeout": "1000.0",
+              "--url": true
+            },
+            "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+            "start_timestamp": "2023-01-27T004855.988879",
+            "end_timestamp": "2023-01-27T004903.126438",
+            "output_format_version": "1.0.0",
+            "duration": 7.137569427490234,
+            "message": null,
+            "errors": [],
+            "extra_data": {
+              "spdx_license_list_version": "3.14",
+              "OUTDATED": "WARNING: Outdated ScanCode Toolkit version! You are using an outdated version of ScanCode Toolkit: 30.1.0 released on: 2021-09-24. A new version is available with important improvements including bug and security fixes, updated license, copyright and package detection, and improved scanning accuracy. Please download and install the latest version of ScanCode. Visit https://github.com/nexB/scancode-toolkit/releases for details.",
+              "files_count": 32
+            }
+          }
+        ],
+        "summary": {
+          "license_expressions": [
+            {
+              "value": "lgpl-2.0-plus",
+              "count": 2
+            },
+            {
+              "value": "lgpl-2.1",
+              "count": 2
+            }
+          ],
+          "copyrights": [
+            {
+              "value": null,
+              "count": 31
+            },
+            {
+              "value": "Copyright (c) Free Software Foundation, Inc.",
+              "count": 1
+            },
+            {
+              "value": "copyrighted by the Free Software Foundation",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": null,
+              "count": 31
+            },
+            {
+              "value": "Free Software Foundation, Inc.",
+              "count": 2
+            }
+          ],
+          "authors": [
+            {
+              "value": null,
+              "count": 26
+            },
+            {
+              "value": "Kaloyan K. Tsvetkov <mrasnika@users.sourceforge.net>",
+              "count": 5
+            },
+            {
+              "value": "Kaloyan K. Tsvetkov <kaloyan@kaloyan.info>",
+              "count": 1
+            },
+            {
+              "value": "Matthew J. Mucklo <mmucklo@gmail.com>",
+              "count": 1
+            },
+            {
+              "value": "Scott Baker <scott@perturb.org>",
+              "count": 1
+            }
+          ],
+          "programming_language": [
+            {
+              "value": "CSS",
+              "count": 13
+            },
+            {
+              "value": "PHP",
+              "count": 4
+            },
+            {
+              "value": "JavaScript",
+              "count": 2
+            }
+          ],
+          "packages": [
+            {
+              "type": "composer",
+              "namespace": "mmucklo",
+              "name": "krumo",
+              "version": null,
+              "qualifiers": {},
+              "subpath": null,
+              "primary_language": "PHP",
+              "description": null,
+              "release_date": null,
+              "parties": [
+                {
+                  "type": "person",
+                  "role": "author",
+                  "name": "Kaloyan K. Tsvetkov",
+                  "email": "kaloyan@kaloyan.info",
+                  "url": null
+                },
+                {
+                  "type": "person",
+                  "role": "author",
+                  "name": "Matthew J. Mucklo",
+                  "email": "mmucklo@gmail.com",
+                  "url": null
+                },
+                {
+                  "type": "person",
+                  "role": "author",
+                  "name": "Stefan Thomas",
+                  "email": "moon@justmoon.de",
+                  "url": null
+                },
+                {
+                  "type": "person",
+                  "role": "author",
+                  "name": "Scott Baker",
+                  "email": "scott@perturb.org",
+                  "url": null
+                },
+                {
+                  "type": "person",
+                  "role": "vendor",
+                  "name": "mmucklo",
+                  "email": null,
+                  "url": null
+                }
+              ],
+              "keywords": [],
+              "homepage_url": null,
+              "download_url": null,
+              "size": null,
+              "sha1": null,
+              "md5": null,
+              "sha256": null,
+              "sha512": null,
+              "bug_tracking_url": null,
+              "code_view_url": null,
+              "vcs_url": null,
+              "copyright": null,
+              "license_expression": "lgpl-2.0-plus",
+              "declared_license": "LGPL",
+              "notice_text": null,
+              "root_path": "mmucklo-krumo-29a6fad",
+              "dependencies": [
+                {
+                  "purl": "pkg:composer/php",
+                  "requirement": ">=7.0",
+                  "scope": "require",
+                  "is_runtime": true,
+                  "is_optional": false,
+                  "is_resolved": false
+                },
+                {
+                  "purl": "pkg:composer/fabpot/php-cs-fixer",
+                  "requirement": "dev-master",
+                  "scope": "require-dev",
+                  "is_runtime": false,
+                  "is_optional": true,
+                  "is_resolved": false
+                },
+                {
+                  "purl": "pkg:composer/phpmd/phpmd",
+                  "requirement": "dev-master",
+                  "scope": "require-dev",
+                  "is_runtime": false,
+                  "is_optional": true,
+                  "is_resolved": false
+                }
+              ],
+              "contains_source_code": null,
+              "source_packages": [],
+              "extra_data": {},
+              "purl": "pkg:composer/mmucklo/krumo",
+              "repository_homepage_url": "https://packagist.org/packages/mmucklo/krumo",
+              "repository_download_url": null,
+              "api_data_url": "https://packagist.org/p/packages/mmucklo/krumo.json",
+              "files": [
+                {
+                  "path": "mmucklo-krumo-29a6fad/composer.json",
+                  "type": "file"
+                }
+              ]
+            }
+          ]
+        },
+        "license_clarity_score": {
+          "score": 45,
+          "declared": true,
+          "discovered": 0,
+          "consistency": true,
+          "spdx": false,
+          "license_texts": false
+        },
+        "summary_of_key_files": {
+          "license_expressions": [
+            {
+              "value": "lgpl-2.0-plus",
+              "count": 1
+            },
+            {
+              "value": "lgpl-2.1",
+              "count": 1
+            }
+          ],
+          "copyrights": [
+            {
+              "value": "Copyright (c) Free Software Foundation, Inc.",
+              "count": 1
+            },
+            {
+              "value": "copyrighted by the Free Software Foundation",
+              "count": 1
+            }
+          ],
+          "holders": [
+            {
+              "value": "Free Software Foundation, Inc.",
+              "count": 2
+            }
+          ],
+          "authors": [],
+          "programming_language": []
+        },
+        "files": [
+          {
+            "path": "mmucklo-krumo-29a6fad",
+            "type": "directory",
+            "name": "mmucklo-krumo-29a6fad",
+            "base_name": "mmucklo-krumo-29a6fad",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 32,
+            "dirs_count": 12,
+            "size_count": 122445,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/class.krumo.php",
+            "type": "file",
+            "name": "class.krumo.php",
+            "base_name": "class.krumo",
+            "extension": ".php",
+            "size": 46272,
+            "date": "2022-08-06",
+            "sha1": "c2abce21f9e4eab6cf3b09c8151a50558b215afd",
+            "md5": "6873817abafb08d67aab4a3f56c94f48",
+            "sha256": "3931aa89881e51284faa4551030e87aa61996dcf5c228a049640801c30be9859",
+            "mime_type": "text/x-php",
+            "file_type": "PHP script, ASCII text",
+            "programming_language": "PHP",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": true,
+            "licenses": [
+              {
+                "key": "lgpl-2.0-plus",
+                "score": 100,
+                "name": "GNU Library General Public License 2.0 or later",
+                "short_name": "LGPL 2.0 or later",
+                "category": "Copyleft Limited",
+                "is_exception": false,
+                "is_unknown": false,
+                "owner": "Free Software Foundation (FSF)",
+                "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.0.html",
+                "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html",
+                "reference_url": "https://scancode-licensedb.aboutcode.org/lgpl-2.0-plus",
+                "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/lgpl-2.0-plus.LICENSE",
+                "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/lgpl-2.0-plus.yml",
+                "spdx_license_key": "LGPL-2.0-or-later",
+                "spdx_url": "https://spdx.org/licenses/LGPL-2.0-or-later",
+                "start_line": 13,
+                "end_line": 13,
+                "matched_rule": {
+                  "identifier": "lgpl-2.0-plus_333.RULE",
+                  "license_expression": "lgpl-2.0-plus",
+                  "licenses": [
+                    "lgpl-2.0-plus"
+                  ],
+                  "referenced_filenames": [],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "is_license_intro": false,
+                  "has_unknown": false,
+                  "matcher": "2-aho",
+                  "rule_length": 8,
+                  "matched_length": 8,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "license http://opensource.org/licenses/lgpl-license.php"
+              },
+              {
+                "key": "lgpl-2.1",
+                "score": 100,
+                "name": "GNU Lesser General Public License 2.1",
+                "short_name": "LGPL 2.1",
+                "category": "Copyleft Limited",
+                "is_exception": false,
+                "is_unknown": false,
+                "owner": "Free Software Foundation (FSF)",
+                "homepage_url": "http://www.gnu.org/licenses/lgpl-2.1.html",
+                "text_url": "http://www.gnu.org/licenses/lgpl-2.1.txt",
+                "reference_url": "https://scancode-licensedb.aboutcode.org/lgpl-2.1",
+                "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/lgpl-2.1.LICENSE",
+                "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/lgpl-2.1.yml",
+                "spdx_license_key": "LGPL-2.1-only",
+                "spdx_url": "https://spdx.org/licenses/LGPL-2.1-only",
+                "start_line": 13,
+                "end_line": 13,
+                "matched_rule": {
+                  "identifier": "lgpl-2.1_36.RULE",
+                  "license_expression": "lgpl-2.1",
+                  "licenses": [
+                    "lgpl-2.1"
+                  ],
+                  "referenced_filenames": [],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": true,
+                  "is_license_tag": false,
+                  "is_license_intro": false,
+                  "has_unknown": false,
+                  "matcher": "2-aho",
+                  "rule_length": 8,
+                  "matched_length": 8,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "GNU Lesser General Public License Version 2.1"
+              }
+            ],
+            "license_expressions": [
+              "lgpl-2.0-plus",
+              "lgpl-2.1"
+            ],
+            "percentage_of_license_text": 0.37,
+            "copyrights": [],
+            "holders": [],
+            "authors": [
+              {
+                "value": "Kaloyan K. Tsvetkov <kaloyan@kaloyan.info>",
+                "start_line": 9,
+                "end_line": 9
+              },
+              {
+                "value": "Matthew J. Mucklo <mmucklo@gmail.com>",
+                "start_line": 10,
+                "end_line": 10
+              },
+              {
+                "value": "Scott Baker <scott@perturb.org>",
+                "start_line": 11,
+                "end_line": 11
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "kaloyan@kaloyan.info",
+                "start_line": 9,
+                "end_line": 9
+              },
+              {
+                "email": "mmucklo@gmail.com",
+                "start_line": 10,
+                "end_line": 10
+              },
+              {
+                "email": "scott@perturb.org",
+                "start_line": 11,
+                "end_line": 11
+              }
+            ],
+            "urls": [
+              {
+                "url": "http://opensource.org/licenses/lgpl-license.php",
+                "start_line": 13,
+                "end_line": 13
+              },
+              {
+                "url": "https://github.com/mmucklo/krumo",
+                "start_line": 15,
+                "end_line": 15
+              },
+              {
+                "url": "https://secure.php.net/manual/en/function.is-countable.php",
+                "start_line": 1665,
+                "end_line": 1665
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/composer.json",
+            "type": "file",
+            "name": "composer.json",
+            "base_name": "composer",
+            "extension": ".json",
+            "size": 818,
+            "date": "2022-08-06",
+            "sha1": "6cb2bbdcf3523410605775a8f28983bfcbb54bee",
+            "md5": "91cf5dc4ce7feaef148a0b6023aee341",
+            "sha256": "8169b7e4284c96202e7ae099134b8e3c4d617b94e47372fcdb5ff57e952e12d3",
+            "mime_type": "application/json",
+            "file_type": "JSON data",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "lgpl-2.0-plus",
+                "score": 100,
+                "name": "GNU Library General Public License 2.0 or later",
+                "short_name": "LGPL 2.0 or later",
+                "category": "Copyleft Limited",
+                "is_exception": false,
+                "is_unknown": false,
+                "owner": "Free Software Foundation (FSF)",
+                "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.0.html",
+                "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html",
+                "reference_url": "https://scancode-licensedb.aboutcode.org/lgpl-2.0-plus",
+                "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/lgpl-2.0-plus.LICENSE",
+                "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/lgpl-2.0-plus.yml",
+                "spdx_license_key": "LGPL-2.0-or-later",
+                "spdx_url": "https://spdx.org/licenses/LGPL-2.0-or-later",
+                "start_line": 5,
+                "end_line": 5,
+                "matched_rule": {
+                  "identifier": "lgpl-2.0-plus_51.RULE",
+                  "license_expression": "lgpl-2.0-plus",
+                  "licenses": [
+                    "lgpl-2.0-plus"
+                  ],
+                  "referenced_filenames": [],
+                  "is_license_text": false,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": true,
+                  "is_license_intro": false,
+                  "has_unknown": false,
+                  "matcher": "2-aho",
+                  "rule_length": 2,
+                  "matched_length": 2,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "license\": \"LGPL\","
+              }
+            ],
+            "license_expressions": [
+              "lgpl-2.0-plus"
+            ],
+            "percentage_of_license_text": 2.44,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [
+              {
+                "type": "composer",
+                "namespace": "mmucklo",
+                "name": "krumo",
+                "version": null,
+                "qualifiers": {},
+                "subpath": null,
+                "primary_language": "PHP",
+                "description": null,
+                "release_date": null,
+                "parties": [
+                  {
+                    "type": "person",
+                    "role": "author",
+                    "name": "Kaloyan K. Tsvetkov",
+                    "email": "kaloyan@kaloyan.info",
+                    "url": null
+                  },
+                  {
+                    "type": "person",
+                    "role": "author",
+                    "name": "Matthew J. Mucklo",
+                    "email": "mmucklo@gmail.com",
+                    "url": null
+                  },
+                  {
+                    "type": "person",
+                    "role": "author",
+                    "name": "Stefan Thomas",
+                    "email": "moon@justmoon.de",
+                    "url": null
+                  },
+                  {
+                    "type": "person",
+                    "role": "author",
+                    "name": "Scott Baker",
+                    "email": "scott@perturb.org",
+                    "url": null
+                  },
+                  {
+                    "type": "person",
+                    "role": "vendor",
+                    "name": "mmucklo",
+                    "email": null,
+                    "url": null
+                  }
+                ],
+                "keywords": [],
+                "homepage_url": null,
+                "download_url": null,
+                "size": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "sha512": null,
+                "bug_tracking_url": null,
+                "code_view_url": null,
+                "vcs_url": null,
+                "copyright": null,
+                "license_expression": "lgpl-2.0-plus",
+                "declared_license": "LGPL",
+                "notice_text": null,
+                "root_path": "mmucklo-krumo-29a6fad",
+                "dependencies": [
+                  {
+                    "purl": "pkg:composer/php",
+                    "requirement": ">=7.0",
+                    "scope": "require",
+                    "is_runtime": true,
+                    "is_optional": false,
+                    "is_resolved": false
+                  },
+                  {
+                    "purl": "pkg:composer/fabpot/php-cs-fixer",
+                    "requirement": "dev-master",
+                    "scope": "require-dev",
+                    "is_runtime": false,
+                    "is_optional": true,
+                    "is_resolved": false
+                  },
+                  {
+                    "purl": "pkg:composer/phpmd/phpmd",
+                    "requirement": "dev-master",
+                    "scope": "require-dev",
+                    "is_runtime": false,
+                    "is_optional": true,
+                    "is_resolved": false
+                  }
+                ],
+                "contains_source_code": null,
+                "source_packages": [],
+                "extra_data": {},
+                "purl": "pkg:composer/mmucklo/krumo",
+                "repository_homepage_url": "https://packagist.org/packages/mmucklo/krumo",
+                "repository_download_url": null,
+                "api_data_url": "https://packagist.org/p/packages/mmucklo/krumo.json",
+                "files": [
+                  {
+                    "path": "mmucklo-krumo-29a6fad/composer.json",
+                    "type": "file"
+                  }
+                ]
+              }
+            ],
+            "emails": [
+              {
+                "email": "kaloyan@kaloyan.info",
+                "start_line": 10,
+                "end_line": 10
+              },
+              {
+                "email": "mmucklo@gmail.com",
+                "start_line": 14,
+                "end_line": 14
+              },
+              {
+                "email": "moon@justmoon.de",
+                "start_line": 18,
+                "end_line": 18
+              },
+              {
+                "email": "scott@perturb.org",
+                "start_line": 22,
+                "end_line": 22
+              }
+            ],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": true,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/krumo.sample.ini",
+            "type": "file",
+            "name": "krumo.sample.ini",
+            "base_name": "krumo.sample",
+            "extension": ".ini",
+            "size": 1699,
+            "date": "2022-08-06",
+            "sha1": "d6d23e621e217e2cac70538cc32ba9a6ac95777a",
+            "md5": "50e812f2554db4b98c9e127a926d5230",
+            "sha256": "03ecb74995c0403469dddbd82804c305d2f33021cc730197d472683bebca11e0",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/LICENSE",
+            "type": "file",
+            "name": "LICENSE",
+            "base_name": "LICENSE",
+            "extension": "",
+            "size": 26421,
+            "date": "2022-08-06",
+            "sha1": "65c71b7ff77a59a32247d83a528728637263c1b5",
+            "md5": "278f2557e3b277b94e9a8430f6a6d0a9",
+            "sha256": "6f679d0555a9a5aad08a4e88cdba552cf62bb46585084572f3cfd1b0c7e6ec4f",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [
+              {
+                "key": "lgpl-2.1",
+                "score": 100,
+                "name": "GNU Lesser General Public License 2.1",
+                "short_name": "LGPL 2.1",
+                "category": "Copyleft Limited",
+                "is_exception": false,
+                "is_unknown": false,
+                "owner": "Free Software Foundation (FSF)",
+                "homepage_url": "http://www.gnu.org/licenses/lgpl-2.1.html",
+                "text_url": "http://www.gnu.org/licenses/lgpl-2.1.txt",
+                "reference_url": "https://scancode-licensedb.aboutcode.org/lgpl-2.1",
+                "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/lgpl-2.1.LICENSE",
+                "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/lgpl-2.1.yml",
+                "spdx_license_key": "LGPL-2.1-only",
+                "spdx_url": "https://spdx.org/licenses/LGPL-2.1-only",
+                "start_line": 1,
+                "end_line": 502,
+                "matched_rule": {
+                  "identifier": "lgpl-2.1_101.RULE",
+                  "license_expression": "lgpl-2.1",
+                  "licenses": [
+                    "lgpl-2.1"
+                  ],
+                  "referenced_filenames": [],
+                  "is_license_text": true,
+                  "is_license_notice": false,
+                  "is_license_reference": false,
+                  "is_license_tag": false,
+                  "is_license_intro": false,
+                  "has_unknown": false,
+                  "matcher": "1-hash",
+                  "rule_length": 4281,
+                  "matched_length": 4281,
+                  "match_coverage": 100,
+                  "rule_relevance": 100
+                },
+                "matched_text": "GNU LESSER GENERAL PUBLIC LICENSE\n\t\t       Version 2.1, February 1999\n\n Copyright (C) 1991, 1999 Free Software Foundation, Inc.\n     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA\n Everyone is permitted to copy and distribute verbatim copies\n of this license document, but changing it is not allowed.\n\n[This is the first released version of the Lesser GPL.  It also counts\n as the successor of the GNU Library Public License, version 2, hence\n the version number 2.1.]\n\n\t\t\t    Preamble\n\n  The licenses for most software are designed to take away your\nfreedom to share and change it.  By contrast, the GNU General Public\nLicenses are intended to guarantee your freedom to share and change\nfree software--to make sure the software is free for all its users.\n\n  This license, the Lesser General Public License, applies to some\nspecially designated software packages--typically libraries--of the\nFree Software Foundation and other authors who decide to use it.  You\ncan use it too, but we suggest you first think carefully about whether\nthis license or the ordinary General Public License is the better\nstrategy to use in any particular case, based on the explanations below.\n\n  When we speak of free software, we are referring to freedom of use,\nnot price.  Our General Public Licenses are designed to make sure that\nyou have the freedom to distribute copies of free software (and charge\nfor this service if you wish); that you receive source code or can get\nit if you want it; that you can change the software and use pieces of\nit in new free programs; and that you are informed that you can do\nthese things.\n\n  To protect your rights, we need to make restrictions that forbid\ndistributors to deny you these rights or to ask you to surrender these\nrights.  These restrictions translate to certain responsibilities for\nyou if you distribute copies of the library or if you modify it.\n\n  For example, if you distribute copies of the library, whether gratis\nor for a fee, you must give the recipients all the rights that we gave\nyou.  You must make sure that they, too, receive or can get the source\ncode.  If you link other code with the library, you must provide\ncomplete object files to the recipients, so that they can relink them\nwith the library after making changes to the library and recompiling\nit.  And you must show them these terms so they know their rights.\n\n  We protect your rights with a two-step method: (1) we copyright the\nlibrary, and (2) we offer you this license, which gives you legal\npermission to copy, distribute and/or modify the library.\n\n  To protect each distributor, we want to make it very clear that\nthere is no warranty for the free library.  Also, if the library is\nmodified by someone else and passed on, the recipients should know\nthat what they have is not the original version, so that the original\nauthor's reputation will not be affected by problems that might be\nintroduced by others.\n\n  Finally, software patents pose a constant threat to the existence of\nany free program.  We wish to make sure that a company cannot\neffectively restrict the users of a free program by obtaining a\nrestrictive license from a patent holder.  Therefore, we insist that\nany patent license obtained for a version of the library must be\nconsistent with the full freedom of use specified in this license.\n\n  Most GNU software, including some libraries, is covered by the\nordinary GNU General Public License.  This license, the GNU Lesser\nGeneral Public License, applies to certain designated libraries, and\nis quite different from the ordinary General Public License.  We use\nthis license for certain libraries in order to permit linking those\nlibraries into non-free programs.\n\n  When a program is linked with a library, whether statically or using\na shared library, the combination of the two is legally speaking a\ncombined work, a derivative of the original library.  The ordinary\nGeneral Public License therefore permits such linking only if the\nentire combination fits its criteria of freedom.  The Lesser General\nPublic License permits more lax criteria for linking other code with\nthe library.\n\n  We call this license the \"Lesser\" General Public License because it\ndoes Less to protect the user's freedom than the ordinary General\nPublic License.  It also provides other free software developers Less\nof an advantage over competing non-free programs.  These disadvantages\nare the reason we use the ordinary General Public License for many\nlibraries.  However, the Lesser license provides advantages in certain\nspecial circumstances.\n\n  For example, on rare occasions, there may be a special need to\nencourage the widest possible use of a certain library, so that it becomes\na de-facto standard.  To achieve this, non-free programs must be\nallowed to use the library.  A more frequent case is that a free\nlibrary does the same job as widely used non-free libraries.  In this\ncase, there is little to gain by limiting the free library to free\nsoftware only, so we use the Lesser General Public License.\n\n  In other cases, permission to use a particular library in non-free\nprograms enables a greater number of people to use a large body of\nfree software.  For example, permission to use the GNU C Library in\nnon-free programs enables many more people to use the whole GNU\noperating system, as well as its variant, the GNU/Linux operating\nsystem.\n\n  Although the Lesser General Public License is Less protective of the\nusers' freedom, it does ensure that the user of a program that is\nlinked with the Library has the freedom and the wherewithal to run\nthat program using a modified version of the Library.\n\n  The precise terms and conditions for copying, distribution and\nmodification follow.  Pay close attention to the difference between a\n\"work based on the library\" and a \"work that uses the library\".  The\nformer contains code derived from the library, whereas the latter must\nbe combined with the library in order to run.\n\n\t\t  GNU LESSER GENERAL PUBLIC LICENSE\n   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION\n\n  0. This License Agreement applies to any software library or other\nprogram which contains a notice placed by the copyright holder or\nother authorized party saying it may be distributed under the terms of\nthis Lesser General Public License (also called \"this License\").\nEach licensee is addressed as \"you\".\n\n  A \"library\" means a collection of software functions and/or data\nprepared so as to be conveniently linked with application programs\n(which use some of those functions and data) to form executables.\n\n  The \"Library\", below, refers to any such software library or work\nwhich has been distributed under these terms.  A \"work based on the\nLibrary\" means either the Library or any derivative work under\ncopyright law: that is to say, a work containing the Library or a\nportion of it, either verbatim or with modifications and/or translated\nstraightforwardly into another language.  (Hereinafter, translation is\nincluded without limitation in the term \"modification\".)\n\n  \"Source code\" for a work means the preferred form of the work for\nmaking modifications to it.  For a library, complete source code means\nall the source code for all modules it contains, plus any associated\ninterface definition files, plus the scripts used to control compilation\nand installation of the library.\n\n  Activities other than copying, distribution and modification are not\ncovered by this License; they are outside its scope.  The act of\nrunning a program using the Library is not restricted, and output from\nsuch a program is covered only if its contents constitute a work based\non the Library (independent of the use of the Library in a tool for\nwriting it).  Whether that is true depends on what the Library does\nand what the program that uses the Library does.\n  \n  1. You may copy and distribute verbatim copies of the Library's\ncomplete source code as you receive it, in any medium, provided that\nyou conspicuously and appropriately publish on each copy an\nappropriate copyright notice and disclaimer of warranty; keep intact\nall the notices that refer to this License and to the absence of any\nwarranty; and distribute a copy of this License along with the\nLibrary.\n\n  You may charge a fee for the physical act of transferring a copy,\nand you may at your option offer warranty protection in exchange for a\nfee.\n\n  2. You may modify your copy or copies of the Library or any portion\nof it, thus forming a work based on the Library, and copy and\ndistribute such modifications or work under the terms of Section 1\nabove, provided that you also meet all of these conditions:\n\n    a) The modified work must itself be a software library.\n\n    b) You must cause the files modified to carry prominent notices\n    stating that you changed the files and the date of any change.\n\n    c) You must cause the whole of the work to be licensed at no\n    charge to all third parties under the terms of this License.\n\n    d) If a facility in the modified Library refers to a function or a\n    table of data to be supplied by an application program that uses\n    the facility, other than as an argument passed when the facility\n    is invoked, then you must make a good faith effort to ensure that,\n    in the event an application does not supply such function or\n    table, the facility still operates, and performs whatever part of\n    its purpose remains meaningful.\n\n    (For example, a function in a library to compute square roots has\n    a purpose that is entirely well-defined independent of the\n    application.  Therefore, Subsection 2d requires that any\n    application-supplied function or table used by this function must\n    be optional: if the application does not supply it, the square\n    root function must still compute square roots.)\n\nThese requirements apply to the modified work as a whole.  If\nidentifiable sections of that work are not derived from the Library,\nand can be reasonably considered independent and separate works in\nthemselves, then this License, and its terms, do not apply to those\nsections when you distribute them as separate works.  But when you\ndistribute the same sections as part of a whole which is a work based\non the Library, the distribution of the whole must be on the terms of\nthis License, whose permissions for other licensees extend to the\nentire whole, and thus to each and every part regardless of who wrote\nit.\n\nThus, it is not the intent of this section to claim rights or contest\nyour rights to work written entirely by you; rather, the intent is to\nexercise the right to control the distribution of derivative or\ncollective works based on the Library.\n\nIn addition, mere aggregation of another work not based on the Library\nwith the Library (or with a work based on the Library) on a volume of\na storage or distribution medium does not bring the other work under\nthe scope of this License.\n\n  3. You may opt to apply the terms of the ordinary GNU General Public\nLicense instead of this License to a given copy of the Library.  To do\nthis, you must alter all the notices that refer to this License, so\nthat they refer to the ordinary GNU General Public License, version 2,\ninstead of to this License.  (If a newer version than version 2 of the\nordinary GNU General Public License has appeared, then you can specify\nthat version instead if you wish.)  Do not make any other change in\nthese notices.\n\n  Once this change is made in a given copy, it is irreversible for\nthat copy, so the ordinary GNU General Public License applies to all\nsubsequent copies and derivative works made from that copy.\n\n  This option is useful when you wish to copy part of the code of\nthe Library into a program that is not a library.\n\n  4. You may copy and distribute the Library (or a portion or\nderivative of it, under Section 2) in object code or executable form\nunder the terms of Sections 1 and 2 above provided that you accompany\nit with the complete corresponding machine-readable source code, which\nmust be distributed under the terms of Sections 1 and 2 above on a\nmedium customarily used for software interchange.\n\n  If distribution of object code is made by offering access to copy\nfrom a designated place, then offering equivalent access to copy the\nsource code from the same place satisfies the requirement to\ndistribute the source code, even though third parties are not\ncompelled to copy the source along with the object code.\n\n  5. A program that contains no derivative of any portion of the\nLibrary, but is designed to work with the Library by being compiled or\nlinked with it, is called a \"work that uses the Library\".  Such a\nwork, in isolation, is not a derivative work of the Library, and\ntherefore falls outside the scope of this License.\n\n  However, linking a \"work that uses the Library\" with the Library\ncreates an executable that is a derivative of the Library (because it\ncontains portions of the Library), rather than a \"work that uses the\nlibrary\".  The executable is therefore covered by this License.\nSection 6 states terms for distribution of such executables.\n\n  When a \"work that uses the Library\" uses material from a header file\nthat is part of the Library, the object code for the work may be a\nderivative work of the Library even though the source code is not.\nWhether this is true is especially significant if the work can be\nlinked without the Library, or if the work is itself a library.  The\nthreshold for this to be true is not precisely defined by law.\n\n  If such an object file uses only numerical parameters, data\nstructure layouts and accessors, and small macros and small inline\nfunctions (ten lines or less in length), then the use of the object\nfile is unrestricted, regardless of whether it is legally a derivative\nwork.  (Executables containing this object code plus portions of the\nLibrary will still fall under Section 6.)\n\n  Otherwise, if the work is a derivative of the Library, you may\ndistribute the object code for the work under the terms of Section 6.\nAny executables containing that work also fall under Section 6,\nwhether or not they are linked directly with the Library itself.\n\n  6. As an exception to the Sections above, you may also combine or\nlink a \"work that uses the Library\" with the Library to produce a\nwork containing portions of the Library, and distribute that work\nunder terms of your choice, provided that the terms permit\nmodification of the work for the customer's own use and reverse\nengineering for debugging such modifications.\n\n  You must give prominent notice with each copy of the work that the\nLibrary is used in it and that the Library and its use are covered by\nthis License.  You must supply a copy of this License.  If the work\nduring execution displays copyright notices, you must include the\ncopyright notice for the Library among them, as well as a reference\ndirecting the user to the copy of this License.  Also, you must do one\nof these things:\n\n    a) Accompany the work with the complete corresponding\n    machine-readable source code for the Library including whatever\n    changes were used in the work (which must be distributed under\n    Sections 1 and 2 above); and, if the work is an executable linked\n    with the Library, with the complete machine-readable \"work that\n    uses the Library\", as object code and/or source code, so that the\n    user can modify the Library and then relink to produce a modified\n    executable containing the modified Library.  (It is understood\n    that the user who changes the contents of definitions files in the\n    Library will not necessarily be able to recompile the application\n    to use the modified definitions.)\n\n    b) Use a suitable shared library mechanism for linking with the\n    Library.  A suitable mechanism is one that (1) uses at run time a\n    copy of the library already present on the user's computer system,\n    rather than copying library functions into the executable, and (2)\n    will operate properly with a modified version of the library, if\n    the user installs one, as long as the modified version is\n    interface-compatible with the version that the work was made with.\n\n    c) Accompany the work with a written offer, valid for at\n    least three years, to give the same user the materials\n    specified in Subsection 6a, above, for a charge no more\n    than the cost of performing this distribution.\n\n    d) If distribution of the work is made by offering access to copy\n    from a designated place, offer equivalent access to copy the above\n    specified materials from the same place.\n\n    e) Verify that the user has already received a copy of these\n    materials or that you have already sent this user a copy.\n\n  For an executable, the required form of the \"work that uses the\nLibrary\" must include any data and utility programs needed for\nreproducing the executable from it.  However, as a special exception,\nthe materials to be distributed need not include anything that is\nnormally distributed (in either source or binary form) with the major\ncomponents (compiler, kernel, and so on) of the operating system on\nwhich the executable runs, unless that component itself accompanies\nthe executable.\n\n  It may happen that this requirement contradicts the license\nrestrictions of other proprietary libraries that do not normally\naccompany the operating system.  Such a contradiction means you cannot\nuse both them and the Library together in an executable that you\ndistribute.\n\n  7. You may place library facilities that are a work based on the\nLibrary side-by-side in a single library together with other library\nfacilities not covered by this License, and distribute such a combined\nlibrary, provided that the separate distribution of the work based on\nthe Library and of the other library facilities is otherwise\npermitted, and provided that you do these two things:\n\n    a) Accompany the combined library with a copy of the same work\n    based on the Library, uncombined with any other library\n    facilities.  This must be distributed under the terms of the\n    Sections above.\n\n    b) Give prominent notice with the combined library of the fact\n    that part of it is a work based on the Library, and explaining\n    where to find the accompanying uncombined form of the same work.\n\n  8. You may not copy, modify, sublicense, link with, or distribute\nthe Library except as expressly provided under this License.  Any\nattempt otherwise to copy, modify, sublicense, link with, or\ndistribute the Library is void, and will automatically terminate your\nrights under this License.  However, parties who have received copies,\nor rights, from you under this License will not have their licenses\nterminated so long as such parties remain in full compliance.\n\n  9. You are not required to accept this License, since you have not\nsigned it.  However, nothing else grants you permission to modify or\ndistribute the Library or its derivative works.  These actions are\nprohibited by law if you do not accept this License.  Therefore, by\nmodifying or distributing the Library (or any work based on the\nLibrary), you indicate your acceptance of this License to do so, and\nall its terms and conditions for copying, distributing or modifying\nthe Library or works based on it.\n\n  10. Each time you redistribute the Library (or any work based on the\nLibrary), the recipient automatically receives a license from the\noriginal licensor to copy, distribute, link with or modify the Library\nsubject to these terms and conditions.  You may not impose any further\nrestrictions on the recipients' exercise of the rights granted herein.\nYou are not responsible for enforcing compliance by third parties with\nthis License.\n\n  11. If, as a consequence of a court judgment or allegation of patent\ninfringement or for any other reason (not limited to patent issues),\nconditions are imposed on you (whether by court order, agreement or\notherwise) that contradict the conditions of this License, they do not\nexcuse you from the conditions of this License.  If you cannot\ndistribute so as to satisfy simultaneously your obligations under this\nLicense and any other pertinent obligations, then as a consequence you\nmay not distribute the Library at all.  For example, if a patent\nlicense would not permit royalty-free redistribution of the Library by\nall those who receive copies directly or indirectly through you, then\nthe only way you could satisfy both it and this License would be to\nrefrain entirely from distribution of the Library.\n\nIf any portion of this section is held invalid or unenforceable under any\nparticular circumstance, the balance of the section is intended to apply,\nand the section as a whole is intended to apply in other circumstances.\n\nIt is not the purpose of this section to induce you to infringe any\npatents or other property right claims or to contest validity of any\nsuch claims; this section has the sole purpose of protecting the\nintegrity of the free software distribution system which is\nimplemented by public license practices.  Many people have made\ngenerous contributions to the wide range of software distributed\nthrough that system in reliance on consistent application of that\nsystem; it is up to the author/donor to decide if he or she is willing\nto distribute software through any other system and a licensee cannot\nimpose that choice.\n\nThis section is intended to make thoroughly clear what is believed to\nbe a consequence of the rest of this License.\n\n  12. If the distribution and/or use of the Library is restricted in\ncertain countries either by patents or by copyrighted interfaces, the\noriginal copyright holder who places the Library under this License may add\nan explicit geographical distribution limitation excluding those countries,\nso that distribution is permitted only in or among countries not thus\nexcluded.  In such case, this License incorporates the limitation as if\nwritten in the body of this License.\n\n  13. The Free Software Foundation may publish revised and/or new\nversions of the Lesser General Public License from time to time.\nSuch new versions will be similar in spirit to the present version,\nbut may differ in detail to address new problems or concerns.\n\nEach version is given a distinguishing version number.  If the Library\nspecifies a version number of this License which applies to it and\n\"any later version\", you have the option of following the terms and\nconditions either of that version or of any later version published by\nthe Free Software Foundation.  If the Library does not specify a\nlicense version number, you may choose any version ever published by\nthe Free Software Foundation.\n\n  14. If you wish to incorporate parts of the Library into other free\nprograms whose distribution conditions are incompatible with these,\nwrite to the author to ask for permission.  For software which is\ncopyrighted by the Free Software Foundation, write to the Free\nSoftware Foundation; we sometimes make exceptions for this.  Our\ndecision will be guided by the two goals of preserving the free status\nof all derivatives of our free software and of promoting the sharing\nand reuse of software generally.\n\n\t\t\t    NO WARRANTY\n\n  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO\nWARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.\nEXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR\nOTHER PARTIES PROVIDE THE LIBRARY \"AS IS\" WITHOUT WARRANTY OF ANY\nKIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE\nIMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\nPURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE\nLIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME\nTHE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\n\n  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN\nWRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY\nAND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU\nFOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR\nCONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE\nLIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING\nRENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A\nFAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF\nSUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH\nDAMAGES.\n\n\t\t     END OF TERMS AND CONDITIONS\n\n           How to Apply These Terms to Your New Libraries\n\n  If you develop a new library, and you want it to be of the greatest\npossible use to the public, we recommend making it free software that\neveryone can redistribute and change.  You can do so by permitting\nredistribution under these terms (or, alternatively, under the terms of the\nordinary General Public License).\n\n  To apply these terms, attach the following notices to the library.  It is\nsafest to attach them to the start of each source file to most effectively\nconvey the exclusion of warranty; and each file should have at least the\n\"copyright\" line and a pointer to where the full notice is found.\n\n    <one line to give the library's name and a brief idea of what it does.>\n    Copyright (C) <year>  <name of author>\n\n    This library is free software; you can redistribute it and/or\n    modify it under the terms of the GNU Lesser General Public\n    License as published by the Free Software Foundation; either\n    version 2.1 of the License, or (at your option) any later version.\n\n    This library is distributed in the hope that it will be useful,\n    but WITHOUT ANY WARRANTY; without even the implied warranty of\n    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU\n    Lesser General Public License for more details.\n\n    You should have received a copy of the GNU Lesser General Public\n    License along with this library; if not, write to the Free Software\n    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA\n\nAlso add information on how to contact you by electronic and paper mail.\n\nYou should also get your employer (if you work as a programmer) or your\nschool, if any, to sign a \"copyright disclaimer\" for the library, if\nnecessary.  Here is a sample; alter the names:\n\n  Yoyodyne, Inc., hereby disclaims all copyright interest in the\n  library `Frob' (a library for tweaking knobs) written by James Random Hacker.\n\n  <signature of Ty Coon>, 1 April 1990\n  Ty Coon, President of Vice\n\nThat's all there is to it!"
+              }
+            ],
+            "license_expressions": [
+              "lgpl-2.1"
+            ],
+            "percentage_of_license_text": 100,
+            "copyrights": [
+              {
+                "value": "Copyright (c) 1991, 1999 Free Software Foundation, Inc.",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "value": "copyrighted by the Free Software Foundation",
+                "start_line": 429,
+                "end_line": 429
+              }
+            ],
+            "holders": [
+              {
+                "value": "Free Software Foundation, Inc.",
+                "start_line": 4,
+                "end_line": 4
+              },
+              {
+                "value": "the Free Software Foundation",
+                "start_line": 429,
+                "end_line": 429
+              }
+            ],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": true,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": true,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/phpmd.xml",
+            "type": "file",
+            "name": "phpmd.xml",
+            "base_name": "phpmd",
+            "extension": ".xml",
+            "size": 686,
+            "date": "2022-08-06",
+            "sha1": "09f0a2ef79f4618d2e5a43908e92c901259a3617",
+            "md5": "f47e88e1f592c5a32d0ac19673ffa5fd",
+            "sha256": "2e028da54f110e28d1cc5bb8287800a90098d0c01dac6cbefc2f0aef6aadc591",
+            "mime_type": "text/xml",
+            "file_type": "XML 1.0 document, ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "http://pmd.sf.net/ruleset/1.0.0",
+                "start_line": 3,
+                "end_line": 3
+              },
+              {
+                "url": "http://pmd.sf.net/ruleset_xml_schema.xsd",
+                "start_line": 5,
+                "end_line": 5
+              },
+              {
+                "url": "http://edorian.github.com/php-coding-standard-generator/",
+                "start_line": 7,
+                "end_line": 7
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/README.md",
+            "type": "file",
+            "name": "README.md",
+            "base_name": "README",
+            "extension": ".md",
+            "size": 1713,
+            "date": "2022-08-06",
+            "sha1": "1126638450470af69b37e6e82cafe632cf13ba51",
+            "md5": "208b38f9263b5d4768ce6a872f8ea313",
+            "sha256": "7d9e2f43195a083f03ffe1f710b45e910a9df3f9202a49f2ec2a7930eb415b6b",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": true,
+            "is_top_level": true,
+            "is_key_file": true,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/icons",
+            "type": "directory",
+            "name": "icons",
+            "base_name": "icons",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 1,
+            "dirs_count": 0,
+            "size_count": 778,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/icons/information.png",
+            "type": "file",
+            "name": "information.png",
+            "base_name": "information",
+            "extension": ".png",
+            "size": 778,
+            "date": "2022-08-06",
+            "sha1": "04b482344d75d0732275727bd73cceb9b049d276",
+            "md5": "3750c701d2ec35a45d289b9b9c1a0667",
+            "sha256": "ff9c48d8c2d063932c7aadd5e15ddfdc76b7111bf0715f3a192bba26df2c531c",
+            "mime_type": "image/png",
+            "file_type": "PNG image data, 16 x 16, 8-bit/color RGBA, non-interlaced",
+            "programming_language": null,
+            "is_binary": true,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": true,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/js",
+            "type": "directory",
+            "name": "js",
+            "base_name": "js",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 2,
+            "dirs_count": 0,
+            "size_count": 5535,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/js/krumo.js",
+            "type": "file",
+            "name": "krumo.js",
+            "base_name": "krumo",
+            "extension": ".js",
+            "size": 3874,
+            "date": "2022-08-06",
+            "sha1": "e65b0abbf6120699980dce4abcda17cdd6f72ff6",
+            "md5": "99a82cd8cfd221f3c1b446c492d51713",
+            "sha256": "11f3082f82dd86b8d8651cb9fb3f4011d08c2be76bc76e20517f5fd21e4bfaae",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "JavaScript",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [
+              {
+                "url": "https://www.toptal.com/developers/javascript-minifier/api/raw",
+                "start_line": 2,
+                "end_line": 2
+              },
+              {
+                "url": "https://stackoverflow.com/questions/2304941/what-is-the-non-jquery-equivalent-of-document-ready",
+                "start_line": 172,
+                "end_line": 172
+              }
+            ],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/js/krumo.min.js",
+            "type": "file",
+            "name": "krumo.min.js",
+            "base_name": "krumo.min",
+            "extension": ".js",
+            "size": 1661,
+            "date": "2022-08-06",
+            "sha1": "c30c745f5ca221304ff6185d3b1f73c173f03ce7",
+            "md5": "e54a30f7680d2a42b61a2884fcc7cdb0",
+            "sha256": "c82eff828b943a618df4b09cbe00662609e525b3175e49fea586bec4e8408fd6",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text, with very long lines, with no line terminators",
+            "programming_language": "JavaScript",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins",
+            "type": "directory",
+            "name": "skins",
+            "base_name": "skins",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 20,
+            "dirs_count": 7,
+            "size_count": 36475,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/blue",
+            "type": "directory",
+            "name": "blue",
+            "base_name": "blue",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 3,
+            "dirs_count": 0,
+            "size_count": 4797,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/blue/bg.gif",
+            "type": "file",
+            "name": "bg.gif",
+            "base_name": "bg",
+            "extension": ".gif",
+            "size": 141,
+            "date": "2022-08-06",
+            "sha1": "30f5b4191609bfadea746b20fede640887b0f1bc",
+            "md5": "0571095d6bb6b31406fb2070cff1ba46",
+            "sha256": "4e5e9c025a77eb3bceb3e80daf49d9a66edd9005e4a7bf13e5fa394adcc0888c",
+            "mime_type": "image/gif",
+            "file_type": "GIF image data, version 89a, 90 x 9",
+            "programming_language": null,
+            "is_binary": true,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": true,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/blue/skin.css",
+            "type": "file",
+            "name": "skin.css",
+            "base_name": "skin",
+            "extension": ".css",
+            "size": 1779,
+            "date": "2022-08-06",
+            "sha1": "7f7cf673d89ee1c808d7b1cb2f4908552505da29",
+            "md5": "91caadd4153088f67eceeee215973600",
+            "sha256": "d62f98929f2060fed0177539a19ffaf16ea50b1db1e53ed5ce6f20381f8ebfb1",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text, with very long lines",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/blue/skin.unminified.css",
+            "type": "file",
+            "name": "skin.unminified.css",
+            "base_name": "skin.unminified",
+            "extension": ".css",
+            "size": 2877,
+            "date": "2022-08-06",
+            "sha1": "ed0d30ae326cc206aad55fd879d9f28e7bcef4da",
+            "md5": "a2b14ab959c53928be4db93f829771d7",
+            "sha256": "ed2ec5160598346de4b5754719fd2d3d0329367e8b8920464df8add0c10ff36b",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [
+              {
+                "value": "Kaloyan K. Tsvetkov <mrasnika@users.sourceforge.net>",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "mrasnika@users.sourceforge.net",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/default",
+            "type": "directory",
+            "name": "default",
+            "base_name": "default",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 2,
+            "dirs_count": 0,
+            "size_count": 3027,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/default/bg.gif",
+            "type": "file",
+            "name": "bg.gif",
+            "base_name": "bg",
+            "extension": ".gif",
+            "size": 141,
+            "date": "2022-08-06",
+            "sha1": "700e1fbb731a8b21cd5513a1f632136f53fe7f17",
+            "md5": "4b6dc32a322b82802d7f7b8c5dfeea9d",
+            "sha256": "7d4af4e005c3b2a9a63e2505e62ee352eb49c6256a1adc4cd21463d7c0c147f6",
+            "mime_type": "image/gif",
+            "file_type": "GIF image data, version 89a, 90 x 9",
+            "programming_language": null,
+            "is_binary": true,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": true,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/default/skin.css",
+            "type": "file",
+            "name": "skin.css",
+            "base_name": "skin",
+            "extension": ".css",
+            "size": 2886,
+            "date": "2022-08-06",
+            "sha1": "a19b6f8338339bdc72b45ef97edd19613480e5ad",
+            "md5": "87c2164da737bf14ca3c006ff8eb04ba",
+            "sha256": "f508e46b7c7ab5c733bdbabf605e840fddfcedd256fcfb693d18a1e6f49749cd",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [
+              {
+                "value": "Kaloyan K. Tsvetkov <mrasnika@users.sourceforge.net>",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "mrasnika@users.sourceforge.net",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/green",
+            "type": "directory",
+            "name": "green",
+            "base_name": "green",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 3,
+            "dirs_count": 0,
+            "size_count": 4804,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/green/bg.gif",
+            "type": "file",
+            "name": "bg.gif",
+            "base_name": "bg",
+            "extension": ".gif",
+            "size": 141,
+            "date": "2022-08-06",
+            "sha1": "870a05ac94ea9b6a81eadeeffb6a54680c62162e",
+            "md5": "3a4d54b45d2fc8dc964a566929c6dae2",
+            "sha256": "c37c6336daf3abf58f22e3c599334920e7af1e5893245a34b174c8250fea7de8",
+            "mime_type": "image/gif",
+            "file_type": "GIF image data, version 89a, 90 x 9",
+            "programming_language": null,
+            "is_binary": true,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": true,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/green/skin.css",
+            "type": "file",
+            "name": "skin.css",
+            "base_name": "skin",
+            "extension": ".css",
+            "size": 1782,
+            "date": "2022-08-06",
+            "sha1": "87b056e0a132f3fd9603c98f7eb5910a38d6c7b7",
+            "md5": "0d10d0de585c9ad612e772ef1208cae8",
+            "sha256": "bd4f23575265fb0fa8b247a4e63ae2e3267b3c5145586b58a43b7e5209e447db",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text, with very long lines",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/green/skin.unminified.css",
+            "type": "file",
+            "name": "skin.unminified.css",
+            "base_name": "skin.unminified",
+            "extension": ".css",
+            "size": 2881,
+            "date": "2022-08-06",
+            "sha1": "4452511b4031d4f6e093f166a2e8052378f8a00e",
+            "md5": "7d696ee5f604deaed1a786089c7563ee",
+            "sha256": "15404cbcb453b7dc09e5c6fd30615e99ec84d265b74e3d10979a2ed9522e6d70",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [
+              {
+                "value": "Kaloyan K. Tsvetkov <mrasnika@users.sourceforge.net>",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "mrasnika@users.sourceforge.net",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/modern",
+            "type": "directory",
+            "name": "modern",
+            "base_name": "modern",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 2,
+            "dirs_count": 0,
+            "size_count": 6294,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/modern/skin.css",
+            "type": "file",
+            "name": "skin.css",
+            "base_name": "skin",
+            "extension": ".css",
+            "size": 2926,
+            "date": "2022-08-06",
+            "sha1": "f4b62b610f5477acc5483414d891dce8be8a1006",
+            "md5": "e8f70919c7c9397b866831397bc61c8e",
+            "sha256": "9e0981c666743fcd4db419d1bce9f0fc1af145dd0fb483dcbc748e6b5ecdbd99",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text, with very long lines",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/modern/skin.unminified.css",
+            "type": "file",
+            "name": "skin.unminified.css",
+            "base_name": "skin.unminified",
+            "extension": ".css",
+            "size": 3368,
+            "date": "2022-08-06",
+            "sha1": "cd632c9004147618b44e97fb51b04428504e6156",
+            "md5": "6e8755e1bdf4d32808cd7fba63fbceab",
+            "sha256": "ff935913d5b998f12a0c867dc43c024e0997a1d499331a6d2b80b4b4d863266e",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/orange",
+            "type": "directory",
+            "name": "orange",
+            "base_name": "orange",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 2,
+            "dirs_count": 0,
+            "size_count": 5069,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/orange/skin.css",
+            "type": "file",
+            "name": "skin.css",
+            "base_name": "skin",
+            "extension": ".css",
+            "size": 1984,
+            "date": "2022-08-06",
+            "sha1": "09cbcad13a75be23825ef997b321be796ac495ed",
+            "md5": "4510bf06b1d0d1a40b7f6af373f37f4f",
+            "sha256": "f9e4205f13b5da3224ffd5a3c91089647b16c84ff7f4fa97585da221e98fff75",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text, with very long lines",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/orange/skin.unminified.css",
+            "type": "file",
+            "name": "skin.unminified.css",
+            "base_name": "skin.unminified",
+            "extension": ".css",
+            "size": 3085,
+            "date": "2022-08-06",
+            "sha1": "80ee31914e76fa3cd728680228ba5040927dab1b",
+            "md5": "d2fc7ec0db56e1305e72bf699370ee14",
+            "sha256": "0a55c29ca7b1e0186bfd12d4c66e56e97d9ec04bcc1b68bfd60bfec283fff879",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [
+              {
+                "value": "Kaloyan K. Tsvetkov <mrasnika@users.sourceforge.net>",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "mrasnika@users.sourceforge.net",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/schablon.com",
+            "type": "directory",
+            "name": "schablon.com",
+            "base_name": "schablon.com",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 6,
+            "dirs_count": 0,
+            "size_count": 5562,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/schablon.com/collapsed.gif",
+            "type": "file",
+            "name": "collapsed.gif",
+            "base_name": "collapsed",
+            "extension": ".gif",
+            "size": 102,
+            "date": "2022-08-06",
+            "sha1": "a57040f6ca02950fd2bac6b25a4f97df88a2c25c",
+            "md5": "9f822be4370c2c85b107a2a5a4b481a5",
+            "sha256": "f5caf9ab93ea5b7a328398cfbc21260bbc0cc9f26148cd18bc09c11943b345eb",
+            "mime_type": "image/gif",
+            "file_type": "GIF image data, version 89a, 9 x 9",
+            "programming_language": null,
+            "is_binary": true,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": true,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/schablon.com/dotted.gif",
+            "type": "file",
+            "name": "dotted.gif",
+            "base_name": "dotted",
+            "extension": ".gif",
+            "size": 91,
+            "date": "2022-08-06",
+            "sha1": "ee2e3cdf195f2f9649882576dd2c1717f0dd4352",
+            "md5": "4bd0b101111a2679522ab9ea30e51fba",
+            "sha256": "57c3396301215899e29335076f0a76ed3cb75c2f26c0ef88dc2d5bccbe35d4ae",
+            "mime_type": "image/gif",
+            "file_type": "GIF image data, version 89a, 10 x 2",
+            "programming_language": null,
+            "is_binary": true,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": true,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/schablon.com/empty.gif",
+            "type": "file",
+            "name": "empty.gif",
+            "base_name": "empty",
+            "extension": ".gif",
+            "size": 101,
+            "date": "2022-08-06",
+            "sha1": "3f7e39397fdd90196619d5dd3831c086e81650f6",
+            "md5": "f06a9516fc45296d03901eeac555ca36",
+            "sha256": "318d344eba97116021d42482f2c2cebe3d6f6a5fba7b459f7e914751584a6eef",
+            "mime_type": "image/gif",
+            "file_type": "GIF image data, version 89a, 9 x 9",
+            "programming_language": null,
+            "is_binary": true,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": true,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/schablon.com/expanded.gif",
+            "type": "file",
+            "name": "expanded.gif",
+            "base_name": "expanded",
+            "extension": ".gif",
+            "size": 99,
+            "date": "2022-08-06",
+            "sha1": "c3b94c2c4ee2bf215d2c518d629bd573442d3514",
+            "md5": "115925f46a969d6e915e79f6d20c8955",
+            "sha256": "7aed071622594189ded0d863a585429f3a24e7c930cc97e393ed5dd78943f5ce",
+            "mime_type": "image/gif",
+            "file_type": "GIF image data, version 89a, 9 x 9",
+            "programming_language": null,
+            "is_binary": true,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": true,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/schablon.com/skin.css",
+            "type": "file",
+            "name": "skin.css",
+            "base_name": "skin",
+            "extension": ".css",
+            "size": 2013,
+            "date": "2022-08-06",
+            "sha1": "2e7234cdac65f7cc4f39e716d8349e6594e33cd4",
+            "md5": "c92c8c4727e248b5553adc5b938e631a",
+            "sha256": "05786fbbc52ddb3f5159a8734dc5316fb29360946ae8a36461d6d42f0c682238",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text, with very long lines",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/schablon.com/skin.unminified.css",
+            "type": "file",
+            "name": "skin.unminified.css",
+            "base_name": "skin.unminified",
+            "extension": ".css",
+            "size": 3156,
+            "date": "2022-08-06",
+            "sha1": "b6f72c9ba70633c95cf14dd9182b90ef51bab974",
+            "md5": "f29e25a685292473d30f0224ed976bbe",
+            "sha256": "a1e2885f62b4ca08ceb426b10940a73fd0dcc1f569971277f114e3b73f63fa7e",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [
+              {
+                "value": "Kaloyan K. Tsvetkov <mrasnika@users.sourceforge.net>",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "packages": [],
+            "emails": [
+              {
+                "email": "mrasnika@users.sourceforge.net",
+                "start_line": 5,
+                "end_line": 5
+              }
+            ],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/stylish",
+            "type": "directory",
+            "name": "stylish",
+            "base_name": "stylish",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 2,
+            "dirs_count": 0,
+            "size_count": 6922,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/stylish/skin.css",
+            "type": "file",
+            "name": "skin.css",
+            "base_name": "skin",
+            "extension": ".css",
+            "size": 2997,
+            "date": "2022-08-06",
+            "sha1": "83fbbed368302d10d561d0d76259ef36f9c73e45",
+            "md5": "c1fd358545f4c1c49da67fd271bc9dd1",
+            "sha256": "bcbb3113c9fdea76edb0dd0f8710ded3b9b771e49587f5b42714353b41947485",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text, with very long lines, with no line terminators",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/skins/stylish/skin.unminified.css",
+            "type": "file",
+            "name": "skin.unminified.css",
+            "base_name": "skin.unminified",
+            "extension": ".css",
+            "size": 3925,
+            "date": "2022-08-06",
+            "sha1": "e8ef5085ed7b5ecd87d126b406e099bdcf4b1e51",
+            "md5": "11612b0b418d700386a7705c7f781046",
+            "sha256": "1a1eec29232dc59e57b2325b0975cae3f818a462f4e42987e581c31dd8725e6b",
+            "mime_type": "text/plain",
+            "file_type": "ASCII text",
+            "programming_language": "CSS",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/tests",
+            "type": "directory",
+            "name": "tests",
+            "base_name": "tests",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": true,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 3,
+            "dirs_count": 1,
+            "size_count": 2048,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/tests/php",
+            "type": "directory",
+            "name": "php",
+            "base_name": "php",
+            "extension": "",
+            "size": 0,
+            "date": null,
+            "sha1": null,
+            "md5": null,
+            "sha256": null,
+            "mime_type": null,
+            "file_type": null,
+            "programming_language": null,
+            "is_binary": false,
+            "is_text": false,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": false,
+            "is_script": false,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 3,
+            "dirs_count": 0,
+            "size_count": 2048,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/tests/php/class.php",
+            "type": "file",
+            "name": "class.php",
+            "base_name": "class",
+            "extension": ".php",
+            "size": 191,
+            "date": "2022-08-06",
+            "sha1": "92a0f2004cbb650cfccfbb7e9e0a1b38ff083f81",
+            "md5": "fd6d610837870cb278455a4781385158",
+            "sha256": "8eac035934010deb6cc7b79e6c452349cc16a50ae85fcf6277442f94bbf1e51b",
+            "mime_type": "text/x-php",
+            "file_type": "PHP script, ASCII text",
+            "programming_language": "PHP",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": true,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/tests/php/misc.php",
+            "type": "file",
+            "name": "misc.php",
+            "base_name": "misc",
+            "extension": ".php",
+            "size": 1709,
+            "date": "2022-08-06",
+            "sha1": "06e641ceeee54fcf825c8a45ae2dfdf9b406b96b",
+            "md5": "547cd4d16e08a98b3f2e5ad7e7479188",
+            "sha256": "7da49a4e5d07fa9fb18ad3dcfd660455edf680478617a002003efaa7252a9334",
+            "mime_type": "text/x-php",
+            "file_type": "PHP script, ASCII text, with very long lines",
+            "programming_language": "PHP",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": true,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          },
+          {
+            "path": "mmucklo-krumo-29a6fad/tests/php/object.php",
+            "type": "file",
+            "name": "object.php",
+            "base_name": "object",
+            "extension": ".php",
+            "size": 148,
+            "date": "2022-08-06",
+            "sha1": "fc0ff74960198bc2bd2f8411bfe6a93363ffe041",
+            "md5": "621b060a71a4274238be8adcbac1cf1e",
+            "sha256": "693b991939f1b3658f4d57cbf66e25fa314e7b5818a1becfd6a3ed561f2340dc",
+            "mime_type": "text/x-php",
+            "file_type": "PHP script, ASCII text",
+            "programming_language": "PHP",
+            "is_binary": false,
+            "is_text": true,
+            "is_archive": false,
+            "is_media": false,
+            "is_source": true,
+            "is_script": true,
+            "licenses": [],
+            "license_expressions": [],
+            "percentage_of_license_text": 0,
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "packages": [],
+            "emails": [],
+            "urls": [],
+            "is_legal": false,
+            "is_manifest": false,
+            "is_readme": false,
+            "is_top_level": false,
+            "is_key_file": false,
+            "is_generated": false,
+            "is_license_text": false,
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
For composer components, files are packaged under one single sub directory in the root directory. The license file contained in the sub directory is not picked up.  Solve by traversing into the subdirectory to detect license file.

Task: https://github.com/clearlydefined/service/issues/846#issuecomment-1411265574