### PR TITLE
Fallback to package.license_expression in scancode for license

### DIFF
--- a/test/fixtures/scancode/30.1.0/debsrc-license-expression.json
+++ b/test/fixtures/scancode/30.1.0/debsrc-license-expression.json
@@ -1,0 +1,8924 @@
+{
+    "_metadata": {
+        "type": "scancode",
+        "url": "cd:/debsrc/debian/-/python-tenacity/8.0.1-1",
+        "fetchedAt": "2022-03-15T08:37:52.953Z",
+        "links": {
+            "self": {
+                "href": "urn:debsrc:debian:-:python-tenacity:revision:8.0.1-1:tool:scancode:30.3.0",
+                "type": "resource"
+            },
+            "siblings": {
+                "href": "urn:debsrc:debian:-:python-tenacity:revision:8.0.1-1:tool:scancode",
+                "type": "collection"
+            }
+        },
+        "schemaVersion": "30.3.0",
+        "toolVersion": "30.1.0",
+        "contentType": "application/json",
+        "releaseDate": "2022-02-06T23:08:02.000Z",
+        "processedAt": "2022-03-15T08:38:15.390Z"
+    },
+    "content": {
+        "headers": [
+            {
+                "tool_name": "scancode-toolkit",
+                "tool_version": "30.1.0",
+                "options": {
+                    "input": [
+                        "/tmp/cd-43UBv7"
+                    ],
+                    "--classify": true,
+                    "--copyright": true,
+                    "--email": true,
+                    "--generated": true,
+                    "--info": true,
+                    "--is-license-text": true,
+                    "--json-pp": "/tmp/cd-6Gz0BX",
+                    "--license": true,
+                    "--license-clarity-score": true,
+                    "--license-text": true,
+                    "--license-text-diagnostics": true,
+                    "--package": true,
+                    "--processes": "2",
+                    "--strip-root": true,
+                    "--summary": true,
+                    "--summary-key-files": true,
+                    "--timeout": "1000.0",
+                    "--url": true
+                },
+                "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+                "start_timestamp": "2022-03-15T083753.981513",
+                "end_timestamp": "2022-03-15T083814.302904",
+                "output_format_version": "1.0.0",
+                "duration": 20.321408987045288,
+                "message": null,
+                "errors": [],
+                "extra_data": {
+                    "spdx_license_list_version": "3.14",
+                    "OUTDATED": "WARNING: Outdated ScanCode Toolkit version! You are using an outdated version of ScanCode Toolkit: 30.1.0 released on: 2021-09-24. A new version is available with important improvements including bug and security fixes, updated license, copyright and package detection, and improved scanning accuracy. Please download and install the latest version of ScanCode. Visit https://github.com/nexB/scancode-toolkit/releases for details.",
+                    "files_count": 70
+                }
+            }
+        ],
+        "summary": {
+            "license_expressions": [
+                {
+                    "value": "apache-2.0",
+                    "count": 30
+                }
+            ],
+            "copyrights": [
+                {
+                    "value": null,
+                    "count": 53
+                },
+                {
+                    "value": "Copyright Joshua Harlow",
+                    "count": 12
+                },
+                {
+                    "value": "Copyright Julien Danjou",
+                    "count": 12
+                },
+                {
+                    "value": "Copyright Ray",
+                    "count": 12
+                },
+                {
+                    "value": "Copyright Etienne Bersac",
+                    "count": 5
+                },
+                {
+                    "value": "Copyright Elisey Zanko",
+                    "count": 3
+                },
+                {
+                    "value": "(c) Joshua Harlow",
+                    "count": 1
+                },
+                {
+                    "value": "(c) Michal Arbet <michal.arbet@ultimum.io>",
+                    "count": 1
+                },
+                {
+                    "value": "(c) Ondrej Koblizek <kobla@debian.org>",
+                    "count": 1
+                },
+                {
+                    "value": "(c) Ondrej Novy <onovy@debian.org>",
+                    "count": 1
+                },
+                {
+                    "value": "(c) Ray",
+                    "count": 1
+                },
+                {
+                    "value": "Copyright (c) Julien Danjou <julien@danjou.info>",
+                    "count": 1
+                },
+                {
+                    "value": "Copyright (c) Thomas Goirand <zigo@debian.org>",
+                    "count": 1
+                },
+                {
+                    "value": "copyright year. d/control Update Vcs- fields with new Debian Python Team",
+                    "count": 1
+                }
+            ],
+            "holders": [
+                {
+                    "value": null,
+                    "count": 53
+                },
+                {
+                    "value": "Joshua Harlow",
+                    "count": 13
+                },
+                {
+                    "value": "Julien Danjou",
+                    "count": 13
+                },
+                {
+                    "value": "Ray",
+                    "count": 13
+                },
+                {
+                    "value": "Etienne Bersac",
+                    "count": 5
+                },
+                {
+                    "value": "Elisey Zanko",
+                    "count": 3
+                },
+                {
+                    "value": "Michal Arbet",
+                    "count": 1
+                },
+                {
+                    "value": "Ondrej Koblizek",
+                    "count": 1
+                },
+                {
+                    "value": "Ondrej Novy",
+                    "count": 1
+                },
+                {
+                    "value": "Thomas Goirand",
+                    "count": 1
+                },
+                {
+                    "value": "year. d/control Update Vcs- fields with new Debian Python Team",
+                    "count": 1
+                }
+            ],
+            "authors": [
+                {
+                    "value": "Julien Danjou <julien@danjou.info>",
+                    "count": 174
+                },
+                {
+                    "value": null,
+                    "count": 65
+                },
+                {
+                    "value": "immerrr <immerrr@gmail.com>",
+                    "count": 16
+                },
+                {
+                    "value": "Joshua Harlow <harlowja@gmail.com>",
+                    "count": 11
+                },
+                {
+                    "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                    "count": 10
+                },
+                {
+                    "value": "Joshua Harlow <jxharlow@godaddy.com>",
+                    "count": 8
+                },
+                {
+                    "value": "Etienne BERSAC",
+                    "count": 5
+                },
+                {
+                    "value": "Anders Ellenshoj Andersen <andersa@ellenshoej.dk>",
+                    "count": 4
+                },
+                {
+                    "value": "Joshua Harlow <harlowja@yahoo-inc.com>",
+                    "count": 4
+                },
+                {
+                    "value": "Boden R <bodenvmw@gmail.com>",
+                    "count": 3
+                },
+                {
+                    "value": "Craig Younkins <cyounkins@gmail.com>",
+                    "count": 3
+                },
+                {
+                    "value": "John Mezger <mezger.10@gmail.com>",
+                    "count": 3
+                },
+                {
+                    "value": "Sam Park <spark@goodrx.com>",
+                    "count": 3
+                },
+                {
+                    "value": "Simon Dolle <simon.dolle@gmail.com>",
+                    "count": 3
+                },
+                {
+                    "value": "mezgerj <mezger.10@gmail.com>",
+                    "count": 3
+                },
+                {
+                    "value": "Alex Chan <alex@alexwlchan.net>",
+                    "count": 2
+                },
+                {
+                    "value": "Brian Williams <brian.williams@actifio.com>",
+                    "count": 2
+                },
+                {
+                    "value": "Etienne BERSAC <bersace03@cae.li>",
+                    "count": 2
+                },
+                {
+                    "value": "Gevorg Davoian <gdavoian@mirantis.com>",
+                    "count": 2
+                },
+                {
+                    "value": "Hamish Downer <hamish@foobacca.co.uk>",
+                    "count": 2
+                },
+                {
+                    "value": "Julien Danjou Author-email julien@danjou.info",
+                    "count": 2
+                },
+                {
+                    "value": "Michael Elsdorfer <michael@elsdoerfer.info>",
+                    "count": 2
+                },
+                {
+                    "value": "Zane Bitter <zbitter@redhat.com>",
+                    "count": 2
+                },
+                {
+                    "value": "mergify-bot <noreply@mergify.io>",
+                    "count": 2
+                },
+                {
+                    "value": "Alex Kuang <akuang@bizo.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Brian Pandola <bpandola@hsdp.io>",
+                    "count": 1
+                },
+                {
+                    "value": "Brian Williams <briancmwilliams@gmail.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Chen Shijiang <chenshijiang@evision.ai>",
+                    "count": 1
+                },
+                {
+                    "value": "Cyrus Durgin <cyrus@statelessnetworks.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Daniel Bennett <daniel.bennett@wpengine.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Daniel Fortunov <asqui@users.noreply.github.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Daniel Fortunov <dfortunov@bats.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Daniel Nephin <dnephin@yelp.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Dave Hirschfeld <dave.hirschfeld@gmail.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Derek Wilson <dwilson@domaintools.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Elisey Zanko <elisey.zanko@gmail.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Etienne BERSAC <etienne.bersac@dalibo.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Haikel Guemar <hguemar@fedoraproject.org>",
+                    "count": 1
+                },
+                {
+                    "value": "Hannes Grauler <hannes@smasi.de>",
+                    "count": 1
+                },
+                {
+                    "value": "Jaye Doepke <jdoepke@mintel.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Jonathan Herriott <jherriott@bitcasa.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Julien Danjou",
+                    "count": 1
+                },
+                {
+                    "value": "Malthe Borch <mborch@gmail.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Martin Larralde <althonos@users.noreply.github.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Matthew Planchard <mplanchard@users.noreply.github.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Mehdi Abaakouk <sileht@sileht.net>",
+                    "count": 1
+                },
+                {
+                    "value": "Michael Evans <michael.evans@mwrinfosecurity.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Monty Taylor <mordred@inaugust.com>",
+                    "count": 1
+                },
+                {
+                    "value": "N/A Abstract Sphinx",
+                    "count": 1
+                },
+                {
+                    "value": "Ryan Peck <ryan@rypeck.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Saul Shanabrook <s.shanabrook@gmail.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Simeon Visser <svisser@users.noreply.github.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Tim Burke <tim.burke@gmail.com>",
+                    "count": 1
+                },
+                {
+                    "value": "Victor Yap <victor@vicyap.com>",
+                    "count": 1
+                },
+                {
+                    "value": "William Silversmith <william.silversmith@gmail.com>",
+                    "count": 1
+                }
+            ],
+            "programming_language": [
+                {
+                    "value": "Python",
+                    "count": 18
+                },
+                {
+                    "value": "Haxe",
+                    "count": 3
+                },
+                {
+                    "value": "Objective-C",
+                    "count": 1
+                }
+            ],
+            "packages": [
+                {
+                    "type": "pypi",
+                    "namespace": null,
+                    "name": "tenacity",
+                    "version": "8.0.1",
+                    "qualifiers": {},
+                    "subpath": null,
+                    "primary_language": "Python",
+                    "description": "Retry code until it succeeds\nTenacity is a general-purpose retrying library to simplify the task of adding retry behavior to just about anything.",
+                    "release_date": null,
+                    "parties": [
+                        {
+                            "type": "person",
+                            "role": "author",
+                            "name": "Julien Danjou",
+                            "email": "julien@danjou.info",
+                            "url": null
+                        }
+                    ],
+                    "keywords": [
+                        "Intended Audience :: Developers",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3 :: Only",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "Programming Language :: Python :: 3.9",
+                        "Programming Language :: Python :: 3.10",
+                        "Topic :: Utilities"
+                    ],
+                    "homepage_url": "https://github.com/jd/tenacity",
+                    "download_url": null,
+                    "size": null,
+                    "sha1": null,
+                    "md5": null,
+                    "sha256": null,
+                    "sha512": null,
+                    "bug_tracking_url": null,
+                    "code_view_url": null,
+                    "vcs_url": null,
+                    "copyright": null,
+                    "license_expression": "apache-2.0",
+                    "declared_license": {
+                        "license": "Apache 2.0",
+                        "classifiers": [
+                            "License :: OSI Approved :: Apache Software License"
+                        ]
+                    },
+                    "notice_text": null,
+                    "root_path": "tenacity-8.0.1/PKG-INFO",
+                    "dependencies": [],
+                    "contains_source_code": null,
+                    "source_packages": [],
+                    "extra_data": {},
+                    "purl": "pkg:pypi/tenacity@8.0.1",
+                    "repository_homepage_url": "https://pypi.org/project/https://pypi.org",
+                    "repository_download_url": "https://pypi.org/packages/source/t/tenacity/tenacity-8.0.1.tar.gz",
+                    "api_data_url": "https://pypi.org/pypi/tenacity/8.0.1/json",
+                    "files": [
+                        {
+                            "path": "tenacity-8.0.1/PKG-INFO",
+                            "type": "file"
+                        }
+                    ]
+                },
+                {
+                    "type": "pypi",
+                    "namespace": null,
+                    "name": null,
+                    "version": null,
+                    "qualifiers": {},
+                    "subpath": null,
+                    "primary_language": "Python",
+                    "description": null,
+                    "release_date": null,
+                    "parties": [],
+                    "keywords": [],
+                    "homepage_url": null,
+                    "download_url": null,
+                    "size": null,
+                    "sha1": null,
+                    "md5": null,
+                    "sha256": null,
+                    "sha512": null,
+                    "bug_tracking_url": null,
+                    "code_view_url": null,
+                    "vcs_url": null,
+                    "copyright": null,
+                    "license_expression": null,
+                    "declared_license": null,
+                    "notice_text": null,
+                    "root_path": "tenacity-8.0.1/setup.cfg",
+                    "dependencies": [
+                        {
+                            "purl": "pkg:pypi/reno",
+                            "requirement": "reno",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/sphinx",
+                            "requirement": "sphinx",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/tornado",
+                            "requirement": ">=4.5",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        }
+                    ],
+                    "contains_source_code": null,
+                    "source_packages": [],
+                    "extra_data": {},
+                    "purl": null,
+                    "repository_homepage_url": null,
+                    "repository_download_url": null,
+                    "api_data_url": null,
+                    "files": [
+                        {
+                            "path": "tenacity-8.0.1/setup.cfg",
+                            "type": "file"
+                        }
+                    ]
+                },
+                {
+                    "type": "pypi",
+                    "namespace": null,
+                    "name": null,
+                    "version": null,
+                    "qualifiers": {},
+                    "subpath": null,
+                    "primary_language": "Python",
+                    "description": "",
+                    "release_date": null,
+                    "parties": [],
+                    "keywords": [],
+                    "homepage_url": null,
+                    "download_url": null,
+                    "size": null,
+                    "sha1": null,
+                    "md5": null,
+                    "sha256": null,
+                    "sha512": null,
+                    "bug_tracking_url": null,
+                    "code_view_url": null,
+                    "vcs_url": null,
+                    "copyright": null,
+                    "license_expression": null,
+                    "declared_license": {},
+                    "notice_text": null,
+                    "root_path": "tenacity-8.0.1/setup.py",
+                    "dependencies": [],
+                    "contains_source_code": null,
+                    "source_packages": [],
+                    "extra_data": {},
+                    "purl": null,
+                    "repository_homepage_url": null,
+                    "repository_download_url": null,
+                    "api_data_url": null,
+                    "files": [
+                        {
+                            "path": "tenacity-8.0.1/setup.py",
+                            "type": "file"
+                        }
+                    ]
+                },
+                {
+                    "type": "pypi",
+                    "namespace": null,
+                    "name": null,
+                    "version": null,
+                    "qualifiers": {},
+                    "subpath": null,
+                    "primary_language": "Python",
+                    "description": null,
+                    "release_date": null,
+                    "parties": [],
+                    "keywords": [],
+                    "homepage_url": null,
+                    "download_url": null,
+                    "size": null,
+                    "sha1": null,
+                    "md5": null,
+                    "sha256": null,
+                    "sha512": null,
+                    "bug_tracking_url": null,
+                    "code_view_url": null,
+                    "vcs_url": null,
+                    "copyright": null,
+                    "license_expression": null,
+                    "declared_license": null,
+                    "notice_text": null,
+                    "root_path": "tenacity-8.0.1/tox.ini",
+                    "dependencies": [
+                        {
+                            "purl": "pkg:pypi/pytest",
+                            "requirement": "pytest",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/typeguard",
+                            "requirement": "typeguard",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/flake8",
+                            "requirement": "flake8",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/flake8-import-order",
+                            "requirement": "flake8-import-order",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/flake8-blind-except",
+                            "requirement": "flake8-blind-except",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/flake8-builtins",
+                            "requirement": "flake8-builtins",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/flake8-docstrings",
+                            "requirement": "flake8-docstrings",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/flake8-rst-docstrings",
+                            "requirement": "flake8-rst-docstrings",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/flake8-logging-format",
+                            "requirement": "flake8-logging-format",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/black",
+                            "requirement": "black",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/black",
+                            "requirement": "black",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/reno",
+                            "requirement": "reno",
+                            "scope": "install",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        }
+                    ],
+                    "contains_source_code": null,
+                    "source_packages": [],
+                    "extra_data": {},
+                    "purl": null,
+                    "repository_homepage_url": null,
+                    "repository_download_url": null,
+                    "api_data_url": null,
+                    "files": [
+                        {
+                            "path": "tenacity-8.0.1/tox.ini",
+                            "type": "file"
+                        }
+                    ]
+                },
+                {
+                    "type": "pypi",
+                    "namespace": null,
+                    "name": "tenacity",
+                    "version": "8.0.1",
+                    "qualifiers": {},
+                    "subpath": null,
+                    "primary_language": "Python",
+                    "description": "Retry code until it succeeds\nTenacity is a general-purpose retrying library to simplify the task of adding retry behavior to just about anything.",
+                    "release_date": null,
+                    "parties": [
+                        {
+                            "type": "person",
+                            "role": "author",
+                            "name": "Julien Danjou",
+                            "email": "julien@danjou.info",
+                            "url": null
+                        }
+                    ],
+                    "keywords": [
+                        "Intended Audience :: Developers",
+                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3 :: Only",
+                        "Programming Language :: Python :: 3.6",
+                        "Programming Language :: Python :: 3.7",
+                        "Programming Language :: Python :: 3.8",
+                        "Programming Language :: Python :: 3.9",
+                        "Programming Language :: Python :: 3.10",
+                        "Topic :: Utilities"
+                    ],
+                    "homepage_url": "https://github.com/jd/tenacity",
+                    "download_url": null,
+                    "size": null,
+                    "sha1": null,
+                    "md5": null,
+                    "sha256": null,
+                    "sha512": null,
+                    "bug_tracking_url": null,
+                    "code_view_url": null,
+                    "vcs_url": null,
+                    "copyright": null,
+                    "license_expression": "apache-2.0",
+                    "declared_license": {
+                        "license": "Apache 2.0",
+                        "classifiers": [
+                            "License :: OSI Approved :: Apache Software License"
+                        ]
+                    },
+                    "notice_text": null,
+                    "root_path": "tenacity-8.0.1/tenacity.egg-info/PKG-INFO",
+                    "dependencies": [
+                        {
+                            "purl": "pkg:pypi/reno",
+                            "requirement": null,
+                            "scope": "doc",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/sphinx",
+                            "requirement": null,
+                            "scope": "doc",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        },
+                        {
+                            "purl": "pkg:pypi/tornado",
+                            "requirement": ">=4.5",
+                            "scope": "doc",
+                            "is_runtime": true,
+                            "is_optional": false,
+                            "is_resolved": false
+                        }
+                    ],
+                    "contains_source_code": null,
+                    "source_packages": [],
+                    "extra_data": {},
+                    "purl": "pkg:pypi/tenacity@8.0.1",
+                    "repository_homepage_url": "https://pypi.org/project/https://pypi.org",
+                    "repository_download_url": "https://pypi.org/packages/source/t/tenacity/tenacity-8.0.1.tar.gz",
+                    "api_data_url": "https://pypi.org/pypi/tenacity/8.0.1/json",
+                    "files": [
+                        {
+                            "path": "tenacity-8.0.1/tenacity.egg-info/PKG-INFO",
+                            "type": "file"
+                        }
+                    ]
+                }
+            ]
+        },
+        "license_clarity_score": {
+            "score": 50,
+            "declared": true,
+            "discovered": 0.23,
+            "consistency": false,
+            "spdx": false,
+            "license_texts": true
+        },
+        "summary_of_key_files": {
+            "license_expressions": [],
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "programming_language": []
+        },
+        "files": [
+            {
+                "path": "debian",
+                "type": "directory",
+                "name": "debian",
+                "base_name": "debian",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": true,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 15,
+                "dirs_count": 4,
+                "size_count": 104080,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/CHANGELOG",
+                "type": "file",
+                "name": "CHANGELOG",
+                "base_name": "CHANGELOG",
+                "extension": "",
+                "size": 90889,
+                "date": "2022-02-06",
+                "sha1": "b2b22ff8208907eaffb1e85eca937889f68c4085",
+                "md5": "6ac84e545f47dbf940951a4d712b3b14",
+                "sha256": "c668b89b166d59953e5b196a6bb495a1bed46c56e89e8333e267b23e4ceabaee",
+                "mime_type": "text/plain",
+                "file_type": "Git commit 5",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [
+                    {
+                        "value": "Daniel Fortunov <asqui@users.noreply.github.com>",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 20,
+                        "end_line": 20
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 26,
+                        "end_line": 26
+                    },
+                    {
+                        "value": "Matthew Planchard <mplanchard@users.noreply.github.com>",
+                        "start_line": 38,
+                        "end_line": 38
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 56,
+                        "end_line": 56
+                    },
+                    {
+                        "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                        "start_line": 63,
+                        "end_line": 63
+                    },
+                    {
+                        "value": "Anders Ellenshoj Andersen <andersa@ellenshoej.dk>",
+                        "start_line": 71,
+                        "end_line": 71
+                    },
+                    {
+                        "value": "Anders Ellenshoj Andersen <andersa@ellenshoej.dk>",
+                        "start_line": 77,
+                        "end_line": 77
+                    },
+                    {
+                        "value": "Anders Ellenshoj Andersen <andersa@ellenshoej.dk>",
+                        "start_line": 83,
+                        "end_line": 83
+                    },
+                    {
+                        "value": "Anders Ellenshoj Andersen <andersa@ellenshoej.dk>",
+                        "start_line": 89,
+                        "end_line": 89
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 96,
+                        "end_line": 96
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 104,
+                        "end_line": 104
+                    },
+                    {
+                        "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                        "start_line": 111,
+                        "end_line": 111
+                    },
+                    {
+                        "value": "Alex Chan <alex@alexwlchan.net>",
+                        "start_line": 119,
+                        "end_line": 119
+                    },
+                    {
+                        "value": "Alex Chan <alex@alexwlchan.net>",
+                        "start_line": 125,
+                        "end_line": 125
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 150,
+                        "end_line": 150
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 158,
+                        "end_line": 158
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 164,
+                        "end_line": 164
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 171,
+                        "end_line": 171
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 179,
+                        "end_line": 179
+                    },
+                    {
+                        "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                        "start_line": 186,
+                        "end_line": 186
+                    },
+                    {
+                        "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                        "start_line": 195,
+                        "end_line": 195
+                    },
+                    {
+                        "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                        "start_line": 202,
+                        "end_line": 202
+                    },
+                    {
+                        "value": "Etienne BERSAC <bersace03@cae.li>",
+                        "start_line": 210,
+                        "end_line": 210
+                    },
+                    {
+                        "value": "Etienne BERSAC <bersace03@cae.li>",
+                        "start_line": 216,
+                        "end_line": 216
+                    },
+                    {
+                        "value": "Etienne BERSAC <etienne.bersac@dalibo.com>",
+                        "start_line": 224,
+                        "end_line": 224
+                    },
+                    {
+                        "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                        "start_line": 231,
+                        "end_line": 231
+                    },
+                    {
+                        "value": "Chen Shijiang <chenshijiang@evision.ai>",
+                        "start_line": 239,
+                        "end_line": 239
+                    },
+                    {
+                        "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                        "start_line": 246,
+                        "end_line": 246
+                    },
+                    {
+                        "value": "Daniel Fortunov <dfortunov@bats.com>",
+                        "start_line": 254,
+                        "end_line": 254
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 266,
+                        "end_line": 266
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 274,
+                        "end_line": 274
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 280,
+                        "end_line": 280
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 286,
+                        "end_line": 286
+                    },
+                    {
+                        "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                        "start_line": 293,
+                        "end_line": 293
+                    },
+                    {
+                        "value": "mezgerj <mezger.10@gmail.com>",
+                        "start_line": 301,
+                        "end_line": 301
+                    },
+                    {
+                        "value": "mezgerj <mezger.10@gmail.com>",
+                        "start_line": 307,
+                        "end_line": 307
+                    },
+                    {
+                        "value": "mezgerj <mezger.10@gmail.com>",
+                        "start_line": 314,
+                        "end_line": 314
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 320,
+                        "end_line": 320
+                    },
+                    {
+                        "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                        "start_line": 331,
+                        "end_line": 331
+                    },
+                    {
+                        "value": "Malthe Borch <mborch@gmail.com>",
+                        "start_line": 339,
+                        "end_line": 339
+                    },
+                    {
+                        "value": "John Mezger <mezger.10@gmail.com>",
+                        "start_line": 347,
+                        "end_line": 347
+                    },
+                    {
+                        "value": "John Mezger <mezger.10@gmail.com>",
+                        "start_line": 353,
+                        "end_line": 353
+                    },
+                    {
+                        "value": "John Mezger <mezger.10@gmail.com>",
+                        "start_line": 359,
+                        "end_line": 359
+                    },
+                    {
+                        "value": "mergify bot <37929162+mergify bot users.noreply.github.com>",
+                        "start_line": 366,
+                        "end_line": 366
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 375,
+                        "end_line": 375
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 382,
+                        "end_line": 382
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 390,
+                        "end_line": 390
+                    },
+                    {
+                        "value": "Craig Younkins <cyounkins@gmail.com>",
+                        "start_line": 396,
+                        "end_line": 396
+                    },
+                    {
+                        "value": "Craig Younkins <cyounkins@gmail.com>",
+                        "start_line": 411,
+                        "end_line": 411
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 421,
+                        "end_line": 421
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 429,
+                        "end_line": 429
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 436,
+                        "end_line": 436
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 444,
+                        "end_line": 444
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 450,
+                        "end_line": 450
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 456,
+                        "end_line": 456
+                    },
+                    {
+                        "value": "Craig Younkins <cyounkins@gmail.com>",
+                        "start_line": 462,
+                        "end_line": 462
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 468,
+                        "end_line": 468
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 474,
+                        "end_line": 474
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 482,
+                        "end_line": 482
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 488,
+                        "end_line": 488
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 494,
+                        "end_line": 494
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 500,
+                        "end_line": 500
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 506,
+                        "end_line": 506
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 512,
+                        "end_line": 512
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 518,
+                        "end_line": 518
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 524,
+                        "end_line": 524
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 530,
+                        "end_line": 530
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 538,
+                        "end_line": 538
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 544,
+                        "end_line": 544
+                    },
+                    {
+                        "value": "Sam Park <spark@goodrx.com>",
+                        "start_line": 552,
+                        "end_line": 552
+                    },
+                    {
+                        "value": "Sam Park <spark@goodrx.com>",
+                        "start_line": 560,
+                        "end_line": 560
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 568,
+                        "end_line": 568
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 576,
+                        "end_line": 576
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 584,
+                        "end_line": 584
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 590,
+                        "end_line": 590
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 596,
+                        "end_line": 596
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 602,
+                        "end_line": 602
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 618,
+                        "end_line": 618
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 624,
+                        "end_line": 624
+                    },
+                    {
+                        "value": "Sam Park <spark@goodrx.com>",
+                        "start_line": 630,
+                        "end_line": 630
+                    },
+                    {
+                        "value": "Brian Pandola <bpandola@hsdp.io>",
+                        "start_line": 677,
+                        "end_line": 677
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 683,
+                        "end_line": 683
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 698,
+                        "end_line": 698
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 750,
+                        "end_line": 750
+                    },
+                    {
+                        "value": "mergify-bot <noreply@mergify.io>",
+                        "start_line": 770,
+                        "end_line": 770
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 776,
+                        "end_line": 776
+                    },
+                    {
+                        "value": "Dave Hirschfeld <dave.hirschfeld@gmail.com>",
+                        "start_line": 791,
+                        "end_line": 791
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 797,
+                        "end_line": 797
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 803,
+                        "end_line": 803
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 809,
+                        "end_line": 809
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 815,
+                        "end_line": 815
+                    },
+                    {
+                        "value": "mergify-bot <noreply@mergify.io>",
+                        "start_line": 831,
+                        "end_line": 831
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 846,
+                        "end_line": 846
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 852,
+                        "end_line": 852
+                    },
+                    {
+                        "value": "Brian Williams <briancmwilliams@gmail.com>",
+                        "start_line": 867,
+                        "end_line": 867
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 893,
+                        "end_line": 893
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 899,
+                        "end_line": 899
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 905,
+                        "end_line": 905
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 911,
+                        "end_line": 911
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 917,
+                        "end_line": 917
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 932,
+                        "end_line": 932
+                    },
+                    {
+                        "value": "immerrr <immerrr@gmail.com>",
+                        "start_line": 938,
+                        "end_line": 938
+                    },
+                    {
+                        "value": "Hamish Downer <hamish@foobacca.co.uk>",
+                        "start_line": 944,
+                        "end_line": 944
+                    },
+                    {
+                        "value": "Hamish Downer <hamish@foobacca.co.uk>",
+                        "start_line": 953,
+                        "end_line": 953
+                    },
+                    {
+                        "value": "Daniel Bennett <daniel.bennett@wpengine.com>",
+                        "start_line": 959,
+                        "end_line": 959
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 965,
+                        "end_line": 965
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 971,
+                        "end_line": 971
+                    },
+                    {
+                        "value": "Hannes Grauler <hannes@smasi.de>",
+                        "start_line": 977,
+                        "end_line": 977
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 985,
+                        "end_line": 985
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 993,
+                        "end_line": 993
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 999,
+                        "end_line": 999
+                    },
+                    {
+                        "value": "Michael Elsdorfer <michael@elsdoerfer.info>",
+                        "start_line": 1005,
+                        "end_line": 1005
+                    },
+                    {
+                        "value": "Michael Elsdorfer <michael@elsdoerfer.info>",
+                        "start_line": 1011,
+                        "end_line": 1011
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1017,
+                        "end_line": 1017
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1025,
+                        "end_line": 1025
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1031,
+                        "end_line": 1031
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1039,
+                        "end_line": 1039
+                    },
+                    {
+                        "value": "Martin Larralde <althonos@users.noreply.github.com>",
+                        "start_line": 1045,
+                        "end_line": 1045
+                    },
+                    {
+                        "value": "Jaye Doepke <jdoepke@mintel.com>",
+                        "start_line": 1051,
+                        "end_line": 1051
+                    },
+                    {
+                        "value": "Tim Burke <tim.burke@gmail.com>",
+                        "start_line": 1060,
+                        "end_line": 1060
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1070,
+                        "end_line": 1070
+                    },
+                    {
+                        "value": "Joshua Harlow <jxharlow@godaddy.com>",
+                        "start_line": 1078,
+                        "end_line": 1078
+                    },
+                    {
+                        "value": "Joshua Harlow <jxharlow@godaddy.com>",
+                        "start_line": 1088,
+                        "end_line": 1088
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1096,
+                        "end_line": 1096
+                    },
+                    {
+                        "value": "Brian Williams <brian.williams@actifio.com>",
+                        "start_line": 1104,
+                        "end_line": 1104
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1117,
+                        "end_line": 1117
+                    },
+                    {
+                        "value": "Elisey Zanko <elisey.zanko@gmail.com>",
+                        "start_line": 1125,
+                        "end_line": 1125
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1131,
+                        "end_line": 1131
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1139,
+                        "end_line": 1139
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1147,
+                        "end_line": 1147
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1153,
+                        "end_line": 1153
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1159,
+                        "end_line": 1159
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1165,
+                        "end_line": 1165
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1173,
+                        "end_line": 1173
+                    },
+                    {
+                        "value": "Victor Yap <victor@vicyap.com>",
+                        "start_line": 1179,
+                        "end_line": 1179
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1215,
+                        "end_line": 1215
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1221,
+                        "end_line": 1221
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1230,
+                        "end_line": 1230
+                    },
+                    {
+                        "value": "Zane Bitter <zbitter@redhat.com>",
+                        "start_line": 1238,
+                        "end_line": 1238
+                    },
+                    {
+                        "value": "Zane Bitter <zbitter@redhat.com>",
+                        "start_line": 1244,
+                        "end_line": 1244
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1275,
+                        "end_line": 1275
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1297,
+                        "end_line": 1297
+                    },
+                    {
+                        "value": "Brian Williams <brian.williams@actifio.com>",
+                        "start_line": 1305,
+                        "end_line": 1305
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1311,
+                        "end_line": 1311
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1322,
+                        "end_line": 1322
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1330,
+                        "end_line": 1330
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1339,
+                        "end_line": 1339
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1348,
+                        "end_line": 1348
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1356,
+                        "end_line": 1356
+                    },
+                    {
+                        "value": "William Silversmith <william.silversmith@gmail.com>",
+                        "start_line": 1364,
+                        "end_line": 1364
+                    },
+                    {
+                        "value": "Joshua Harlow <jxharlow@godaddy.com>",
+                        "start_line": 1387,
+                        "end_line": 1387
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1393,
+                        "end_line": 1393
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1403,
+                        "end_line": 1403
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1409,
+                        "end_line": 1409
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1421,
+                        "end_line": 1421
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1427,
+                        "end_line": 1427
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1437,
+                        "end_line": 1437
+                    },
+                    {
+                        "value": "Michael Evans <michael.evans@mwrinfosecurity.com>",
+                        "start_line": 1445,
+                        "end_line": 1445
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1451,
+                        "end_line": 1451
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1459,
+                        "end_line": 1459
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1467,
+                        "end_line": 1467
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1475,
+                        "end_line": 1475
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1483,
+                        "end_line": 1483
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1489,
+                        "end_line": 1489
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1497,
+                        "end_line": 1497
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1505,
+                        "end_line": 1505
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1511,
+                        "end_line": 1511
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1521,
+                        "end_line": 1521
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1529,
+                        "end_line": 1529
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1538,
+                        "end_line": 1538
+                    },
+                    {
+                        "value": "Etienne BERSAC",
+                        "start_line": 1546,
+                        "end_line": 1546
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1553,
+                        "end_line": 1553
+                    },
+                    {
+                        "value": "Etienne BERSAC",
+                        "start_line": 1561,
+                        "end_line": 1561
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1568,
+                        "end_line": 1568
+                    },
+                    {
+                        "value": "Etienne BERSAC",
+                        "start_line": 1576,
+                        "end_line": 1576
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1583,
+                        "end_line": 1583
+                    },
+                    {
+                        "value": "Etienne BERSAC",
+                        "start_line": 1591,
+                        "end_line": 1591
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1597,
+                        "end_line": 1597
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1603,
+                        "end_line": 1603
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1611,
+                        "end_line": 1611
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1617,
+                        "end_line": 1617
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1623,
+                        "end_line": 1623
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1630,
+                        "end_line": 1630
+                    },
+                    {
+                        "value": "Etienne BERSAC",
+                        "start_line": 1638,
+                        "end_line": 1638
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1645,
+                        "end_line": 1645
+                    },
+                    {
+                        "value": "Mehdi Abaakouk <sileht@sileht.net>",
+                        "start_line": 1653,
+                        "end_line": 1653
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1659,
+                        "end_line": 1659
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1666,
+                        "end_line": 1666
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1675,
+                        "end_line": 1675
+                    },
+                    {
+                        "value": "Joshua Harlow <jxharlow@godaddy.com>",
+                        "start_line": 1683,
+                        "end_line": 1683
+                    },
+                    {
+                        "value": "Joshua Harlow <jxharlow@godaddy.com>",
+                        "start_line": 1694,
+                        "end_line": 1694
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1701,
+                        "end_line": 1701
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1710,
+                        "end_line": 1710
+                    },
+                    {
+                        "value": "Joshua Harlow <jxharlow@godaddy.com>",
+                        "start_line": 1718,
+                        "end_line": 1718
+                    },
+                    {
+                        "value": "Joshua Harlow <jxharlow@godaddy.com>",
+                        "start_line": 1724,
+                        "end_line": 1724
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1731,
+                        "end_line": 1731
+                    },
+                    {
+                        "value": "Gevorg Davoian <gdavoian@mirantis.com>",
+                        "start_line": 1739,
+                        "end_line": 1739
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1746,
+                        "end_line": 1746
+                    },
+                    {
+                        "value": "Gevorg Davoian <gdavoian@mirantis.com>",
+                        "start_line": 1754,
+                        "end_line": 1754
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1760,
+                        "end_line": 1760
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1769,
+                        "end_line": 1769
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1775,
+                        "end_line": 1775
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1783,
+                        "end_line": 1783
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1789,
+                        "end_line": 1789
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1796,
+                        "end_line": 1796
+                    },
+                    {
+                        "value": "Boden R <bodenvmw@gmail.com>",
+                        "start_line": 1804,
+                        "end_line": 1804
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1820,
+                        "end_line": 1820
+                    },
+                    {
+                        "value": "Boden R <bodenvmw@gmail.com>",
+                        "start_line": 1828,
+                        "end_line": 1828
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1834,
+                        "end_line": 1834
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1843,
+                        "end_line": 1843
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 1851,
+                        "end_line": 1851
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1857,
+                        "end_line": 1857
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1865,
+                        "end_line": 1865
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1873,
+                        "end_line": 1873
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1879,
+                        "end_line": 1879
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1887,
+                        "end_line": 1887
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1895,
+                        "end_line": 1895
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1904,
+                        "end_line": 1904
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1913,
+                        "end_line": 1913
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 1921,
+                        "end_line": 1921
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1928,
+                        "end_line": 1928
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 1936,
+                        "end_line": 1936
+                    },
+                    {
+                        "value": "Boden R <bodenvmw@gmail.com>",
+                        "start_line": 1946,
+                        "end_line": 1946
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1959,
+                        "end_line": 1959
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1968,
+                        "end_line": 1968
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 1976,
+                        "end_line": 1976
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 1984,
+                        "end_line": 1984
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1990,
+                        "end_line": 1990
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 1998,
+                        "end_line": 1998
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2006,
+                        "end_line": 2006
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2012,
+                        "end_line": 2012
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2021,
+                        "end_line": 2021
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2030,
+                        "end_line": 2030
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 2038,
+                        "end_line": 2038
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 2049,
+                        "end_line": 2049
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2062,
+                        "end_line": 2062
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2071,
+                        "end_line": 2071
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 2079,
+                        "end_line": 2079
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2091,
+                        "end_line": 2091
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2097,
+                        "end_line": 2097
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2103,
+                        "end_line": 2103
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2109,
+                        "end_line": 2109
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2116,
+                        "end_line": 2116
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2125,
+                        "end_line": 2125
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 2133,
+                        "end_line": 2133
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 2144,
+                        "end_line": 2144
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2150,
+                        "end_line": 2150
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2158,
+                        "end_line": 2158
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2166,
+                        "end_line": 2166
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2174,
+                        "end_line": 2174
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2182,
+                        "end_line": 2182
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2190,
+                        "end_line": 2190
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2198,
+                        "end_line": 2198
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2206,
+                        "end_line": 2206
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2212,
+                        "end_line": 2212
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2218,
+                        "end_line": 2218
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2226,
+                        "end_line": 2226
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2234,
+                        "end_line": 2234
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2242,
+                        "end_line": 2242
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2248,
+                        "end_line": 2248
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2256,
+                        "end_line": 2256
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2262,
+                        "end_line": 2262
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2270,
+                        "end_line": 2270
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2276,
+                        "end_line": 2276
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2284,
+                        "end_line": 2284
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2292,
+                        "end_line": 2292
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2300,
+                        "end_line": 2300
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2308,
+                        "end_line": 2308
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2316,
+                        "end_line": 2316
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2324,
+                        "end_line": 2324
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2332,
+                        "end_line": 2332
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2340,
+                        "end_line": 2340
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2348,
+                        "end_line": 2348
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2354,
+                        "end_line": 2354
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@gmail.com>",
+                        "start_line": 2362,
+                        "end_line": 2362
+                    },
+                    {
+                        "value": "Joshua Harlow <jxharlow@godaddy.com>",
+                        "start_line": 2380,
+                        "end_line": 2380
+                    },
+                    {
+                        "value": "Ryan Peck <ryan@rypeck.com>",
+                        "start_line": 2413,
+                        "end_line": 2413
+                    },
+                    {
+                        "value": "Cyrus Durgin <cyrus@statelessnetworks.com>",
+                        "start_line": 2437,
+                        "end_line": 2437
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@yahoo-inc.com>",
+                        "start_line": 2460,
+                        "end_line": 2460
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@yahoo-inc.com>",
+                        "start_line": 2466,
+                        "end_line": 2466
+                    },
+                    {
+                        "value": "Julien Danjou <julien@danjou.info>",
+                        "start_line": 2483,
+                        "end_line": 2483
+                    },
+                    {
+                        "value": "Jonathan Herriott <jherriott@bitcasa.com>",
+                        "start_line": 2518,
+                        "end_line": 2518
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@yahoo-inc.com>",
+                        "start_line": 2578,
+                        "end_line": 2578
+                    },
+                    {
+                        "value": "Joshua Harlow <harlowja@yahoo-inc.com>",
+                        "start_line": 2592,
+                        "end_line": 2592
+                    },
+                    {
+                        "value": "Monty Taylor <mordred@inaugust.com>",
+                        "start_line": 2612,
+                        "end_line": 2612
+                    },
+                    {
+                        "value": "Haikel Guemar <hguemar@fedoraproject.org>",
+                        "start_line": 2642,
+                        "end_line": 2642
+                    },
+                    {
+                        "value": "Simeon Visser <svisser@users.noreply.github.com>",
+                        "start_line": 2678,
+                        "end_line": 2678
+                    },
+                    {
+                        "value": "Daniel Nephin <dnephin@yelp.com>",
+                        "start_line": 2705,
+                        "end_line": 2705
+                    },
+                    {
+                        "value": "Saul Shanabrook <s.shanabrook@gmail.com>",
+                        "start_line": 2732,
+                        "end_line": 2732
+                    },
+                    {
+                        "value": "Simon Dolle <simon.dolle@gmail.com>",
+                        "start_line": 2765,
+                        "end_line": 2765
+                    },
+                    {
+                        "value": "Simon Dolle <simon.dolle@gmail.com>",
+                        "start_line": 2771,
+                        "end_line": 2771
+                    },
+                    {
+                        "value": "Simon Dolle <simon.dolle@gmail.com>",
+                        "start_line": 2782,
+                        "end_line": 2782
+                    },
+                    {
+                        "value": "Alex Kuang <akuang@bizo.com>",
+                        "start_line": 2815,
+                        "end_line": 2815
+                    },
+                    {
+                        "value": "Derek Wilson <dwilson@domaintools.com>",
+                        "start_line": 2848,
+                        "end_line": 2848
+                    }
+                ],
+                "packages": [],
+                "emails": [
+                    {
+                        "email": "asqui@users.noreply.github.com",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "email": "julien@danjou.info",
+                        "start_line": 20,
+                        "end_line": 20
+                    },
+                    {
+                        "email": "himself@willemthiart.com",
+                        "start_line": 32,
+                        "end_line": 32
+                    },
+                    {
+                        "email": "mplanchard@users.noreply.github.com",
+                        "start_line": 38,
+                        "end_line": 38
+                    },
+                    {
+                        "email": "andersa@ellenshoej.dk",
+                        "start_line": 71,
+                        "end_line": 71
+                    },
+                    {
+                        "email": "alex@alexwlchan.net",
+                        "start_line": 119,
+                        "end_line": 119
+                    },
+                    {
+                        "email": "bersace03@cae.li",
+                        "start_line": 210,
+                        "end_line": 210
+                    },
+                    {
+                        "email": "etienne.bersac@dalibo.com",
+                        "start_line": 224,
+                        "end_line": 224
+                    },
+                    {
+                        "email": "chenshijiang@evision.ai",
+                        "start_line": 239,
+                        "end_line": 239
+                    },
+                    {
+                        "email": "dfortunov@bats.com",
+                        "start_line": 254,
+                        "end_line": 254
+                    },
+                    {
+                        "email": "mezger.10@gmail.com",
+                        "start_line": 301,
+                        "end_line": 301
+                    },
+                    {
+                        "email": "mborch@gmail.com",
+                        "start_line": 339,
+                        "end_line": 339
+                    },
+                    {
+                        "email": "cyounkins@gmail.com",
+                        "start_line": 396,
+                        "end_line": 396
+                    },
+                    {
+                        "email": "spark@goodrx.com",
+                        "start_line": 552,
+                        "end_line": 552
+                    },
+                    {
+                        "email": "hugovk@users.noreply.github.com",
+                        "start_line": 662,
+                        "end_line": 662
+                    },
+                    {
+                        "email": "bpandola@hsdp.io",
+                        "start_line": 677,
+                        "end_line": 677
+                    },
+                    {
+                        "email": "immerrr@gmail.com",
+                        "start_line": 698,
+                        "end_line": 698
+                    },
+                    {
+                        "email": "forestbiiird@gmail.com",
+                        "start_line": 714,
+                        "end_line": 714
+                    },
+                    {
+                        "email": "mikewooster87@gmail.com",
+                        "start_line": 735,
+                        "end_line": 735
+                    },
+                    {
+                        "email": "noreply@mergify.io",
+                        "start_line": 770,
+                        "end_line": 770
+                    },
+                    {
+                        "email": "dave.hirschfeld@gmail.com",
+                        "start_line": 791,
+                        "end_line": 791
+                    },
+                    {
+                        "email": "briancmwilliams@gmail.com",
+                        "start_line": 867,
+                        "end_line": 867
+                    },
+                    {
+                        "email": "hamish@foobacca.co.uk",
+                        "start_line": 944,
+                        "end_line": 944
+                    },
+                    {
+                        "email": "daniel.bennett@wpengine.com",
+                        "start_line": 959,
+                        "end_line": 959
+                    },
+                    {
+                        "email": "hannes@smasi.de",
+                        "start_line": 977,
+                        "end_line": 977
+                    },
+                    {
+                        "email": "michael@elsdoerfer.info",
+                        "start_line": 1005,
+                        "end_line": 1005
+                    },
+                    {
+                        "email": "althonos@users.noreply.github.com",
+                        "start_line": 1045,
+                        "end_line": 1045
+                    },
+                    {
+                        "email": "jdoepke@mintel.com",
+                        "start_line": 1051,
+                        "end_line": 1051
+                    },
+                    {
+                        "email": "tim.burke@gmail.com",
+                        "start_line": 1060,
+                        "end_line": 1060
+                    },
+                    {
+                        "email": "jxharlow@godaddy.com",
+                        "start_line": 1078,
+                        "end_line": 1078
+                    },
+                    {
+                        "email": "brian.williams@actifio.com",
+                        "start_line": 1104,
+                        "end_line": 1104
+                    },
+                    {
+                        "email": "elisey.zanko@gmail.com",
+                        "start_line": 1125,
+                        "end_line": 1125
+                    },
+                    {
+                        "email": "victor@vicyap.com",
+                        "start_line": 1179,
+                        "end_line": 1179
+                    },
+                    {
+                        "email": "zbitter@redhat.com",
+                        "start_line": 1238,
+                        "end_line": 1238
+                    },
+                    {
+                        "email": "Brian-Williams@users.noreply.github.com",
+                        "start_line": 1283,
+                        "end_line": 1283
+                    },
+                    {
+                        "email": "william.silversmith@gmail.com",
+                        "start_line": 1364,
+                        "end_line": 1364
+                    },
+                    {
+                        "email": "michael.evans@mwrinfosecurity.com",
+                        "start_line": 1445,
+                        "end_line": 1445
+                    },
+                    {
+                        "email": "etienne.bersac@people-doc.com",
+                        "start_line": 1546,
+                        "end_line": 1546
+                    },
+                    {
+                        "email": "sileht@sileht.net",
+                        "start_line": 1653,
+                        "end_line": 1653
+                    },
+                    {
+                        "email": "gdavoian@mirantis.com",
+                        "start_line": 1739,
+                        "end_line": 1739
+                    },
+                    {
+                        "email": "bodenvmw@gmail.com",
+                        "start_line": 1804,
+                        "end_line": 1804
+                    },
+                    {
+                        "email": "harlowja@gmail.com",
+                        "start_line": 1851,
+                        "end_line": 1851
+                    },
+                    {
+                        "email": "github@gmail.com",
+                        "start_line": 2387,
+                        "end_line": 2387
+                    },
+                    {
+                        "email": "ryan@rypeck.com",
+                        "start_line": 2413,
+                        "end_line": 2413
+                    },
+                    {
+                        "email": "cyrus@statelessnetworks.com",
+                        "start_line": 2437,
+                        "end_line": 2437
+                    },
+                    {
+                        "email": "cyrusd@gmail.com",
+                        "start_line": 2443,
+                        "end_line": 2443
+                    },
+                    {
+                        "email": "harlowja@yahoo-inc.com",
+                        "start_line": 2460,
+                        "end_line": 2460
+                    },
+                    {
+                        "email": "ray@blacklocus.com",
+                        "start_line": 2477,
+                        "end_line": 2477
+                    },
+                    {
+                        "email": "jherriott@bitcasa.com",
+                        "start_line": 2518,
+                        "end_line": 2518
+                    },
+                    {
+                        "email": "mordred@inaugust.com",
+                        "start_line": 2612,
+                        "end_line": 2612
+                    }
+                ],
+                "urls": [
+                    {
+                        "url": "https://readthedocs.org/projects/tenacity/builds/9021631/",
+                        "start_line": 145,
+                        "end_line": 145
+                    },
+                    {
+                        "url": "https://github.com/sphinx-doc/sphinx/blob/a503ed8b781cd19f601b5294518aeb8adb9f011e/sphinx/templates/quickstart/conf.py_t#L9-L11",
+                        "start_line": 146,
+                        "end_line": 146
+                    },
+                    {
+                        "url": "https://docs.openstack.org/reno/latest/user/usage.html#within-travis-ci",
+                        "start_line": 557,
+                        "end_line": 557
+                    },
+                    {
+                        "url": "https://www.awsarchitectureblog.com/2015/03/backoff.html",
+                        "start_line": 1269,
+                        "end_line": 1269
+                    },
+                    {
+                        "url": "http://www.cs.utexas.edu/users/lam/NRL/backoff.html",
+                        "start_line": 1270,
+                        "end_line": 1270
+                    },
+                    {
+                        "url": "https://en.wikipedia.org/wiki/Exponential_backoff",
+                        "start_line": 1271,
+                        "end_line": 1271
+                    },
+                    {
+                        "url": "https://github.com/jd/tenacity/pull/27",
+                        "start_line": 1809,
+                        "end_line": 1809
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/changelog",
+                "type": "file",
+                "name": "changelog",
+                "base_name": "changelog",
+                "extension": "",
+                "size": 6547,
+                "date": "2022-02-06",
+                "sha1": "4a792b170eacdeba3521c33cc77f40a9ae318a6a",
+                "md5": "2bb76555653e45e2897a87fd2d947a34",
+                "sha256": "07c65a2e98531e5f4c795a4a4d63a3faff9687f4f9f9adc97d63484d736840a4",
+                "mime_type": "text/plain",
+                "file_type": "UTF-8 Unicode text",
+                "programming_language": "Objective-C",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [
+                    {
+                        "value": "copyright year. d/control Update Vcs- fields with new Debian Python Team",
+                        "start_line": 20,
+                        "end_line": 21
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "year. d/control Update Vcs- fields with new Debian Python Team",
+                        "start_line": 20,
+                        "end_line": 21
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [
+                    {
+                        "email": "samueloph@debian.org",
+                        "start_line": 8,
+                        "end_line": 8
+                    },
+                    {
+                        "email": "morph@debian.org",
+                        "start_line": 15,
+                        "end_line": 15
+                    },
+                    {
+                        "email": "zigo@debian.org",
+                        "start_line": 27,
+                        "end_line": 27
+                    },
+                    {
+                        "email": "onovy@debian.org",
+                        "start_line": 44,
+                        "end_line": 44
+                    },
+                    {
+                        "email": "kobla@debian.org",
+                        "start_line": 68,
+                        "end_line": 68
+                    },
+                    {
+                        "email": "koblizeko@gmail.com",
+                        "start_line": 113,
+                        "end_line": 113
+                    }
+                ],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/control",
+                "type": "file",
+                "name": "control",
+                "base_name": "control",
+                "extension": "",
+                "size": 2097,
+                "date": "2022-02-06",
+                "sha1": "15594abf6d428f72893c182b6f4d0c8535b5ce7d",
+                "md5": "19d49a48170c98e155c961e6c683500c",
+                "sha256": "16a4d3cfccf3b3dc2eb3c48ba2377fc187317203a9c239462472d0505ecd71df",
+                "mime_type": "text/plain",
+                "file_type": "UTF-8 Unicode text",
+                "programming_language": "Haxe",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [
+                    {
+                        "email": "python@tracker.debian.org",
+                        "start_line": 4,
+                        "end_line": 4
+                    },
+                    {
+                        "email": "zigo@debian.org",
+                        "start_line": 6,
+                        "end_line": 6
+                    },
+                    {
+                        "email": "michal.arbet@ultimum.io",
+                        "start_line": 7,
+                        "end_line": 7
+                    },
+                    {
+                        "email": "kobla@debian.org",
+                        "start_line": 8,
+                        "end_line": 8
+                    },
+                    {
+                        "email": "onovy@debian.org",
+                        "start_line": 9,
+                        "end_line": 9
+                    }
+                ],
+                "urls": [
+                    {
+                        "url": "https://salsa.debian.org/python-team/packages/python-tenacity",
+                        "start_line": 25,
+                        "end_line": 25
+                    },
+                    {
+                        "url": "https://salsa.debian.org/python-team/packages/python-tenacity.git",
+                        "start_line": 26,
+                        "end_line": 26
+                    },
+                    {
+                        "url": "https://github.com/jd/tenacity",
+                        "start_line": 27,
+                        "end_line": 27
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/copyright",
+                "type": "file",
+                "name": "copyright",
+                "base_name": "copyright",
+                "extension": "",
+                "size": 1262,
+                "date": "2022-02-06",
+                "sha1": "46ff097a3210433012b9ac819fac8a6f2c5bd087",
+                "md5": "ea5910f6f4196cc6ae8283511861ef2f",
+                "sha256": "565364c17e785925331d26a385bde31d41f22eb4798508ecf6a3ba56c407e01a",
+                "mime_type": "text/plain",
+                "file_type": "UTF-8 Unicode text",
+                "programming_language": "Haxe",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 90,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 9,
+                        "end_line": 9,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_161.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": false,
+                            "is_license_tag": true,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 2,
+                            "matched_length": 2,
+                            "match_coverage": 100,
+                            "rule_relevance": 90
+                        },
+                        "matched_text": "License: Apache-"
+                    },
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 16,
+                        "end_line": 18,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_305.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": true,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 3,
+                            "matched_length": 3,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Apache-2\n\nLicense:"
+                    },
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 18,
+                        "end_line": 18,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_217.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": true,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 2,
+                            "matched_length": 2,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Apache-2"
+                    },
+                    {
+                        "key": "apache-2.0",
+                        "score": 90.48,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 19,
+                        "end_line": 32,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_1019.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [
+                                "/usr/share/common-licenses/Apache-2.0"
+                            ],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "3-seq",
+                            "rule_length": 105,
+                            "matched_length": 95,
+                            "match_coverage": 90.48,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n you may not use this file except in compliance with the License.\n You may obtain a copy of the License at\n .\n    http://www.apache.org/licenses/LICENSE-2.0\n .\n Unless required by applicable law or agreed to in writing, software\n distributed under the License is distributed on an \"AS IS\" BASIS,\n WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n See the License for the specific language governing permissions and\n limitations under the License.\n .\n On Debian-[based] [systems] [the] [full] [text] [of] [the] [Apache] [version] [2].[0] license\n [can] [be] [found] [in] /usr/share/common-licenses/Apache-2.0."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0",
+                    "apache-2.0",
+                    "apache-2.0",
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 52.58,
+                "copyrights": [
+                    {
+                        "value": "Copyright (c) 2013-2016, Julien Danjou <julien@danjou.info>",
+                        "start_line": 6,
+                        "end_line": 6
+                    },
+                    {
+                        "value": "(c) 2016, Joshua Harlow",
+                        "start_line": 7,
+                        "end_line": 7
+                    },
+                    {
+                        "value": "(c) 2013-2014, Ray",
+                        "start_line": 8,
+                        "end_line": 8
+                    },
+                    {
+                        "value": "Copyright (c) 2016, Thomas Goirand <zigo@debian.org>",
+                        "start_line": 12,
+                        "end_line": 12
+                    },
+                    {
+                        "value": "(c) 2017-2019, Ondrej Koblizek <kobla@debian.org>",
+                        "start_line": 13,
+                        "end_line": 13
+                    },
+                    {
+                        "value": "(c) 2018-2020, Ondrej Novy <onovy@debian.org>",
+                        "start_line": 14,
+                        "end_line": 14
+                    },
+                    {
+                        "value": "(c) 2018-2018, Michal Arbet <michal.arbet@ultimum.io>",
+                        "start_line": 15,
+                        "end_line": 15
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 6,
+                        "end_line": 6
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 7,
+                        "end_line": 7
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 8,
+                        "end_line": 8
+                    },
+                    {
+                        "value": "Thomas Goirand",
+                        "start_line": 12,
+                        "end_line": 12
+                    },
+                    {
+                        "value": "Ondrej Koblizek",
+                        "start_line": 13,
+                        "end_line": 13
+                    },
+                    {
+                        "value": "Ondrej Novy",
+                        "start_line": 14,
+                        "end_line": 14
+                    },
+                    {
+                        "value": "Michal Arbet",
+                        "start_line": 15,
+                        "end_line": 15
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [
+                    {
+                        "email": "julien@danjou.info",
+                        "start_line": 6,
+                        "end_line": 6
+                    },
+                    {
+                        "email": "zigo@debian.org",
+                        "start_line": 12,
+                        "end_line": 12
+                    },
+                    {
+                        "email": "kobla@debian.org",
+                        "start_line": 13,
+                        "end_line": 13
+                    },
+                    {
+                        "email": "onovy@debian.org",
+                        "start_line": 14,
+                        "end_line": 14
+                    },
+                    {
+                        "email": "michal.arbet@ultimum.io",
+                        "start_line": 15,
+                        "end_line": 15
+                    }
+                ],
+                "urls": [
+                    {
+                        "url": "https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "url": "https://github.com/jd/tenacity",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 23,
+                        "end_line": 23
+                    }
+                ],
+                "is_legal": true,
+                "is_manifest": true,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/gbp.conf",
+                "type": "file",
+                "name": "gbp.conf",
+                "base_name": "gbp",
+                "extension": ".conf",
+                "size": 31,
+                "date": "2022-02-06",
+                "sha1": "2451a407ee35120f19ca3866c0d8ddec4d504186",
+                "md5": "17c195371ea72125a3c62fc154a984fa",
+                "sha256": "696086f80255977ce81c5e0f9179384f77ee1eb5269fb50e0ac319a957b74c9a",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/python-tenacity-doc.doc-base",
+                "type": "file",
+                "name": "python-tenacity-doc.doc-base",
+                "base_name": "python-tenacity-doc",
+                "extension": ".doc-base",
+                "size": 265,
+                "date": "2022-02-06",
+                "sha1": "cab7c7ad42b43bd3884cd9ba7b20ad9711227a25",
+                "md5": "94a76e8f536ddd647f1f7964987b32c0",
+                "sha256": "00b02b6e1e74ff6370a272b60022eadf78e7c9f072cf68588b57ec6ecac1c724",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [
+                    {
+                        "value": "N/A Abstract Sphinx",
+                        "start_line": 3,
+                        "end_line": 4
+                    }
+                ],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/rules",
+                "type": "file",
+                "name": "rules",
+                "base_name": "rules",
+                "extension": "",
+                "size": 564,
+                "date": "2022-02-06",
+                "sha1": "47d73b1b30733d2c9fa62e75c627ba016aae353b",
+                "md5": "7e60dbe0bef6cd29b11055afa0b58e09",
+                "sha256": "b57a34aba334c9a83f8622fd3c8bbdf0105db6cd7e1da73498efc645ba604043",
+                "mime_type": "text/plain",
+                "file_type": "a /usr/bin/make -f script, ASCII text executable",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/watch",
+                "type": "file",
+                "name": "watch",
+                "base_name": "watch",
+                "extension": "",
+                "size": 142,
+                "date": "2022-02-06",
+                "sha1": "3b5f5b275d04fa265647fd50715e5bafe4cb4d6e",
+                "md5": "e218f205693ec6b2536f681086d30309",
+                "sha256": "cc5dbd6e81f1c581e91c5209a9554a11d0c7b7ddd4a6140cc6d5267d01dfdf76",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "https://pypi.debian.net/tenacity/tenacity-",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/patches",
+                "type": "directory",
+                "name": "patches",
+                "base_name": "patches",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 3,
+                "dirs_count": 0,
+                "size_count": 1749,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/patches/0001-Remove-privacy-breach-in-doc.patch",
+                "type": "file",
+                "name": "0001-Remove-privacy-breach-in-doc.patch",
+                "base_name": "0001-Remove-privacy-breach-in-doc",
+                "extension": ".patch",
+                "size": 1028,
+                "date": "2022-02-06",
+                "sha1": "c05f5972709b44ac0906d5d8a373172905c986b4",
+                "md5": "18a74e47fb52cba27aceb47aa5da231c",
+                "sha256": "86b506110225c5f22fba300d8e395273afacfbfd5f99d394b94986581c636d39",
+                "mime_type": "text/x-diff",
+                "file_type": "unified diff output, ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 28,
+                        "end_line": 28,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_132.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 4,
+                            "matched_length": 4,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Apache 2.0 licensed"
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 2.78,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [
+                    {
+                        "email": "zigo@debian.org",
+                        "start_line": 1,
+                        "end_line": 1
+                    }
+                ],
+                "urls": [
+                    {
+                        "url": "https://img.shields.io/pypi/v/tenacity.svg",
+                        "start_line": 18,
+                        "end_line": 18
+                    },
+                    {
+                        "url": "https://pypi.python.org/pypi/tenacity",
+                        "start_line": 19,
+                        "end_line": 19
+                    },
+                    {
+                        "url": "https://circleci.com/gh/jd/tenacity.svg?style=svg",
+                        "start_line": 21,
+                        "end_line": 21
+                    },
+                    {
+                        "url": "https://circleci.com/gh/jd/tenacity",
+                        "start_line": 22,
+                        "end_line": 22
+                    },
+                    {
+                        "url": "https://img.shields.io/endpoint.svg?url=https://dashboard.mergify.io/badges/jd/tenacity&style=flat",
+                        "start_line": 24,
+                        "end_line": 24
+                    },
+                    {
+                        "url": "https://mergify.io/",
+                        "start_line": 25,
+                        "end_line": 25
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/patches/remove-reno-sphinx-extension.patch",
+                "type": "file",
+                "name": "remove-reno-sphinx-extension.patch",
+                "base_name": "remove-reno-sphinx-extension",
+                "extension": ".patch",
+                "size": 646,
+                "date": "2022-02-06",
+                "sha1": "e712605253eeca52c01178b6467a7c08aab64e40",
+                "md5": "9adba3381e22b36374130bb045c7265b",
+                "sha256": "072335cbe9ae1c3a3f319c1c7568a9e718c5d9f713f1b95e8b24f807773e0bbb",
+                "mime_type": "text/x-diff",
+                "file_type": "unified diff output, ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [
+                    {
+                        "email": "zigo@debian.org",
+                        "start_line": 1,
+                        "end_line": 1
+                    }
+                ],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/patches/series",
+                "type": "file",
+                "name": "series",
+                "base_name": "series",
+                "extension": "",
+                "size": 75,
+                "date": "2022-02-06",
+                "sha1": "1fdda28d103d095dde35241cc0dd0a2defb2d449",
+                "md5": "eb0d25228577f680c4f0326cf90e5457",
+                "sha256": "103ca43eb00ff84ca192c703d7102dc015805f4160ca2aa762d58a4d0ad843fa",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/source",
+                "type": "directory",
+                "name": "source",
+                "base_name": "source",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 2,
+                "dirs_count": 0,
+                "size_count": 54,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/source/format",
+                "type": "file",
+                "name": "format",
+                "base_name": "format",
+                "extension": "",
+                "size": 12,
+                "date": "2022-02-06",
+                "sha1": "1064dc0ce263680c076a1005f35ec906a5cf5a32",
+                "md5": "d3a10140af54ec7371d3b9b084b07c14",
+                "sha256": "1be7080d72e6b566df3e236ce2c55efdfbbb8fa1c972d825e5b672ff8773be1a",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/source/options",
+                "type": "file",
+                "name": "options",
+                "base_name": "options",
+                "extension": "",
+                "size": 42,
+                "date": "2022-02-06",
+                "sha1": "376efdf6725adf6355700dfc04b70674510c3471",
+                "md5": "563eb6c619a4afdc835face81c9f80c7",
+                "sha256": "2cc5452b4dfb102978da04ed0297715370c72092061c207d0a42d50f73550e2b",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/tests",
+                "type": "directory",
+                "name": "tests",
+                "base_name": "tests",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 1,
+                "dirs_count": 0,
+                "size_count": 262,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/tests/control",
+                "type": "file",
+                "name": "control",
+                "base_name": "control",
+                "extension": "",
+                "size": 262,
+                "date": "2022-02-06",
+                "sha1": "1d724d561613120df4a1270df21fab00b029b95e",
+                "md5": "0997b3273e4f04379fef5472ba45e934",
+                "sha256": "71cd3a5a6f081889c18106ddb452a34cb19329441b54d55aede03ed755972c25",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": "Haxe",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/upstream",
+                "type": "directory",
+                "name": "upstream",
+                "base_name": "upstream",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 1,
+                "dirs_count": 0,
+                "size_count": 218,
+                "scan_errors": []
+            },
+            {
+                "path": "debian/upstream/metadata",
+                "type": "file",
+                "name": "metadata",
+                "base_name": "metadata",
+                "extension": "",
+                "size": 218,
+                "date": "2022-02-06",
+                "sha1": "415a7507effeeaf3aca0051c2fba70efacb1269d",
+                "md5": "18a43f12a3725ad9ea2e3ac033d6ee5f",
+                "sha256": "5733d936c79762f99bf217680d9758daafd20128ede4076d6ad042e13aa98f7b",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "https://github.com/jd/tenacity/issues",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "url": "https://github.com/jd/tenacity/issues/new",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "url": "https://github.com/jd/tenacity.git",
+                        "start_line": 4,
+                        "end_line": 4
+                    },
+                    {
+                        "url": "https://github.com/jd/tenacity",
+                        "start_line": 5,
+                        "end_line": 5
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": true,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1",
+                "type": "directory",
+                "name": "tenacity-8.0.1",
+                "base_name": "tenacity-8.0.1",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": true,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 55,
+                "dirs_count": 8,
+                "size_count": 169099,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/.editorconfig",
+                "type": "file",
+                "name": ".editorconfig",
+                "base_name": ".editorconfig",
+                "extension": "",
+                "size": 294,
+                "date": "1970-01-01",
+                "sha1": "889a7d60cc2dad1c0eedebac9c20c08c92e23911",
+                "md5": "352337a10b86467508e12f23e526ccfa",
+                "sha256": "13468ca7f59876c373ddd0f0248c1aed25350536391c862fc349ad1c66ce4701",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/.mergify.yml",
+                "type": "file",
+                "name": ".mergify.yml",
+                "base_name": ".mergify",
+                "extension": ".yml",
+                "size": 2262,
+                "date": "1970-01-01",
+                "sha1": "e95d065aa17665bdc2451be7c9a5f10917fabf21",
+                "md5": "a48f487a76f128c34c457ea4e69b8851",
+                "sha256": "3ba7e44fed0c1c43ebabc184c76cfdcda58ee512eb9717e1d053c18612b4c19d",
+                "mime_type": "text/plain",
+                "file_type": "UTF-8 Unicode text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "https://docs.openstack.org/reno/latest/user/usage.html",
+                        "start_line": 11,
+                        "end_line": 11
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/.readthedocs.yml",
+                "type": "file",
+                "name": ".readthedocs.yml",
+                "base_name": ".readthedocs",
+                "extension": ".yml",
+                "size": 102,
+                "date": "1970-01-01",
+                "sha1": "f35a946b0ec3a930a2d8572039fbafc49a4555ed",
+                "md5": "79f03924f4d1f69ad2a7314a6b35cd9c",
+                "sha256": "a2ba51b607ce4da41d427fce8bd5f0b2decb88041ebacb15ca663fa9f0062fb5",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/AUTHORS",
+                "type": "file",
+                "name": "AUTHORS",
+                "base_name": "AUTHORS",
+                "extension": "",
+                "size": 1788,
+                "date": "1970-01-01",
+                "sha1": "dc07bdb0bfec4f20380f960e73048aa7af452a7e",
+                "md5": "b3c49a4efd07b5bea046bb7f208d8f9f",
+                "sha256": "15ede84925f8ffee99f006d64828cb560ca5248a50e8e7f960b320f226b5855d",
+                "mime_type": "text/plain",
+                "file_type": "UTF-8 Unicode text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [
+                    {
+                        "email": "akuang@bizo.com",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "email": "forestbiiird@gmail.com",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "email": "bodenvmw@gmail.com",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "email": "bpandola@hsdp.io",
+                        "start_line": 4,
+                        "end_line": 4
+                    },
+                    {
+                        "email": "brian.williams@actifio.com",
+                        "start_line": 5,
+                        "end_line": 5
+                    },
+                    {
+                        "email": "briancmwilliams@gmail.com",
+                        "start_line": 6,
+                        "end_line": 6
+                    },
+                    {
+                        "email": "Brian-Williams@users.noreply.github.com",
+                        "start_line": 7,
+                        "end_line": 7
+                    },
+                    {
+                        "email": "cyrus@statelessnetworks.com",
+                        "start_line": 8,
+                        "end_line": 8
+                    },
+                    {
+                        "email": "daniel.bennett@wpengine.com",
+                        "start_line": 9,
+                        "end_line": 9
+                    },
+                    {
+                        "email": "dnephin@yelp.com",
+                        "start_line": 10,
+                        "end_line": 10
+                    },
+                    {
+                        "email": "dave.hirschfeld@gmail.com",
+                        "start_line": 11,
+                        "end_line": 11
+                    },
+                    {
+                        "email": "dwilson@domaintools.com",
+                        "start_line": 12,
+                        "end_line": 12
+                    },
+                    {
+                        "email": "elisey.zanko@gmail.com",
+                        "start_line": 13,
+                        "end_line": 13
+                    },
+                    {
+                        "email": "gdavoian@mirantis.com",
+                        "start_line": 14,
+                        "end_line": 14
+                    },
+                    {
+                        "email": "hamish@foobacca.co.uk",
+                        "start_line": 15,
+                        "end_line": 15
+                    },
+                    {
+                        "email": "hannes@smasi.de",
+                        "start_line": 16,
+                        "end_line": 16
+                    },
+                    {
+                        "email": "hguemar@fedoraproject.org",
+                        "start_line": 17,
+                        "end_line": 17
+                    },
+                    {
+                        "email": "hugovk@users.noreply.github.com",
+                        "start_line": 18,
+                        "end_line": 18
+                    },
+                    {
+                        "email": "jdoepke@mintel.com",
+                        "start_line": 19,
+                        "end_line": 19
+                    },
+                    {
+                        "email": "jherriott@bitcasa.com",
+                        "start_line": 20,
+                        "end_line": 20
+                    },
+                    {
+                        "email": "harlowja@gmail.com",
+                        "start_line": 21,
+                        "end_line": 21
+                    },
+                    {
+                        "email": "harlowja@yahoo-inc.com",
+                        "start_line": 22,
+                        "end_line": 22
+                    },
+                    {
+                        "email": "jxharlow@godaddy.com",
+                        "start_line": 23,
+                        "end_line": 23
+                    },
+                    {
+                        "email": "julien@danjou.info",
+                        "start_line": 24,
+                        "end_line": 24
+                    },
+                    {
+                        "email": "althonos@users.noreply.github.com",
+                        "start_line": 25,
+                        "end_line": 25
+                    },
+                    {
+                        "email": "sileht@sileht.net",
+                        "start_line": 26,
+                        "end_line": 26
+                    },
+                    {
+                        "email": "michael@elsdoerfer.info",
+                        "start_line": 27,
+                        "end_line": 27
+                    },
+                    {
+                        "email": "michael.evans@mwrinfosecurity.com",
+                        "start_line": 28,
+                        "end_line": 28
+                    },
+                    {
+                        "email": "mikewooster87@gmail.com",
+                        "start_line": 29,
+                        "end_line": 29
+                    },
+                    {
+                        "email": "mordred@inaugust.com",
+                        "start_line": 30,
+                        "end_line": 30
+                    },
+                    {
+                        "email": "github@gmail.com",
+                        "start_line": 31,
+                        "end_line": 31
+                    },
+                    {
+                        "email": "ray@blacklocus.com",
+                        "start_line": 32,
+                        "end_line": 32
+                    },
+                    {
+                        "email": "ryan@rypeck.com",
+                        "start_line": 33,
+                        "end_line": 33
+                    },
+                    {
+                        "email": "spark@goodrx.com",
+                        "start_line": 34,
+                        "end_line": 34
+                    },
+                    {
+                        "email": "s.shanabrook@gmail.com",
+                        "start_line": 35,
+                        "end_line": 35
+                    },
+                    {
+                        "email": "svisser@users.noreply.github.com",
+                        "start_line": 36,
+                        "end_line": 36
+                    },
+                    {
+                        "email": "simon.dolle@gmail.com",
+                        "start_line": 37,
+                        "end_line": 37
+                    },
+                    {
+                        "email": "tim.burke@gmail.com",
+                        "start_line": 38,
+                        "end_line": 38
+                    },
+                    {
+                        "email": "victor@vicyap.com",
+                        "start_line": 39,
+                        "end_line": 39
+                    },
+                    {
+                        "email": "william.silversmith@gmail.com",
+                        "start_line": 40,
+                        "end_line": 40
+                    },
+                    {
+                        "email": "zbitter@redhat.com",
+                        "start_line": 41,
+                        "end_line": 41
+                    },
+                    {
+                        "email": "cyrusd@gmail.com",
+                        "start_line": 42,
+                        "end_line": 42
+                    },
+                    {
+                        "email": "immerrr@gmail.com",
+                        "start_line": 43,
+                        "end_line": 43
+                    },
+                    {
+                        "email": "noreply@mergify.io",
+                        "start_line": 44,
+                        "end_line": 44
+                    },
+                    {
+                        "email": "etienne.bersac@people-doc.com",
+                        "start_line": 46,
+                        "end_line": 46
+                    }
+                ],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/LICENSE",
+                "type": "file",
+                "name": "LICENSE",
+                "base_name": "LICENSE",
+                "extension": "",
+                "size": 11357,
+                "date": "1970-01-01",
+                "sha1": "1128f8f91104ba9ef98d37eea6523a888dcfa5de",
+                "md5": "175792518e4ac015ab6696d16c4f607e",
+                "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 2,
+                        "end_line": 202,
+                        "matched_rule": {
+                            "identifier": "apache-2.0.LICENSE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": true,
+                            "is_license_notice": false,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "1-hash",
+                            "rule_length": 1581,
+                            "matched_length": 1581,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright [yyyy] [name of copyright owner]\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 100,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/",
+                        "start_line": 4,
+                        "end_line": 4
+                    },
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 196,
+                        "end_line": 196
+                    }
+                ],
+                "is_legal": true,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": true,
+                "is_license_text": true,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/PKG-INFO",
+                "type": "file",
+                "name": "PKG-INFO",
+                "base_name": "PKG-INFO",
+                "extension": "",
+                "size": 967,
+                "date": "1970-01-01",
+                "sha1": "22b86313b4a28b7ff06082f94179b082a7bbdbf2",
+                "md5": "249bc229e3415b1b855c1950bc0bcbca",
+                "sha256": "57867fdd81accb937cd806b920aa9fbee5f7896158abf74b393aa1224b1d3ddf",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 8,
+                        "end_line": 8,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_65.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": false,
+                            "is_license_tag": true,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 4,
+                            "matched_length": 4,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "License: Apache 2.0"
+                    },
+                    {
+                        "key": "apache-2.0",
+                        "score": 95,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 11,
+                        "end_line": 11,
+                        "matched_rule": {
+                            "identifier": "pypi_apache_no-version.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": false,
+                            "is_license_tag": true,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 6,
+                            "matched_length": 6,
+                            "match_coverage": 100,
+                            "rule_relevance": 95
+                        },
+                        "matched_text": "License :: OSI Approved :: Apache Software License"
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0",
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 7.87,
+                "copyrights": [],
+                "holders": [],
+                "authors": [
+                    {
+                        "value": "Julien Danjou Author-email julien@danjou.info",
+                        "start_line": 6,
+                        "end_line": 7
+                    }
+                ],
+                "packages": [
+                    {
+                        "type": "pypi",
+                        "namespace": null,
+                        "name": "tenacity",
+                        "version": "8.0.1",
+                        "qualifiers": {},
+                        "subpath": null,
+                        "primary_language": "Python",
+                        "description": "Retry code until it succeeds\nTenacity is a general-purpose retrying library to simplify the task of adding retry behavior to just about anything.",
+                        "release_date": null,
+                        "parties": [
+                            {
+                                "type": "person",
+                                "role": "author",
+                                "name": "Julien Danjou",
+                                "email": "julien@danjou.info",
+                                "url": null
+                            }
+                        ],
+                        "keywords": [
+                            "Intended Audience :: Developers",
+                            "Programming Language :: Python",
+                            "Programming Language :: Python :: 3",
+                            "Programming Language :: Python :: 3 :: Only",
+                            "Programming Language :: Python :: 3.6",
+                            "Programming Language :: Python :: 3.7",
+                            "Programming Language :: Python :: 3.8",
+                            "Programming Language :: Python :: 3.9",
+                            "Programming Language :: Python :: 3.10",
+                            "Topic :: Utilities"
+                        ],
+                        "homepage_url": "https://github.com/jd/tenacity",
+                        "download_url": null,
+                        "size": null,
+                        "sha1": null,
+                        "md5": null,
+                        "sha256": null,
+                        "sha512": null,
+                        "bug_tracking_url": null,
+                        "code_view_url": null,
+                        "vcs_url": null,
+                        "copyright": null,
+                        "license_expression": "apache-2.0",
+                        "declared_license": {
+                            "license": "Apache 2.0",
+                            "classifiers": [
+                                "License :: OSI Approved :: Apache Software License"
+                            ]
+                        },
+                        "notice_text": null,
+                        "root_path": "tenacity-8.0.1/PKG-INFO",
+                        "dependencies": [],
+                        "contains_source_code": null,
+                        "source_packages": [],
+                        "extra_data": {},
+                        "purl": "pkg:pypi/tenacity@8.0.1",
+                        "repository_homepage_url": "https://pypi.org/project/https://pypi.org",
+                        "repository_download_url": "https://pypi.org/packages/source/t/tenacity/tenacity-8.0.1.tar.gz",
+                        "api_data_url": "https://pypi.org/pypi/tenacity/8.0.1/json",
+                        "files": [
+                            {
+                                "path": "tenacity-8.0.1/PKG-INFO",
+                                "type": "file"
+                            }
+                        ]
+                    }
+                ],
+                "emails": [
+                    {
+                        "email": "julien@danjou.info",
+                        "start_line": 7,
+                        "end_line": 7
+                    }
+                ],
+                "urls": [
+                    {
+                        "url": "https://github.com/jd/tenacity",
+                        "start_line": 5,
+                        "end_line": 5
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/pyproject.toml",
+                "type": "file",
+                "name": "pyproject.toml",
+                "base_name": "pyproject",
+                "extension": ".toml",
+                "size": 507,
+                "date": "1970-01-01",
+                "sha1": "551043d06423330f6f86eba3f8459a9e258fd7a9",
+                "md5": "8300704948f83cd73c7948f066079715",
+                "sha256": "505f8afea8e41cfc330855c1ee680d0db4e45699456c9cafde7833751a0b3783",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": true,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/README.rst",
+                "type": "file",
+                "name": "README.rst",
+                "base_name": "README",
+                "extension": ".rst",
+                "size": 15733,
+                "date": "1970-01-01",
+                "sha1": "cd2ecdd63c2c7c82f9de476729f98e633dd79191",
+                "md5": "46a89362fb3b5779b01a47c432f6b9b3",
+                "sha256": "98cf4a1e42166259bd86ad38f0477beae936605405ba0351c45e54e6c0c6e201",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, ASCII text executable",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 13,
+                        "end_line": 13,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_132.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 4,
+                            "matched_length": 4,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Apache 2.0 licensed"
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 0.19,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "https://img.shields.io/pypi/v/tenacity.svg",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "url": "https://pypi.python.org/pypi/tenacity",
+                        "start_line": 4,
+                        "end_line": 4
+                    },
+                    {
+                        "url": "https://circleci.com/gh/jd/tenacity.svg?style=svg",
+                        "start_line": 6,
+                        "end_line": 6
+                    },
+                    {
+                        "url": "https://circleci.com/gh/jd/tenacity",
+                        "start_line": 7,
+                        "end_line": 7
+                    },
+                    {
+                        "url": "https://img.shields.io/endpoint.svg?url=https://dashboard.mergify.io/badges/jd/tenacity&style=flat",
+                        "start_line": 9,
+                        "end_line": 9
+                    },
+                    {
+                        "url": "https://mergify.io/",
+                        "start_line": 10,
+                        "end_line": 10
+                    },
+                    {
+                        "url": "https://github.com/rholder/retrying/issues/65",
+                        "start_line": 16,
+                        "end_line": 16
+                    },
+                    {
+                        "url": "https://julien.danjou.info/python-tenacity/",
+                        "start_line": 17,
+                        "end_line": 17
+                    },
+                    {
+                        "url": "https://github.com/jd/tenacity",
+                        "start_line": 585,
+                        "end_line": 585
+                    },
+                    {
+                        "url": "https://docs.openstack.org/reno/latest/user/usage.html",
+                        "start_line": 599,
+                        "end_line": 599
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": true,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/reno.yaml",
+                "type": "file",
+                "name": "reno.yaml",
+                "base_name": "reno",
+                "extension": ".yaml",
+                "size": 41,
+                "date": "1970-01-01",
+                "sha1": "84ca1f0866f985a21f20a8c975bb91b0bdbb75a6",
+                "md5": "9f625c87c6375769b4df921f73e6784e",
+                "sha256": "8eb34cb87752cbdb6d10e2ed24a3d2365651dd9a5c93385c582e4c62e51de5d6",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/setup.cfg",
+                "type": "file",
+                "name": "setup.cfg",
+                "base_name": "setup",
+                "extension": ".cfg",
+                "size": 1108,
+                "date": "1970-01-01",
+                "sha1": "80efbd1f41b7b6c668a67979d9906fac20717f22",
+                "md5": "308c4bf64d4f8e1d8b8072fdf5e724d7",
+                "sha256": "666a79fb48f15f5e80d4020d313745ad36dd31ba51853e30bb0ed68cacd0f4db",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 3,
+                        "end_line": 3,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_65.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": false,
+                            "is_license_tag": true,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 4,
+                            "matched_length": 4,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "license = Apache 2.0"
+                    },
+                    {
+                        "key": "apache-2.0",
+                        "score": 95,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 12,
+                        "end_line": 12,
+                        "matched_rule": {
+                            "identifier": "pypi_apache_no-version.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": false,
+                            "is_license_tag": true,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 6,
+                            "matched_length": 6,
+                            "match_coverage": 100,
+                            "rule_relevance": 95
+                        },
+                        "matched_text": "License :: OSI Approved :: Apache Software License"
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0",
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 6.94,
+                "copyrights": [],
+                "holders": [],
+                "authors": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 7,
+                        "end_line": 7
+                    }
+                ],
+                "packages": [
+                    {
+                        "type": "pypi",
+                        "namespace": null,
+                        "name": null,
+                        "version": null,
+                        "qualifiers": {},
+                        "subpath": null,
+                        "primary_language": "Python",
+                        "description": null,
+                        "release_date": null,
+                        "parties": [],
+                        "keywords": [],
+                        "homepage_url": null,
+                        "download_url": null,
+                        "size": null,
+                        "sha1": null,
+                        "md5": null,
+                        "sha256": null,
+                        "sha512": null,
+                        "bug_tracking_url": null,
+                        "code_view_url": null,
+                        "vcs_url": null,
+                        "copyright": null,
+                        "license_expression": null,
+                        "declared_license": null,
+                        "notice_text": null,
+                        "root_path": "tenacity-8.0.1/setup.cfg",
+                        "dependencies": [
+                            {
+                                "purl": "pkg:pypi/reno",
+                                "requirement": "reno",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/sphinx",
+                                "requirement": "sphinx",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/tornado",
+                                "requirement": ">=4.5",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            }
+                        ],
+                        "contains_source_code": null,
+                        "source_packages": [],
+                        "extra_data": {},
+                        "purl": null,
+                        "repository_homepage_url": null,
+                        "repository_download_url": null,
+                        "api_data_url": null,
+                        "files": [
+                            {
+                                "path": "tenacity-8.0.1/setup.cfg",
+                                "type": "file"
+                            }
+                        ]
+                    }
+                ],
+                "emails": [
+                    {
+                        "email": "julien@danjou.info",
+                        "start_line": 8,
+                        "end_line": 8
+                    }
+                ],
+                "urls": [
+                    {
+                        "url": "https://github.com/jd/tenacity",
+                        "start_line": 4,
+                        "end_line": 4
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": true,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/setup.py",
+                "type": "file",
+                "name": "setup.py",
+                "base_name": "setup",
+                "extension": ".py",
+                "size": 674,
+                "date": "1970-01-01",
+                "sha1": "bc9b3cd24c842906831213481a7b5559dc2e9c72",
+                "md5": "4b20f54c5dad95b3d38ad3150087a294",
+                "sha256": "88c409816229d35a1eb18bfe017474be899f0acbf5ee01abcbb05ceff1bad94c",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, ASCII text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 3,
+                        "end_line": 14,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#    http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n# implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 84.16,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [
+                    {
+                        "type": "pypi",
+                        "namespace": null,
+                        "name": null,
+                        "version": null,
+                        "qualifiers": {},
+                        "subpath": null,
+                        "primary_language": "Python",
+                        "description": "",
+                        "release_date": null,
+                        "parties": [],
+                        "keywords": [],
+                        "homepage_url": null,
+                        "download_url": null,
+                        "size": null,
+                        "sha1": null,
+                        "md5": null,
+                        "sha256": null,
+                        "sha512": null,
+                        "bug_tracking_url": null,
+                        "code_view_url": null,
+                        "vcs_url": null,
+                        "copyright": null,
+                        "license_expression": null,
+                        "declared_license": {},
+                        "notice_text": null,
+                        "root_path": "tenacity-8.0.1/setup.py",
+                        "dependencies": [],
+                        "contains_source_code": null,
+                        "source_packages": [],
+                        "extra_data": {},
+                        "purl": null,
+                        "repository_homepage_url": null,
+                        "repository_download_url": null,
+                        "api_data_url": null,
+                        "files": [
+                            {
+                                "path": "tenacity-8.0.1/setup.py",
+                                "type": "file"
+                            }
+                        ]
+                    }
+                ],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 7,
+                        "end_line": 7
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": true,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tox.ini",
+                "type": "file",
+                "name": "tox.ini",
+                "base_name": "tox",
+                "extension": ".ini",
+                "size": 1008,
+                "date": "1970-01-01",
+                "sha1": "9502549be04b9aff47a6acfbef7c9a4244654afd",
+                "md5": "9f73a2b6bb7f3acca1bcc63ee000b924",
+                "sha256": "2d433ed679415d7d1a97d009356395f6ec9ed3a4f7d50acb5f57a30b4da8627d",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [
+                    {
+                        "type": "pypi",
+                        "namespace": null,
+                        "name": null,
+                        "version": null,
+                        "qualifiers": {},
+                        "subpath": null,
+                        "primary_language": "Python",
+                        "description": null,
+                        "release_date": null,
+                        "parties": [],
+                        "keywords": [],
+                        "homepage_url": null,
+                        "download_url": null,
+                        "size": null,
+                        "sha1": null,
+                        "md5": null,
+                        "sha256": null,
+                        "sha512": null,
+                        "bug_tracking_url": null,
+                        "code_view_url": null,
+                        "vcs_url": null,
+                        "copyright": null,
+                        "license_expression": null,
+                        "declared_license": null,
+                        "notice_text": null,
+                        "root_path": "tenacity-8.0.1/tox.ini",
+                        "dependencies": [
+                            {
+                                "purl": "pkg:pypi/pytest",
+                                "requirement": "pytest",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/typeguard",
+                                "requirement": "typeguard",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/flake8",
+                                "requirement": "flake8",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/flake8-import-order",
+                                "requirement": "flake8-import-order",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/flake8-blind-except",
+                                "requirement": "flake8-blind-except",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/flake8-builtins",
+                                "requirement": "flake8-builtins",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/flake8-docstrings",
+                                "requirement": "flake8-docstrings",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/flake8-rst-docstrings",
+                                "requirement": "flake8-rst-docstrings",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/flake8-logging-format",
+                                "requirement": "flake8-logging-format",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/black",
+                                "requirement": "black",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/black",
+                                "requirement": "black",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/reno",
+                                "requirement": "reno",
+                                "scope": "install",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            }
+                        ],
+                        "contains_source_code": null,
+                        "source_packages": [],
+                        "extra_data": {},
+                        "purl": null,
+                        "repository_homepage_url": null,
+                        "repository_download_url": null,
+                        "api_data_url": null,
+                        "files": [
+                            {
+                                "path": "tenacity-8.0.1/tox.ini",
+                                "type": "file"
+                            }
+                        ]
+                    }
+                ],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/.circleci",
+                "type": "directory",
+                "name": ".circleci",
+                "base_name": ".circleci",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 1,
+                "dirs_count": 0,
+                "size_count": 1966,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/.circleci/config.yml",
+                "type": "file",
+                "name": "config.yml",
+                "base_name": "config",
+                "extension": ".yml",
+                "size": 1966,
+                "date": "1970-01-01",
+                "sha1": "34d0a4d7d9027d31d75ac8e2c2b49ae584ea7a81",
+                "md5": "9e4043d00385d56da6cf63917ca05986",
+                "sha256": "737987ab4e37873612f9e137636f5b17ac97d0c8432b4b318b3a830b53cd8eb9",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/doc",
+                "type": "directory",
+                "name": "doc",
+                "base_name": "doc",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 4,
+                "dirs_count": 1,
+                "size_count": 18133,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/doc/source",
+                "type": "directory",
+                "name": "source",
+                "base_name": "source",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 4,
+                "dirs_count": 0,
+                "size_count": 18133,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/doc/source/api.rst",
+                "type": "file",
+                "name": "api.rst",
+                "base_name": "api",
+                "extension": ".rst",
+                "size": 1490,
+                "date": "1970-01-01",
+                "sha1": "6eafda84c5e67c6dfbbba2c85c25b6645b3891d5",
+                "md5": "e8075284b8f70407416a1c1e05a6fdd2",
+                "sha256": "6336e527d3baab691622d00235a3ccecca718cf5ebdf1b01b6419ae4370e4a1e",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/doc/source/changelog.rst",
+                "type": "file",
+                "name": "changelog.rst",
+                "base_name": "changelog",
+                "extension": ".rst",
+                "size": 40,
+                "date": "1970-01-01",
+                "sha1": "a1fdc1312460f9334ab2cff1f2e0b24a6e373b7e",
+                "md5": "743cea20a6b9c7bfd7a700b9dcbc5929",
+                "sha256": "17899cd8e06aeafb4249e43e1abe50009240e4319fd51803bd3dcc8cd9136a3d",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/doc/source/conf.py",
+                "type": "file",
+                "name": "conf.py",
+                "base_name": "conf",
+                "extension": ".py",
+                "size": 1252,
+                "date": "2022-03-15",
+                "sha1": "f3940e81a66ae551b008f47e82c2bfaabe52146a",
+                "md5": "749666a6f6766cc9e42a2f76ed3b64e4",
+                "sha256": "8f63a81acc96bc42325766466e2632991cfbb75b37424a054949da8a4c625bb2",
+                "mime_type": "text/plain",
+                "file_type": "UTF-8 Unicode text",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 6,
+                        "end_line": 16,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 47.75,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 Etienne Bersac",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Julien Danjou",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 4,
+                        "end_line": 4
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Etienne Bersac",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 4,
+                        "end_line": 4
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 10,
+                        "end_line": 10
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/doc/source/index.rst",
+                "type": "file",
+                "name": "index.rst",
+                "base_name": "index",
+                "extension": ".rst",
+                "size": 15351,
+                "date": "2022-03-15",
+                "sha1": "0a1c744de692f8cceaba2a06ad42747f7cbc857e",
+                "md5": "415e1f665e78aeadb5dbd55b392fbf21",
+                "sha256": "c8ec3ce30e965581a9895599e5e86d076fa9d753a0c6e9f82a381c91e00b10ea",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, ASCII text executable",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 4,
+                        "end_line": 4,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_132.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 4,
+                            "matched_length": 4,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Apache 2.0 licensed"
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 0.2,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "https://github.com/rholder/retrying/issues/65",
+                        "start_line": 7,
+                        "end_line": 7
+                    },
+                    {
+                        "url": "https://julien.danjou.info/python-tenacity/",
+                        "start_line": 8,
+                        "end_line": 8
+                    },
+                    {
+                        "url": "https://github.com/jd/tenacity",
+                        "start_line": 576,
+                        "end_line": 576
+                    },
+                    {
+                        "url": "https://docs.openstack.org/reno/latest/user/usage.html",
+                        "start_line": 590,
+                        "end_line": 590
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes",
+                "type": "directory",
+                "name": "releasenotes",
+                "base_name": "releasenotes",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 15,
+                "dirs_count": 1,
+                "size_count": 1609,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes",
+                "type": "directory",
+                "name": "notes",
+                "base_name": "notes",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 15,
+                "dirs_count": 0,
+                "size_count": 1609,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/add-reno-d1ab5710f272650a.yaml",
+                "type": "file",
+                "name": "add-reno-d1ab5710f272650a.yaml",
+                "base_name": "add-reno-d1ab5710f272650a",
+                "extension": ".yaml",
+                "size": 46,
+                "date": "1970-01-01",
+                "sha1": "17087f41b9814eb0974f4aa15d73e83f7e3d1da3",
+                "md5": "2dcf475abed9a26400a781072f3d96f5",
+                "sha256": "94303ff8c6ce5e3cab87db7d443c9f9f446ff04a0a76b8736cbe5213f369e82b",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/add-retry_except_exception_type-31b31da1924d55f4.yaml",
+                "type": "file",
+                "name": "add-retry_except_exception_type-31b31da1924d55f4.yaml",
+                "base_name": "add-retry_except_exception_type-31b31da1924d55f4",
+                "extension": ".yaml",
+                "size": 131,
+                "date": "1970-01-01",
+                "sha1": "da2330920d9b4cc89b08a8b001460f3aa43f96ec",
+                "md5": "1051348470d2bd9570c9274f25f72767",
+                "sha256": "e38086a44543f0714f641b9d28f1576bf6b3cd37aa39613cf6fc615665059a86",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/after_log-50f4d73b24ce9203.yaml",
+                "type": "file",
+                "name": "after_log-50f4d73b24ce9203.yaml",
+                "base_name": "after_log-50f4d73b24ce9203",
+                "extension": ".yaml",
+                "size": 92,
+                "date": "1970-01-01",
+                "sha1": "c94487322ba37ab5e55826712c9ac54ba03b207e",
+                "md5": "5722a7c9d631d4ff08c1f8274975ac8c",
+                "sha256": "dd8e04d15e5f90a94c038c6be17faadc82c818fc10dec0d9af7e701327e8250e",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/allow-mocking-of-nap-sleep-6679c50e702446f1.yaml",
+                "type": "file",
+                "name": "allow-mocking-of-nap-sleep-6679c50e702446f1.yaml",
+                "base_name": "allow-mocking-of-nap-sleep-6679c50e702446f1",
+                "extension": ".yaml",
+                "size": 95,
+                "date": "1970-01-01",
+                "sha1": "5dc5715b54038d80cfd22c86fd551e49ec5e830c",
+                "md5": "3b171218bfcb8bf0fd0305fa7a4aa377",
+                "sha256": "cd9f23bac3fefde9e1349fa0f068c987a81975de538a0ce39db8fa0f96de3cb1",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/annotate_code-197b93130df14042.yaml",
+                "type": "file",
+                "name": "annotate_code-197b93130df14042.yaml",
+                "base_name": "annotate_code-197b93130df14042",
+                "extension": ".yaml",
+                "size": 61,
+                "date": "1970-01-01",
+                "sha1": "70fce23a3dfc6b5683c6ccd0478f83cb3f43ea5b",
+                "md5": "f192fd06a30c329268a99854adf42dc5",
+                "sha256": "2b7837f69eeb7f1065fbc8d6aa1c1f0a02af4d24f942f29c171b6b5f912f9ca7",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/before_sleep_log-improvements-d8149274dfb37d7c.yaml",
+                "type": "file",
+                "name": "before_sleep_log-improvements-d8149274dfb37d7c.yaml",
+                "base_name": "before_sleep_log-improvements-d8149274dfb37d7c",
+                "extension": ".yaml",
+                "size": 84,
+                "date": "1970-01-01",
+                "sha1": "af04bde76b01d12e472be50fc6bb457ec39a31f9",
+                "md5": "37a896553f09db088dfa292f627e43f6",
+                "sha256": "55ae14daa43b040879e16953a35f377ea76a8b83c621d203423067e97b95a38e",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/do_not_package_tests-fe5ac61940b0a5ed.yaml",
+                "type": "file",
+                "name": "do_not_package_tests-fe5ac61940b0a5ed.yaml",
+                "base_name": "do_not_package_tests-fe5ac61940b0a5ed",
+                "extension": ".yaml",
+                "size": 51,
+                "date": "1970-01-01",
+                "sha1": "f99b7170c387741ef41bfe0228a1f3b98e19f108",
+                "md5": "0895ae27611c8402e3621652dd54a156",
+                "sha256": "8d7570c217f84b8753f93b88555741336a2b19b5aec1f656d153487a84c2346e",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/drop-deprecated-python-versions-69a05cb2e0f1034c.yaml",
+                "type": "file",
+                "name": "drop-deprecated-python-versions-69a05cb2e0f1034c.yaml",
+                "base_name": "drop-deprecated-python-versions-69a05cb2e0f1034c",
+                "extension": ".yaml",
+                "size": 79,
+                "date": "1970-01-01",
+                "sha1": "94d60e3f3e12f1490e562f9e591ef3d6df76bae6",
+                "md5": "8a8d10060ae3cb2f98528ddca3d826f1",
+                "sha256": "17d37b043719c4b61b2044188784fa207dce910f8dd65c548ab5df275e25c21d",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/drop_deprecated-7ea90b212509b082.yaml",
+                "type": "file",
+                "name": "drop_deprecated-7ea90b212509b082.yaml",
+                "base_name": "drop_deprecated-7ea90b212509b082",
+                "extension": ".yaml",
+                "size": 274,
+                "date": "1970-01-01",
+                "sha1": "fb3273ad67b8323f3f60582216f559ad42ad79ec",
+                "md5": "899ba4ae8630a69d9e42f597ccba706f",
+                "sha256": "303167653efe0487d2b8909e0a2b203614101cf0d82174100bce19cd49072fe6",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/fix_async-52b6594c8e75c4bc.yaml",
+                "type": "file",
+                "name": "fix_async-52b6594c8e75c4bc.yaml",
+                "base_name": "fix_async-52b6594c8e75c4bc",
+                "extension": ".yaml",
+                "size": 84,
+                "date": "1970-01-01",
+                "sha1": "de32fcfc6f0c4007dd49d865c34a0f11d494140d",
+                "md5": "5d529343d727d3a6c33a21b8536b40af",
+                "sha256": "f0bbdcea219a825d168981dbb71b4a65e1c11f50a2f3ee14d4dc2f449f153f67",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/make-logger-more-compatible-5da1ddf1bab77047.yaml",
+                "type": "file",
+                "name": "make-logger-more-compatible-5da1ddf1bab77047.yaml",
+                "base_name": "make-logger-more-compatible-5da1ddf1bab77047",
+                "extension": ".yaml",
+                "size": 127,
+                "date": "1970-01-01",
+                "sha1": "73d9be2a9ac231dca8b78975f5f6a75a19c73156",
+                "md5": "67de30d6cd7e107d84bfa5422619090e",
+                "sha256": "d5e8606c2c46c9b6dc7d2daf9e0f2ea8d49e7371fc7d9d8de7ae8b5cc55a8a0f",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/pr320-py3-only-wheel-tag.yaml",
+                "type": "file",
+                "name": "pr320-py3-only-wheel-tag.yaml",
+                "base_name": "pr320-py3-only-wheel-tag",
+                "extension": ".yaml",
+                "size": 125,
+                "date": "1970-01-01",
+                "sha1": "bd63386d94bc20ec4f17ae846837c4dfc4bc7641",
+                "md5": "aea87503c9a67875b166ff04b3d9f4a6",
+                "sha256": "605da93d45f86f8485164680f6ba75cc132ccb5ca63c854a19a33d24831fc45f",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/py36_plus-c425fb3aa17c6682.yaml",
+                "type": "file",
+                "name": "py36_plus-c425fb3aa17c6682.yaml",
+                "base_name": "py36_plus-c425fb3aa17c6682",
+                "extension": ".yaml",
+                "size": 99,
+                "date": "1970-01-01",
+                "sha1": "b15f4db7d43ced4e1432773c141bc075b9de2766",
+                "md5": "63a277f05251890acead63177ed8d152",
+                "sha256": "039ba88f2c0e0e30347867109f72ca1a69e59eb2e1aebadbb592b93a0a3d7730",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/retrycallstate-repr-94947f7b00ee15e1.yaml",
+                "type": "file",
+                "name": "retrycallstate-repr-94947f7b00ee15e1.yaml",
+                "base_name": "retrycallstate-repr-94947f7b00ee15e1",
+                "extension": ".yaml",
+                "size": 96,
+                "date": "1970-01-01",
+                "sha1": "abb22d95ad40efae3b606a6a8cd012f78589118b",
+                "md5": "0ae14d8edac3fb8c0fa942730e12e887",
+                "sha256": "d7c0be0d79579ecb3fce308df3f7f04c5b8acfe8c805ad21a685464972c57ed0",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/releasenotes/notes/Use--for-formatting-and-validate-using-black-39ec9d57d4691778.yaml",
+                "type": "file",
+                "name": "Use--for-formatting-and-validate-using-black-39ec9d57d4691778.yaml",
+                "base_name": "Use--for-formatting-and-validate-using-black-39ec9d57d4691778",
+                "extension": ".yaml",
+                "size": 165,
+                "date": "1970-01-01",
+                "sha1": "6e81d311d97ca9f9b884bee61ff13cc4281175d1",
+                "md5": "cc2e2f42de285c578e90fe002dbdc39b",
+                "sha256": "434fb6d1a6b7d5275b6c88e4c86ba351e7056bd70c949a25f466cdc15a098d74",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity",
+                "type": "directory",
+                "name": "tenacity",
+                "base_name": "tenacity",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 12,
+                "dirs_count": 0,
+                "size_count": 47449,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/__init__.py",
+                "type": "file",
+                "name": "__init__.py",
+                "base_name": "__init__",
+                "extension": ".py",
+                "size": 17985,
+                "date": "1970-01-01",
+                "sha1": "4c28af4afc380d0262c6184480eeca41d4eceeda",
+                "md5": "0f09a0f10dd5eff973a204e98b3497b0",
+                "sha256": "34b4d85e6def998e80bbf6024da05a3bca28966620a9715462d6b28450fdb6c0",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, UTF-8 Unicode text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 7,
+                        "end_line": 17,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 3.87,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016-2018 Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2017 Elisey Zanko",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2016 Etienne Bersac",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 4,
+                        "end_line": 4
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 5,
+                        "end_line": 5
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Elisey Zanko",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Etienne Bersac",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 4,
+                        "end_line": 4
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 5,
+                        "end_line": 5
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 11,
+                        "end_line": 11
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/_asyncio.py",
+                "type": "file",
+                "name": "_asyncio.py",
+                "base_name": "_asyncio",
+                "extension": ".py",
+                "size": 3254,
+                "date": "1970-01-01",
+                "sha1": "38a4028f8afb62df483b8a93595411aea83fd9ad",
+                "md5": "17787cf362f19be89a08bd3717f94aa1",
+                "sha256": "32b9fb2854f289521b264c55ee8891d8a685928cf135c73ad857c050d6e8b408",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, UTF-8 Unicode text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 6,
+                        "end_line": 16,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 22.37,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 Etienne Bersac",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Julien Danjou",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 4,
+                        "end_line": 4
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Etienne Bersac",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 4,
+                        "end_line": 4
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 10,
+                        "end_line": 10
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/_utils.py",
+                "type": "file",
+                "name": "_utils.py",
+                "base_name": "_utils",
+                "extension": ".py",
+                "size": 1944,
+                "date": "1970-01-01",
+                "sha1": "2757ec12eee966765f8fc341f8894058a8356274",
+                "md5": "507487d64e81fb7e1afe8f58cf194c7b",
+                "sha256": "fb2ebcb1c0dcca8aaf4c9b892741937e37520a58c46256c262f824ee733835d3",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, ASCII text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 5,
+                        "end_line": 15,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 32.08,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 9,
+                        "end_line": 9
+                    },
+                    {
+                        "url": "https://en.wikipedia.org/wiki/English_numerals#Ordinal_numbers",
+                        "start_line": 27,
+                        "end_line": 27
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/after.py",
+                "type": "file",
+                "name": "after.py",
+                "base_name": "after",
+                "extension": ".py",
+                "size": 1472,
+                "date": "1970-01-01",
+                "sha1": "324f15aefeed836df21deddfcd459200837db0a1",
+                "md5": "1ebbf1557f4eaabcba280fd35db064ec",
+                "sha256": "53241ea9b6bc24c3acf4e19c46127404168c4cf21e5ec371091c6a7695234669",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, ASCII text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 5,
+                        "end_line": 15,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 42.29,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 9,
+                        "end_line": 9
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/before.py",
+                "type": "file",
+                "name": "before.py",
+                "base_name": "before",
+                "extension": ".py",
+                "size": 1352,
+                "date": "1970-01-01",
+                "sha1": "466590a518d95587c64607ca9cb50741ff6663bb",
+                "md5": "7f55c02a98090e718bb80cc0737ad10a",
+                "sha256": "9814680adf0990b9dd526e21c059282635a199341df31c3cce624e741ca3ae30",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, ASCII text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 5,
+                        "end_line": 15,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 45.45,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 9,
+                        "end_line": 9
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/before_sleep.py",
+                "type": "file",
+                "name": "before_sleep.py",
+                "base_name": "before_sleep",
+                "extension": ".py",
+                "size": 1884,
+                "date": "1970-01-01",
+                "sha1": "7e0706a36e396d961b1d15e9e5e273b12f19fe84",
+                "md5": "a08878754ebb25c66fa269feed6f401a",
+                "sha256": "f2ce460208ad660b60c8a0e3bc2851aaabb6a254446958b790d03c0f3db27c7e",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, ASCII text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 5,
+                        "end_line": 15,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 34.69,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 9,
+                        "end_line": 9
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/nap.py",
+                "type": "file",
+                "name": "nap.py",
+                "base_name": "nap",
+                "extension": ".py",
+                "size": 1383,
+                "date": "1970-01-01",
+                "sha1": "b586e8e91a90b3770906a7d73800a474714bb3f3",
+                "md5": "9d250e25bf4c187cb76919de988d47d0",
+                "sha256": "7d15af9f3d5a2336c8abd029de00240198031faa28e73c4cad4e99395072ab42",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, UTF-8 Unicode text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 6,
+                        "end_line": 16,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 42.5,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 Etienne Bersac",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Julien Danjou",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 4,
+                        "end_line": 4
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Etienne Bersac",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 4,
+                        "end_line": 4
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 10,
+                        "end_line": 10
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/py.typed",
+                "type": "file",
+                "name": "py.typed",
+                "base_name": "py",
+                "extension": ".typed",
+                "size": 0,
+                "date": "1970-01-01",
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": "inode/x-empty",
+                "file_type": "empty",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": true,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/retry.py",
+                "type": "file",
+                "name": "retry.py",
+                "base_name": "retry",
+                "extension": ".py",
+                "size": 6633,
+                "date": "1970-01-01",
+                "sha1": "3714346fc01f1203119d9b47306c40072c0def3b",
+                "md5": "a6dc1baee6ab9755412a51a088199a3b",
+                "sha256": "1dbf705990443140e9e63ae7b11982bf2fd412ac3858822df6d8855e18d9e747",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, UTF-8 Unicode text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 5,
+                        "end_line": 15,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 10.94,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016-2021 Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 9,
+                        "end_line": 9
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/stop.py",
+                "type": "file",
+                "name": "stop.py",
+                "base_name": "stop",
+                "extension": ".py",
+                "size": 2778,
+                "date": "1970-01-01",
+                "sha1": "6d80000b181c6c3b202a4f839033a801e50cbc44",
+                "md5": "d7d07b483271661ebe198e5fc438ee2a",
+                "sha256": "c5250099766ede0abcc2327b195b82c769d1418e5d51239d6cccd338c5c28c5d",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, UTF-8 Unicode text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 5,
+                        "end_line": 15,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 22.61,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016-2021 Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 9,
+                        "end_line": 9
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/tornadoweb.py",
+                "type": "file",
+                "name": "tornadoweb.py",
+                "base_name": "tornadoweb",
+                "extension": ".py",
+                "size": 2097,
+                "date": "1970-01-01",
+                "sha1": "a16b365a58d8b3bdd52ce6daddde224a7b8ea35e",
+                "md5": "fbfebd1c296302b1c9722db85be1dabe",
+                "sha256": "57c346020c091b34505ed7da67253a171f3ecb8a1ea5be250975be23fe5b44df",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, ASCII text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 3,
+                        "end_line": 13,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 33.2,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2017 Elisey Zanko",
+                        "start_line": 1,
+                        "end_line": 1
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Elisey Zanko",
+                        "start_line": 1,
+                        "end_line": 1
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 7,
+                        "end_line": 7
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity/wait.py",
+                "type": "file",
+                "name": "wait.py",
+                "base_name": "wait",
+                "extension": ".py",
+                "size": 6667,
+                "date": "1970-01-01",
+                "sha1": "08fc42b09d33452c4b5631e35efcf1044ed20ccf",
+                "md5": "0dd89ed4793d6824bf1777f5c1107ef3",
+                "sha256": "11c0aeac569ba31116d28b8d20c3c1a742a1f4cb979d4f45d3865d7b5148ac1a",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, UTF-8 Unicode text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 5,
+                        "end_line": 15,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 9.74,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016-2021 Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2013-2014 Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 9,
+                        "end_line": 9
+                    },
+                    {
+                        "url": "https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/",
+                        "start_line": 172,
+                        "end_line": 172
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity.egg-info",
+                "type": "directory",
+                "name": "tenacity.egg-info",
+                "base_name": "tenacity.egg-info",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 6,
+                "dirs_count": 0,
+                "size_count": 2744,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity.egg-info/dependency_links.txt",
+                "type": "file",
+                "name": "dependency_links.txt",
+                "base_name": "dependency_links",
+                "extension": ".txt",
+                "size": 1,
+                "date": "1970-01-01",
+                "sha1": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc",
+                "md5": "68b329da9893e34099c7d8ad5cb9c940",
+                "sha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+                "mime_type": "application/octet-stream",
+                "file_type": "very short file (no magic)",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity.egg-info/pbr.json",
+                "type": "file",
+                "name": "pbr.json",
+                "base_name": "pbr",
+                "extension": ".json",
+                "size": 47,
+                "date": "1970-01-01",
+                "sha1": "145e28734c20bc05fe5327a2e04c4e6877bdf35c",
+                "md5": "11edabe154dbf5ec6c843b7714f4d402",
+                "sha256": "c4d08f9b82a565931dedf5882bc401c5eebff14895bb97a9bbd7c3e3735f18d9",
+                "mime_type": "application/json",
+                "file_type": "JSON data",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity.egg-info/PKG-INFO",
+                "type": "file",
+                "name": "PKG-INFO",
+                "base_name": "PKG-INFO",
+                "extension": "",
+                "size": 967,
+                "date": "1970-01-01",
+                "sha1": "22b86313b4a28b7ff06082f94179b082a7bbdbf2",
+                "md5": "249bc229e3415b1b855c1950bc0bcbca",
+                "sha256": "57867fdd81accb937cd806b920aa9fbee5f7896158abf74b393aa1224b1d3ddf",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 8,
+                        "end_line": 8,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_65.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": false,
+                            "is_license_tag": true,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 4,
+                            "matched_length": 4,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "License: Apache 2.0"
+                    },
+                    {
+                        "key": "apache-2.0",
+                        "score": 95,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 11,
+                        "end_line": 11,
+                        "matched_rule": {
+                            "identifier": "pypi_apache_no-version.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": false,
+                            "is_license_tag": true,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 6,
+                            "matched_length": 6,
+                            "match_coverage": 100,
+                            "rule_relevance": 95
+                        },
+                        "matched_text": "License :: OSI Approved :: Apache Software License"
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0",
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 7.87,
+                "copyrights": [],
+                "holders": [],
+                "authors": [
+                    {
+                        "value": "Julien Danjou Author-email julien@danjou.info",
+                        "start_line": 6,
+                        "end_line": 7
+                    }
+                ],
+                "packages": [
+                    {
+                        "type": "pypi",
+                        "namespace": null,
+                        "name": "tenacity",
+                        "version": "8.0.1",
+                        "qualifiers": {},
+                        "subpath": null,
+                        "primary_language": "Python",
+                        "description": "Retry code until it succeeds\nTenacity is a general-purpose retrying library to simplify the task of adding retry behavior to just about anything.",
+                        "release_date": null,
+                        "parties": [
+                            {
+                                "type": "person",
+                                "role": "author",
+                                "name": "Julien Danjou",
+                                "email": "julien@danjou.info",
+                                "url": null
+                            }
+                        ],
+                        "keywords": [
+                            "Intended Audience :: Developers",
+                            "Programming Language :: Python",
+                            "Programming Language :: Python :: 3",
+                            "Programming Language :: Python :: 3 :: Only",
+                            "Programming Language :: Python :: 3.6",
+                            "Programming Language :: Python :: 3.7",
+                            "Programming Language :: Python :: 3.8",
+                            "Programming Language :: Python :: 3.9",
+                            "Programming Language :: Python :: 3.10",
+                            "Topic :: Utilities"
+                        ],
+                        "homepage_url": "https://github.com/jd/tenacity",
+                        "download_url": null,
+                        "size": null,
+                        "sha1": null,
+                        "md5": null,
+                        "sha256": null,
+                        "sha512": null,
+                        "bug_tracking_url": null,
+                        "code_view_url": null,
+                        "vcs_url": null,
+                        "copyright": null,
+                        "license_expression": "apache-2.0",
+                        "declared_license": {
+                            "license": "Apache 2.0",
+                            "classifiers": [
+                                "License :: OSI Approved :: Apache Software License"
+                            ]
+                        },
+                        "notice_text": null,
+                        "root_path": "tenacity-8.0.1/tenacity.egg-info/PKG-INFO",
+                        "dependencies": [
+                            {
+                                "purl": "pkg:pypi/reno",
+                                "requirement": null,
+                                "scope": "doc",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/sphinx",
+                                "requirement": null,
+                                "scope": "doc",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            },
+                            {
+                                "purl": "pkg:pypi/tornado",
+                                "requirement": ">=4.5",
+                                "scope": "doc",
+                                "is_runtime": true,
+                                "is_optional": false,
+                                "is_resolved": false
+                            }
+                        ],
+                        "contains_source_code": null,
+                        "source_packages": [],
+                        "extra_data": {},
+                        "purl": "pkg:pypi/tenacity@8.0.1",
+                        "repository_homepage_url": "https://pypi.org/project/https://pypi.org",
+                        "repository_download_url": "https://pypi.org/packages/source/t/tenacity/tenacity-8.0.1.tar.gz",
+                        "api_data_url": "https://pypi.org/pypi/tenacity/8.0.1/json",
+                        "files": [
+                            {
+                                "path": "tenacity-8.0.1/tenacity.egg-info/PKG-INFO",
+                                "type": "file"
+                            }
+                        ]
+                    }
+                ],
+                "emails": [
+                    {
+                        "email": "julien@danjou.info",
+                        "start_line": 7,
+                        "end_line": 7
+                    }
+                ],
+                "urls": [
+                    {
+                        "url": "https://github.com/jd/tenacity",
+                        "start_line": 5,
+                        "end_line": 5
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity.egg-info/requires.txt",
+                "type": "file",
+                "name": "requires.txt",
+                "base_name": "requires",
+                "extension": ".txt",
+                "size": 32,
+                "date": "1970-01-01",
+                "sha1": "729c56e7a489f935a8350e89905c89754a863fff",
+                "md5": "8f360d782aec9b4c43dfcd51c7e68a8f",
+                "sha256": "28cfe0f59123c00b8df2f9aa9e1a517e1650825548ff71e0fe40ac37e8e9745e",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity.egg-info/SOURCES.txt",
+                "type": "file",
+                "name": "SOURCES.txt",
+                "base_name": "SOURCES",
+                "extension": ".txt",
+                "size": 1688,
+                "date": "1970-01-01",
+                "sha1": "cf576cb15e520e9589934c0a0a9800bffa761c0f",
+                "md5": "8a0611b20cf976040cdef8d97495bfc4",
+                "sha256": "df6e40179b0eac3da009d1f1f35ecd75f90d91c70d61fa81ebc1aaa660171e6b",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tenacity.egg-info/top_level.txt",
+                "type": "file",
+                "name": "top_level.txt",
+                "base_name": "top_level",
+                "extension": ".txt",
+                "size": 9,
+                "date": "1970-01-01",
+                "sha1": "33019574e2bfdb62b882eb7d8a71e18bfa9a96cf",
+                "md5": "9485542a5bf13548cc6d136f7c3feabe",
+                "sha256": "65ff0039930dee1af5104714a3d5392b35ec3384ce0b5a41676d83f3dd77258b",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tests",
+                "type": "directory",
+                "name": "tests",
+                "base_name": "tests",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 5,
+                "dirs_count": 0,
+                "size_count": 61357,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tests/__init__.py",
+                "type": "file",
+                "name": "__init__.py",
+                "base_name": "__init__",
+                "extension": ".py",
+                "size": 0,
+                "date": "1970-01-01",
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": "inode/x-empty",
+                "file_type": "empty",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": true,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tests/test_after.py",
+                "type": "file",
+                "name": "test_after.py",
+                "base_name": "test_after",
+                "extension": ".py",
+                "size": 2079,
+                "date": "1970-01-01",
+                "sha1": "14f572eaf3945678f2cd11f8cd092f592959e3fb",
+                "md5": "d6e6d9cab0b696b9b0af0456abe57f85",
+                "sha256": "b6e24bcf4c45cf0fdb4bd3b5da3bc5302d05dc5804b59b42153fb2f388b93006",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, ASCII text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tests/test_asyncio.py",
+                "type": "file",
+                "name": "test_asyncio.py",
+                "base_name": "test_asyncio",
+                "extension": ".py",
+                "size": 4734,
+                "date": "1970-01-01",
+                "sha1": "f1814270085e75bccf69d34eaff2037584edcff6",
+                "md5": "1d779334188c93449e7eb7a152efdacd",
+                "sha256": "a33306ea2f680addb9253c964ba8201d148aff11e3a201b261bf3ba43c0c6d12",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, UTF-8 Unicode text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 4,
+                        "end_line": 14,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 15.51,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 Etienne Bersac",
+                        "start_line": 2,
+                        "end_line": 2
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Etienne Bersac",
+                        "start_line": 2,
+                        "end_line": 2
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 8,
+                        "end_line": 8
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tests/test_tenacity.py",
+                "type": "file",
+                "name": "test_tenacity.py",
+                "base_name": "test_tenacity",
+                "extension": ".py",
+                "size": 52382,
+                "date": "1970-01-01",
+                "sha1": "bdfdca504501850c1833c65b90e6b4d3ccfad88a",
+                "md5": "468ca8e798d5790672dc43011bf4edc9",
+                "sha256": "12a84b615940434d4b47cd2b910bffdff2e40587656ba4597c53d5c743631f23",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, UTF-8 Unicode text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 5,
+                        "end_line": 15,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 1.3,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016-2021 Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Copyright 2016 Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Copyright 2013 Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Julien Danjou",
+                        "start_line": 1,
+                        "end_line": 1
+                    },
+                    {
+                        "value": "Joshua Harlow",
+                        "start_line": 2,
+                        "end_line": 2
+                    },
+                    {
+                        "value": "Ray",
+                        "start_line": 3,
+                        "end_line": 3
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 9,
+                        "end_line": 9
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "tenacity-8.0.1/tests/test_tornado.py",
+                "type": "file",
+                "name": "test_tornado.py",
+                "base_name": "test_tornado",
+                "extension": ".py",
+                "size": 2162,
+                "date": "1970-01-01",
+                "sha1": "2cc3f6ea71857d37293c6715324d1cd8aea83f39",
+                "md5": "e56cfb334aa076277e4dd44fcf91295e",
+                "sha256": "237c3f021d1a092ba92d5f5a8dcd44eba264f0cf8015529c123f4fbbc41a8e21",
+                "mime_type": "text/x-script.python",
+                "file_type": "Python script, ASCII text executable",
+                "programming_language": "Python",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": true,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 4,
+                        "end_line": 14,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_7.RULE",
+                            "license_expression": "apache-2.0",
+                            "licenses": [
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 85,
+                            "matched_length": 85,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0"
+                ],
+                "percentage_of_license_text": 30.58,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2017 Elisey Zanko",
+                        "start_line": 2,
+                        "end_line": 2
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "Elisey Zanko",
+                        "start_line": 2,
+                        "end_line": 2
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 8,
+                        "end_line": 8
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            }
+        ]
+    }
+}

--- a/test/fixtures/scancode/30.1.0/github-license-expression.json
+++ b/test/fixtures/scancode/30.1.0/github-license-expression.json
@@ -1,0 +1,1165 @@
+{
+    "_metadata": {
+        "type": "scancode",
+        "url": "cd:/git/github/zonyitoo/conhash-rs/779ed931b07c1a9b643dc14f62db29bf8102fd1b",
+        "fetchedAt": "2022-06-07T23:19:43.143Z",
+        "links": {
+            "self": {
+                "href": "urn:git:github:zonyitoo:conhash-rs:revision:779ed931b07c1a9b643dc14f62db29bf8102fd1b:tool:scancode:30.3.0",
+                "type": "resource"
+            },
+            "siblings": {
+                "href": "urn:git:github:zonyitoo:conhash-rs:revision:779ed931b07c1a9b643dc14f62db29bf8102fd1b:tool:scancode",
+                "type": "collection"
+            }
+        },
+        "schemaVersion": "30.3.0",
+        "toolVersion": "30.1.0",
+        "contentType": "application/json",
+        "releaseDate": "2022-04-06T10:36:03.000Z",
+        "processedAt": "2022-06-07T23:19:49.005Z"
+    },
+    "content": {
+        "headers": [
+            {
+                "tool_name": "scancode-toolkit",
+                "tool_version": "30.1.0",
+                "options": {
+                    "input": [
+                        "/tmp/cd-0PH4yo/conhash-rs"
+                    ],
+                    "--classify": true,
+                    "--copyright": true,
+                    "--email": true,
+                    "--generated": true,
+                    "--info": true,
+                    "--is-license-text": true,
+                    "--json-pp": "/tmp/cd-XT1Raq",
+                    "--license": true,
+                    "--license-clarity-score": true,
+                    "--license-text": true,
+                    "--license-text-diagnostics": true,
+                    "--package": true,
+                    "--processes": "2",
+                    "--strip-root": true,
+                    "--summary": true,
+                    "--summary-key-files": true,
+                    "--timeout": "1000.0",
+                    "--url": true
+                },
+                "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+                "start_timestamp": "2022-06-07T231944.163516",
+                "end_timestamp": "2022-06-07T231948.207749",
+                "output_format_version": "1.0.0",
+                "duration": 4.044247627258301,
+                "message": null,
+                "errors": [],
+                "warnings": [],
+                "extra_data": {
+                    "spdx_license_list_version": "3.14",
+                    "OUTDATED": "WARNING: Outdated ScanCode Toolkit version! You are using an outdated version of ScanCode Toolkit: 30.1.0 released on: 2021-09-24. A new version is available with important improvements including bug and security fixes, updated license, copyright and package detection, and improved scanning accuracy. Please download and install the latest version of ScanCode. Visit https://github.com/nexB/scancode-toolkit/releases for details.",
+                    "files_count": 7
+                }
+            }
+        ],
+        "summary": {
+            "license_expressions": [
+                {
+                    "value": "mit OR apache-2.0",
+                    "count": 3
+                },
+                {
+                    "value": "apache-2.0 OR mit",
+                    "count": 2
+                }
+            ],
+            "copyrights": [
+                {
+                    "value": null,
+                    "count": 4
+                },
+                {
+                    "value": "Copyright conhash-rs",
+                    "count": 3
+                }
+            ],
+            "holders": [
+                {
+                    "value": null,
+                    "count": 4
+                },
+                {
+                    "value": "conhash-rs",
+                    "count": 3
+                }
+            ],
+            "authors": [
+                {
+                    "value": null,
+                    "count": 6
+                },
+                {
+                    "value": "Y. T. Chung <zonyitoo@gmail.com>",
+                    "count": 1
+                }
+            ],
+            "programming_language": [
+                {
+                    "value": "Rust",
+                    "count": 4
+                }
+            ],
+            "packages": [
+                {
+                    "type": "cargo",
+                    "namespace": null,
+                    "name": "conhash",
+                    "version": "0.5.0",
+                    "qualifiers": {},
+                    "subpath": null,
+                    "primary_language": "Rust",
+                    "description": "Consistent Hashing library in Rust",
+                    "release_date": null,
+                    "parties": [
+                        {
+                            "type": "person",
+                            "role": "author",
+                            "name": "Y. T. Chung",
+                            "email": "zonyitoo@gmail.com",
+                            "url": null
+                        }
+                    ],
+                    "keywords": [],
+                    "homepage_url": null,
+                    "download_url": null,
+                    "size": null,
+                    "sha1": null,
+                    "md5": null,
+                    "sha256": null,
+                    "sha512": null,
+                    "bug_tracking_url": null,
+                    "code_view_url": null,
+                    "vcs_url": null,
+                    "copyright": null,
+                    "license_expression": "mit OR apache-2.0",
+                    "declared_license": "MIT/Apache-2.0",
+                    "notice_text": null,
+                    "root_path": null,
+                    "dependencies": [],
+                    "contains_source_code": null,
+                    "source_packages": [],
+                    "extra_data": {},
+                    "purl": "pkg:cargo/conhash@0.5.0",
+                    "repository_homepage_url": "https://crates.io/crates/conhash",
+                    "repository_download_url": "https://crates.io/api/v1/crates/conhash/0.5.0/download",
+                    "api_data_url": "https://crates.io/api/v1/crates/conhash",
+                    "files": [
+                        {
+                            "path": "Cargo.toml",
+                            "type": "file"
+                        }
+                    ]
+                }
+            ]
+        },
+        "license_clarity_score": {
+            "score": 57,
+            "declared": true,
+            "discovered": 0.5,
+            "consistency": true,
+            "spdx": false,
+            "license_texts": false
+        },
+        "summary_of_key_files": {
+            "license_expressions": [
+                {
+                    "value": "apache-2.0 OR mit",
+                    "count": 1
+                }
+            ],
+            "copyrights": [],
+            "holders": [],
+            "authors": [],
+            "programming_language": []
+        },
+        "files": [
+            {
+                "path": ".travis.yml",
+                "type": "file",
+                "name": ".travis.yml",
+                "base_name": ".travis",
+                "extension": ".yml",
+                "size": 65,
+                "date": "2022-06-07",
+                "sha1": "b8beff9434d6ca7ef39f22cde11ba4d4f72c912a",
+                "md5": "21f0967bbd10463ecd9542320c8f281d",
+                "sha256": "fd14854f17c2c0b42ee0e12cc360b6a8c48e1b9b4ec21f5351080d75ecb4fdce",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": true,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "Cargo.toml",
+                "type": "file",
+                "name": "Cargo.toml",
+                "base_name": "Cargo",
+                "extension": ".toml",
+                "size": 455,
+                "date": "2022-06-07",
+                "sha1": "2f96a90e23a7a0cb431cdaf88d4a06bef79baeda",
+                "md5": "0bca67c53fe7f105b446addea9d2bdaf",
+                "sha256": "ca2b8b263d7fc837b031c24a31be852cacd3f253a03a58aa293f1785a8e8b4ad",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 9,
+                        "end_line": 9,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_or_mit4.RULE",
+                            "license_expression": "apache-2.0 OR mit",
+                            "licenses": [
+                                "apache-2.0",
+                                "mit"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": false,
+                            "is_license_tag": true,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 5,
+                            "matched_length": 5,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "license = \"MIT/Apache-2.0\""
+                    },
+                    {
+                        "key": "mit",
+                        "score": 100,
+                        "name": "MIT License",
+                        "short_name": "MIT License",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "MIT",
+                        "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                        "text_url": "http://opensource.org/licenses/mit-license.php",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/mit",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.yml",
+                        "spdx_license_key": "MIT",
+                        "spdx_url": "https://spdx.org/licenses/MIT",
+                        "start_line": 9,
+                        "end_line": 9,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_or_mit4.RULE",
+                            "license_expression": "apache-2.0 OR mit",
+                            "licenses": [
+                                "apache-2.0",
+                                "mit"
+                            ],
+                            "referenced_filenames": [],
+                            "is_license_text": false,
+                            "is_license_notice": false,
+                            "is_license_reference": false,
+                            "is_license_tag": true,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 5,
+                            "matched_length": 5,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "license = \"MIT/Apache-2.0\""
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0 OR mit"
+                ],
+                "percentage_of_license_text": 7.81,
+                "copyrights": [],
+                "holders": [],
+                "authors": [
+                    {
+                        "value": "Y. T. Chung <zonyitoo@gmail.com>",
+                        "start_line": 5,
+                        "end_line": 5
+                    }
+                ],
+                "packages": [
+                    {
+                        "type": "cargo",
+                        "namespace": null,
+                        "name": "conhash",
+                        "version": "0.5.0",
+                        "qualifiers": {},
+                        "subpath": null,
+                        "primary_language": "Rust",
+                        "description": "Consistent Hashing library in Rust",
+                        "release_date": null,
+                        "parties": [
+                            {
+                                "type": "person",
+                                "role": "author",
+                                "name": "Y. T. Chung",
+                                "email": "zonyitoo@gmail.com",
+                                "url": null
+                            }
+                        ],
+                        "keywords": [],
+                        "homepage_url": null,
+                        "download_url": null,
+                        "size": null,
+                        "sha1": null,
+                        "md5": null,
+                        "sha256": null,
+                        "sha512": null,
+                        "bug_tracking_url": null,
+                        "code_view_url": null,
+                        "vcs_url": null,
+                        "copyright": null,
+                        "license_expression": "mit OR apache-2.0",
+                        "declared_license": "MIT/Apache-2.0",
+                        "notice_text": null,
+                        "root_path": null,
+                        "dependencies": [],
+                        "contains_source_code": null,
+                        "source_packages": [],
+                        "extra_data": {},
+                        "purl": "pkg:cargo/conhash@0.5.0",
+                        "repository_homepage_url": "https://crates.io/crates/conhash",
+                        "repository_download_url": "https://crates.io/api/v1/crates/conhash/0.5.0/download",
+                        "api_data_url": "https://crates.io/api/v1/crates/conhash",
+                        "files": [
+                            {
+                                "path": "Cargo.toml",
+                                "type": "file"
+                            }
+                        ]
+                    }
+                ],
+                "emails": [
+                    {
+                        "email": "zonyitoo@gmail.com",
+                        "start_line": 5,
+                        "end_line": 5
+                    }
+                ],
+                "urls": [
+                    {
+                        "url": "https://github.com/zonyitoo/conhash-rs",
+                        "start_line": 7,
+                        "end_line": 7
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": true,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "README.md",
+                "type": "file",
+                "name": "README.md",
+                "base_name": "README",
+                "extension": ".md",
+                "size": 2305,
+                "date": "2022-06-07",
+                "sha1": "4c13f6826cf73e6f760d71d4e3dbcbe5b4ed13a4",
+                "md5": "e1d1bee147f584a652b033fa7ef013e3",
+                "sha256": "9e92d76b71aa526eb60512d20cf9138df02b71d78db5dece0c022fd462ba3adc",
+                "mime_type": "text/x-c",
+                "file_type": "C source, ASCII text",
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "apache-2.0",
+                        "score": 96.15,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 73,
+                        "end_line": 86,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_or_mit_32.RULE",
+                            "license_expression": "apache-2.0 OR mit",
+                            "licenses": [
+                                "apache-2.0",
+                                "mit"
+                            ],
+                            "referenced_filenames": [
+                                "LICENSE-APACHE",
+                                "LICENSE-MIT"
+                            ],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "3-seq",
+                            "rule_length": 78,
+                            "matched_length": 75,
+                            "match_coverage": 96.15,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "License\n\nLicensed under either of\n\n * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)\n * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)\n\nat your option.\n\n### Contribution\n\nUnless you explicitly state otherwise, any contribution intentionally submitted\nfor inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any\nadditional terms or conditions."
+                    },
+                    {
+                        "key": "mit",
+                        "score": 96.15,
+                        "name": "MIT License",
+                        "short_name": "MIT License",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "MIT",
+                        "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                        "text_url": "http://opensource.org/licenses/mit-license.php",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/mit",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.yml",
+                        "spdx_license_key": "MIT",
+                        "spdx_url": "https://spdx.org/licenses/MIT",
+                        "start_line": 73,
+                        "end_line": 86,
+                        "matched_rule": {
+                            "identifier": "apache-2.0_or_mit_32.RULE",
+                            "license_expression": "apache-2.0 OR mit",
+                            "licenses": [
+                                "apache-2.0",
+                                "mit"
+                            ],
+                            "referenced_filenames": [
+                                "LICENSE-APACHE",
+                                "LICENSE-MIT"
+                            ],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "3-seq",
+                            "rule_length": 78,
+                            "matched_length": 75,
+                            "match_coverage": 96.15,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "License\n\nLicensed under either of\n\n * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)\n * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)\n\nat your option.\n\n### Contribution\n\nUnless you explicitly state otherwise, any contribution intentionally submitted\nfor inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any\nadditional terms or conditions."
+                    }
+                ],
+                "license_expressions": [
+                    "apache-2.0 OR mit"
+                ],
+                "percentage_of_license_text": 25.25,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "https://travis-ci.org/zonyitoo/conhash-rs.svg",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "url": "https://travis-ci.org/zonyitoo/conhash-rs",
+                        "start_line": 3,
+                        "end_line": 3
+                    },
+                    {
+                        "url": "http://en.wikipedia.org/wiki/Consistent_hashing",
+                        "start_line": 5,
+                        "end_line": 5
+                    },
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 77,
+                        "end_line": 77
+                    },
+                    {
+                        "url": "http://opensource.org/licenses/MIT",
+                        "start_line": 78,
+                        "end_line": 78
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": true,
+                "is_top_level": true,
+                "is_key_file": true,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "benches",
+                "type": "directory",
+                "name": "benches",
+                "base_name": "benches",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": true,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 1,
+                "dirs_count": 0,
+                "size_count": 1397,
+                "scan_errors": []
+            },
+            {
+                "path": "benches/my_benchmark.rs",
+                "type": "file",
+                "name": "my_benchmark.rs",
+                "base_name": "my_benchmark",
+                "extension": ".rs",
+                "size": 1397,
+                "date": "2022-06-07",
+                "sha1": "6583e51f88a84776d72eb7bc889f1f3ac15f00cb",
+                "md5": "241c3374aabe86d004588490420b4a47",
+                "sha256": "e0aed1d8f4a7432c35fd02e79dd4183add6576f93b4348eafe70fcd2602782ce",
+                "mime_type": "text/x-c",
+                "file_type": "C source, ASCII text",
+                "programming_language": "Rust",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "src",
+                "type": "directory",
+                "name": "src",
+                "base_name": "src",
+                "extension": "",
+                "size": 0,
+                "date": null,
+                "sha1": null,
+                "md5": null,
+                "sha256": null,
+                "mime_type": null,
+                "file_type": null,
+                "programming_language": null,
+                "is_binary": false,
+                "is_text": false,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": false,
+                "is_script": false,
+                "licenses": [],
+                "license_expressions": [],
+                "percentage_of_license_text": 0,
+                "copyrights": [],
+                "holders": [],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": true,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 3,
+                "dirs_count": 0,
+                "size_count": 10313,
+                "scan_errors": []
+            },
+            {
+                "path": "src/conhash.rs",
+                "type": "file",
+                "name": "conhash.rs",
+                "base_name": "conhash",
+                "extension": ".rs",
+                "size": 9133,
+                "date": "2022-06-07",
+                "sha1": "222d6171512c6ec5a42c7b01f26509c4e3510f29",
+                "md5": "8f5d9759af2652bd52d3ac7aaf6c9ce2",
+                "sha256": "c1520f7465e401075f3b3065cbca17cde9cd9cbe5b5470cfa51433db5075c93b",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": "Rust",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "mit",
+                        "score": 100,
+                        "name": "MIT License",
+                        "short_name": "MIT License",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "MIT",
+                        "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                        "text_url": "http://opensource.org/licenses/mit-license.php",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/mit",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.yml",
+                        "spdx_license_key": "MIT",
+                        "spdx_url": "https://spdx.org/licenses/MIT",
+                        "start_line": 3,
+                        "end_line": 7,
+                        "matched_rule": {
+                            "identifier": "mit_or_apache-2.0_2.RULE",
+                            "license_expression": "mit OR apache-2.0",
+                            "licenses": [
+                                "mit",
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [
+                                "LICENSE-APACHE",
+                                "LICENSE-MIT"
+                            ],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 48,
+                            "matched_length": 48,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+                    },
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 3,
+                        "end_line": 7,
+                        "matched_rule": {
+                            "identifier": "mit_or_apache-2.0_2.RULE",
+                            "license_expression": "mit OR apache-2.0",
+                            "licenses": [
+                                "mit",
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [
+                                "LICENSE-APACHE",
+                                "LICENSE-MIT"
+                            ],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 48,
+                            "matched_length": 48,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+                    }
+                ],
+                "license_expressions": [
+                    "mit OR apache-2.0"
+                ],
+                "percentage_of_license_text": 4.41,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 conhash-rs",
+                        "start_line": 1,
+                        "end_line": 1
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "conhash-rs",
+                        "start_line": 1,
+                        "end_line": 1
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 4,
+                        "end_line": 4
+                    },
+                    {
+                        "url": "http://opensource.org/licenses/MIT",
+                        "start_line": 5,
+                        "end_line": 5
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "src/lib.rs",
+                "type": "file",
+                "name": "lib.rs",
+                "base_name": "lib",
+                "extension": ".rs",
+                "size": 780,
+                "date": "2022-06-07",
+                "sha1": "c7422a220f450739f908b75d36df3941e15191cd",
+                "md5": "8d288f8f6f09fe63fc032897bcdfa6b8",
+                "sha256": "b2de98c5d43a33c998f97f3c12e7b9c538959d50cca63fed54c7f47c7901fdde",
+                "mime_type": "text/x-c",
+                "file_type": "C source, ASCII text",
+                "programming_language": "Rust",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "mit",
+                        "score": 100,
+                        "name": "MIT License",
+                        "short_name": "MIT License",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "MIT",
+                        "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                        "text_url": "http://opensource.org/licenses/mit-license.php",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/mit",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.yml",
+                        "spdx_license_key": "MIT",
+                        "spdx_url": "https://spdx.org/licenses/MIT",
+                        "start_line": 3,
+                        "end_line": 7,
+                        "matched_rule": {
+                            "identifier": "mit_or_apache-2.0_2.RULE",
+                            "license_expression": "mit OR apache-2.0",
+                            "licenses": [
+                                "mit",
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [
+                                "LICENSE-APACHE",
+                                "LICENSE-MIT"
+                            ],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 48,
+                            "matched_length": 48,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+                    },
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 3,
+                        "end_line": 7,
+                        "matched_rule": {
+                            "identifier": "mit_or_apache-2.0_2.RULE",
+                            "license_expression": "mit OR apache-2.0",
+                            "licenses": [
+                                "mit",
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [
+                                "LICENSE-APACHE",
+                                "LICENSE-MIT"
+                            ],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 48,
+                            "matched_length": 48,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+                    }
+                ],
+                "license_expressions": [
+                    "mit OR apache-2.0"
+                ],
+                "percentage_of_license_text": 38.1,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 conhash-rs",
+                        "start_line": 1,
+                        "end_line": 1
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "conhash-rs",
+                        "start_line": 1,
+                        "end_line": 1
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 4,
+                        "end_line": 4
+                    },
+                    {
+                        "url": "http://opensource.org/licenses/MIT",
+                        "start_line": 5,
+                        "end_line": 5
+                    },
+                    {
+                        "url": "http://en.wikipedia.org/wiki/Consistent_hashing",
+                        "start_line": 9,
+                        "end_line": 9
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            },
+            {
+                "path": "src/node.rs",
+                "type": "file",
+                "name": "node.rs",
+                "base_name": "node",
+                "extension": ".rs",
+                "size": 400,
+                "date": "2022-06-07",
+                "sha1": "3ad90a027890195833dfcdd4bf8b6e52f050f11e",
+                "md5": "59ba9f04f09a87cf21aa08cd34094351",
+                "sha256": "a0212acc9b26df6734ea4fb86aad56cbe936869d7786dea5bc82e497cc0ca3ec",
+                "mime_type": "text/plain",
+                "file_type": "ASCII text",
+                "programming_language": "Rust",
+                "is_binary": false,
+                "is_text": true,
+                "is_archive": false,
+                "is_media": false,
+                "is_source": true,
+                "is_script": false,
+                "licenses": [
+                    {
+                        "key": "mit",
+                        "score": 100,
+                        "name": "MIT License",
+                        "short_name": "MIT License",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "MIT",
+                        "homepage_url": "http://opensource.org/licenses/mit-license.php",
+                        "text_url": "http://opensource.org/licenses/mit-license.php",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/mit",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/mit.yml",
+                        "spdx_license_key": "MIT",
+                        "spdx_url": "https://spdx.org/licenses/MIT",
+                        "start_line": 3,
+                        "end_line": 7,
+                        "matched_rule": {
+                            "identifier": "mit_or_apache-2.0_2.RULE",
+                            "license_expression": "mit OR apache-2.0",
+                            "licenses": [
+                                "mit",
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [
+                                "LICENSE-APACHE",
+                                "LICENSE-MIT"
+                            ],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 48,
+                            "matched_length": 48,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+                    },
+                    {
+                        "key": "apache-2.0",
+                        "score": 100,
+                        "name": "Apache License 2.0",
+                        "short_name": "Apache 2.0",
+                        "category": "Permissive",
+                        "is_exception": false,
+                        "is_unknown": false,
+                        "owner": "Apache Software Foundation",
+                        "homepage_url": "http://www.apache.org/licenses/",
+                        "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+                        "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+                        "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+                        "spdx_license_key": "Apache-2.0",
+                        "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+                        "start_line": 3,
+                        "end_line": 7,
+                        "matched_rule": {
+                            "identifier": "mit_or_apache-2.0_2.RULE",
+                            "license_expression": "mit OR apache-2.0",
+                            "licenses": [
+                                "mit",
+                                "apache-2.0"
+                            ],
+                            "referenced_filenames": [
+                                "LICENSE-APACHE",
+                                "LICENSE-MIT"
+                            ],
+                            "is_license_text": false,
+                            "is_license_notice": true,
+                            "is_license_reference": false,
+                            "is_license_tag": false,
+                            "is_license_intro": false,
+                            "has_unknown": false,
+                            "matcher": "2-aho",
+                            "rule_length": 48,
+                            "matched_length": 48,
+                            "match_coverage": 100,
+                            "rule_relevance": 100
+                        },
+                        "matched_text": "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms."
+                    }
+                ],
+                "license_expressions": [
+                    "mit OR apache-2.0"
+                ],
+                "percentage_of_license_text": 78.69,
+                "copyrights": [
+                    {
+                        "value": "Copyright 2016 conhash-rs",
+                        "start_line": 1,
+                        "end_line": 1
+                    }
+                ],
+                "holders": [
+                    {
+                        "value": "conhash-rs",
+                        "start_line": 1,
+                        "end_line": 1
+                    }
+                ],
+                "authors": [],
+                "packages": [],
+                "emails": [],
+                "urls": [
+                    {
+                        "url": "http://www.apache.org/licenses/LICENSE-2.0",
+                        "start_line": 4,
+                        "end_line": 4
+                    },
+                    {
+                        "url": "http://opensource.org/licenses/MIT",
+                        "start_line": 5,
+                        "end_line": 5
+                    }
+                ],
+                "is_legal": false,
+                "is_manifest": false,
+                "is_readme": false,
+                "is_top_level": false,
+                "is_key_file": false,
+                "is_generated": false,
+                "is_license_text": false,
+                "files_count": 0,
+                "dirs_count": 0,
+                "size_count": 0,
+                "scan_errors": []
+            }
+        ]
+    }
+}

--- a/test/providers/summary/scancode.js
+++ b/test/providers/summary/scancode.js
@@ -74,6 +74,20 @@ describe('ScancodeSummarizer basic compatability', () => {
     )
   })
 
+  it('summarizes using license_expression in version 30.1.0 of ScanCode', () => {
+    const coordinates = { type: 'debsrc', provider: 'debian' }
+    const harvestData = getHarvestData('30.1.0', 'debsrc-license-expression')
+    const result = summarizer.summarize(coordinates, harvestData)
+    assert.equal(result.licensed.declared, 'Apache-2.0')
+  })
+
+  it('summarizes falling back to license_expression in version 30.1.0 of ScanCode', () => {
+    const coordinates = { type: 'git', provider: 'github' }
+    const harvestData = getHarvestData('30.1.0', 'github-license-expression')
+    const result = summarizer.summarize(coordinates, harvestData)
+    assert.equal(result.licensed.declared, 'MIT OR Apache-2.0')
+  })
+
   it('throws an error on an invalid scancode version', () => {
     const version = '0.0.0'
     const coordinates = { type: 'npm', provider: 'npmjs' }


### PR DESCRIPTION
In scancode, `summary.packages[0].license_expression` contains license information.  This field later becomes `declared_license_expression`, see https://github.com/nexB/scancode-toolkit/commit/ab677c6de46929e9ceedcf33af69464245aacbf0#diff-47cc909d82dee95ebbb1a3d3a8ed519ae75684072c8f4867b90056d66863f964 `declared_license_expression` is the 'primary license expression as determined from the declaration(s) of the authors of the package'. see https://www.nexb.com/scancode-license-clarity-scoring/  So `license_expression` can be used to infer license information.

When the existing logic fails to derive license information, try to get license information from packages[0].license_expression.

Test cases:
https://clearlydefined.io/definitions/git/github/jknack/handlebars.java/683c5e885d5dcdf3d17b33e9667f3fb153952016
https://clearlydefined.io/definitions/git/github/jenkinsci/workflow-support-plugin/35e2736cfd5c56799eece176328906d92b6a0dd1
https://clearlydefined.io/definitions/git/github/jenkinsci/durable-task-plugin/e5d4fc08b0be935e03229e23e99a0c92a780da5a
https://clearlydefined.io/definitions/git/github/jenkinsci/pipeline-input-step-plugin/d8a957db5be95ddfbf81f41a60b2f034000314b5
https://clearlydefined.io/definitions/git/github/alephium/extension-wallet/d876b08e0c23ba58bcadedcc5b2a1975af386e6b
https://clearlydefined.io/definitions/git/github/zonyitoo/conhash-rs/779ed931b07c1a9b643dc14f62db29bf8102fd1b
https://clearlydefined.io/definitions/git/github/zowens/crc32c/dea9e9acdbf696dd52e8a62524f0d6a3cb57d105
https://clearlydefined.io/definitions/git/github/saleor/saleor-cli/2996c750aafb302cb1edaa1689f2d75fb5372c09
