### PR TITLE
Fix curation review url to point to the corresponding server

### DIFF
--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -511,7 +511,7 @@ class GitHubCurationService {
       owner,
       repo,
       number,
-      body: `You can review the change introduced to the full definition at [ClearlyDefined](https://clearlydefined.io/curations/${number}).`
+      body: `You can review the change introduced to the full definition at [ClearlyDefined](${this._getCurationReviewUrl(number)}).`
     }
     await serviceGithub.issues.createComment(comment)
     return result
@@ -694,7 +694,7 @@ ${this._formatDefinitions(patch.patches)}`
 
   async _postCommitStatus(sha, number, state, description) {
     const { owner, repo } = this.options
-    const target_url = `${this.endpoints.website}/curations/${number}`
+    const target_url = this._getCurationReviewUrl(number)
     try {
       return this.github.repos.createStatus({
         owner,
@@ -708,6 +708,10 @@ ${this._formatDefinitions(patch.patches)}`
     } catch (error) {
       this.logger.info(`Failed to create status for PR #${number}`)
     }
+  }
+
+  _getCurationReviewUrl(number) {
+    return `${this.endpoints.website}/curations/${number}`
   }
 
   async _postErrorsComment(number, body) {

--- a/test/providers/curation/github.js
+++ b/test/providers/curation/github.js
@@ -206,6 +206,9 @@ describe('Github Curation Service', () => {
 
     const result = await gitHubService.addOrUpdate(null, gitHubService.github, info, contributionPatch)
     expect(result).to.be.deep.equal({ data: { number: 143 } })
+    expect(gitHubService.github.issues.createComment.getCall(0).args[0].body).to.contain(
+      '(http://localhost:3000/curations/143)'
+    )
   })
 
   describe('addByMergedCuration()', () => {
@@ -295,6 +298,9 @@ describe('Github Curation Service', () => {
 
       const result = await gitHubService.addByMergedCuration(pr)
       expect(result).to.be.deep.equal({ data: { number: 143 } })
+      expect(gitHubService.github.issues.createComment.getCall(0).args[0].body).to.contain(
+        '(http://localhost:3000/curations/143)'
+      )
 
       assert(startMatchingSpy.calledWith(
         EntityCoordinates.fromObject(definitionCoordinates),
@@ -458,6 +464,13 @@ describe('Github Curation Service', () => {
     it('verify branch name', () => {
       const branchName = createService()._getBranchName({ login: 'test' })
       expect(branchName).to.be.eq('test_211203_140949.712')
+    })
+  })
+
+  describe('verify _getCurationReviewUrl', () => {
+    it('verify branch name', () => {
+      const curationReviewUrl = createService()._getCurationReviewUrl(143)
+      expect(curationReviewUrl).to.be.eq('http://localhost:3000/curations/143')
     })
   })
 })


### PR DESCRIPTION
The comment auto generated by service always point to the production web ui.  An example is at:
https://github.com/clearlydefined/curated-data-dev/pull/1275#issuecomment-1622265240.

Refactor the existing code into a function for reuse to auto generate comment correctly on dev server.