### PR TITLE
Target Node.js v18

### DIFF
--- a/DevDockerfile
+++ b/DevDockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # FROM node:8-alpine
-FROM node:14
+FROM node:18
 ENV APPDIR=/opt/service
 # RUN apk update && apk upgrade && \
 #    apk add --no-cache bash git openssh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # FROM node:8-alpine
-FROM node:14
+FROM node:18
 ENV APPDIR=/opt/service
 # RUN apk update && apk upgrade && \
 #    apk add --no-cache bash git openssh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pool:
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '14.x'
+      versionSpec: '18.x'
     displayName: 'Install Node.js'
 
   - script: |


### PR DESCRIPTION
Node.js v14 will go EOL on 30th April 2023[^1]. Node.js v18 is the latest LTS release of Node.js and will be supported until 30th April 2025

[^1]: https://github.com/nodejs/release#release-schedule