### PR TITLE
Use `save-exact` in `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 unsafe-perm = true
+save-exact = true


### PR DESCRIPTION
This ensures that dependencies are installed with an exact version, instead of a semantic version range specifier. See [the documentation][1] for more information.

[1]: https://docs.npmjs.com/cli/v8/commands/npm-install#save-exact