### PR TITLE
add github action to build and deploy the dev CD/service

### DIFF
--- a/.github/workflows/build_and_deploy_dev.yml
+++ b/.github/workflows/build_and_deploy_dev.yml
@@ -70,6 +70,11 @@ jobs:
                     "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
                     "value": "${{ secrets.REGISTRY_PASSWORD }}",
                     "slotSetting": false
+                },
+                {
+                    "name": "BUILD_SHA",
+                    "value": "${{ github.sha }}",
+                    "slotSetting": false
                 }
             ]
 

--- a/.github/workflows/build_and_deploy_dev.yml
+++ b/.github/workflows/build_and_deploy_dev.yml
@@ -7,8 +7,7 @@ name: Build and Deploy to dev service app
 on:
   workflow_dispatch:
   push:
-    branches: [elr/gh-action-dev-deploy]
-    # branches: [master]
+    branches: [master]
 
 # There are secrets and environment variables that need to be set that control what is pushed to
 # ghcr and Azure.

--- a/.github/workflows/build_and_deploy_dev.yml
+++ b/.github/workflows/build_and_deploy_dev.yml
@@ -19,7 +19,7 @@ on:
 # Environment Variables:
 #   APPLICATION_TYPE:   type of application that is being deployed; used to add a label to the Docker image (values: api | web | worker)
 #   AZURE_WEBAPP_NAME:  name of the Azure WebApp being deployed
-#   CODE_ENVIRONMENT:   environment that the code is being deployed to; used to add a label to the Docker image (values: dev | prod)
+#   DEPLOY_ENVIRONMENT:   environment that the code is being deployed to; used to add a label to the Docker image (values: dev | prod)
 #   DEPLOY_DOCKER_TAG:  the tag used for deploying a specific Docker image to Azure.  For dev, use the `github.sha`.  For production, use the SEMVER
 #                       version of the release.  Make sure to add this tag to the `DOCKER_TAGS` in the `Build and push Docker image` step.
 #   DOCKER_IMAGE_NAME:  name of the Docker image that is being built and pushed to ghcr.io.
@@ -27,7 +27,7 @@ on:
 env:
   APPLICATION_TYPE: api
   AZURE_WEBAPP_NAME: clearlydefined-api-dev
-  CODE_ENVIRONMENT: dev
+  DEPLOY_ENVIRONMENT: dev
   DEPLOY_DOCKER_TAG: ${{ github.sha }}
   DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}-dev
 
@@ -48,7 +48,7 @@ jobs:
       - name: Build and push Docker image
         env:
           DOCKER_TAGS: |
-            ${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}
         uses: docker/build-push-action@v5.1.0
         with:
           context: .
@@ -56,7 +56,7 @@ jobs:
           file: Dockerfile
           tags: ${{ env.DOCKER_TAGS }}
           labels: |
-            env=${{ env.CODE_ENVIRONMENT }}
+            env=${{ env.DEPLOY_ENVIRONMENT }}
             type=${{ env.APPLICATION_TYPE }}
 
       - name: Login for Azure cli commands

--- a/.github/workflows/build_and_deploy_dev.yml
+++ b/.github/workflows/build_and_deploy_dev.yml
@@ -1,0 +1,77 @@
+name: Build and Deploy to dev service app
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+env:
+  AZURE_WEBAPP_NAME: clearlydefined-api-dev
+  DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}-dev
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log into ghcr registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: DevDockerfile
+          tags: |
+            ${{ env.DOCKER_IMAGE_NAME }}:latest 
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
+          labels: |
+            env=dev
+            type=api
+
+      - name: Login for Azure cli commands
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set DOCKER configs in Azure web app
+        uses: Azure/appservice-settings@v1
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          app-settings-json: |
+            [
+              {
+                    "name": "DOCKER_CUSTOM_IMAGE_NAME",
+                    "value": "${{ env.DOCKER_IMAGE_NAME }}:latest }}",
+                    "slotSetting": false
+              },
+              {
+                    "name": "DOCKER_REGISTRY_SERVER_URL",
+                    "value": "https://ghcr.io",
+                    "slotSetting": false
+                },
+                {
+                    "name": "DOCKER_REGISTRY_SERVER_USERNAME",
+                    "value": "${{ secrets.REGISTRY_USERNAME  }}",
+                    "slotSetting": false
+                },
+                {
+                    "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
+                    "value": "${{ secrets.REGISTRY_PASSWORD }}",
+                    "slotSetting": false
+                }
+            ]
+
+      - name: Deploy to Azure WebApp
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          images: ${{ env.DOCKER_IMAGE_NAME }}:latest

--- a/.github/workflows/build_and_deploy_dev.yml
+++ b/.github/workflows/build_and_deploy_dev.yml
@@ -6,8 +6,11 @@ on:
     branches: [master]
 
 env:
+  CODE_ENVIRONMENT: dev
+  APPLICATION_TYPE: api
   AZURE_WEBAPP_NAME: clearlydefined-api-dev
   DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}-dev
+  # SEMVER: '' # if you want to use semver, you will need to add a tag to the Docker build
 
 jobs:
   build-and-deploy:
@@ -20,21 +23,21 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}         # user that kicked off the action
+          password: ${{ secrets.GITHUB_TOKEN }} # token created when the action launched (short lived)
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          file: DevDockerfile
+          file: Dockerfile
           tags: |
             ${{ env.DOCKER_IMAGE_NAME }}:latest 
             ${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
           labels: |
-            env=dev
-            type=api
+            env=${{ env.CODE_ENVIRONMENT }}
+            type=${{ env.APPLICATION_TYPE }}
 
       - name: Login for Azure cli commands
         uses: azure/login@v1

--- a/.github/workflows/build_and_deploy_dev.yml
+++ b/.github/workflows/build_and_deploy_dev.yml
@@ -1,59 +1,79 @@
+# This workflow will build a docker image, push it to ghcr.io, and deploy it to an Azure WebApp.
 name: Build and Deploy to dev service app
 
+# Update the triggers based on the environment that is being deployed to.
+#   Triggers for dev deployments:  1) manually triggered, 2) push to branch `master`
+#   Triggers for prod deployments: 1) manually triggered, 2) release created
 on:
   workflow_dispatch:
   push:
     branches: [elr/gh-action-dev-deploy]
     # branches: [master]
 
+# There are secrets and environment variables that need to be set that control what is pushed to
+# ghcr and Azure.
+#
+# Secrets:
+#   AZURE_CREDENTIALS:                service principal that has access to the Azure WebApp
+#   AZURE_WEBAPP_PUBLISH_PROFILE_DEV: publish profile for the Azure WebApp  NOTE: The name of the secret changes.  For dev, it ends in `_DEV`.  Production does not have an extension.
+#
+# Environment Variables:
+#   APPLICATION_TYPE:   type of application that is being deployed; used to add a label to the Docker image (values: api | web | worker)
+#   AZURE_WEBAPP_NAME:  name of the Azure WebApp being deployed
+#   CODE_ENVIRONMENT:   environment that the code is being deployed to; used to add a label to the Docker image (values: dev | prod)
+#   DEPLOY_DOCKER_TAG:  the tag used for deploying a specific Docker image to Azure.  For dev, use the `github.sha`.  For production, use the SEMVER
+#                       version of the release.  Make sure to add this tag to the `DOCKER_TAGS` in the `Build and push Docker image` step.
+#   DOCKER_IMAGE_NAME:  name of the Docker image that is being built and pushed to ghcr.io.
+
 env:
-  CODE_ENVIRONMENT: dev
   APPLICATION_TYPE: api
   AZURE_WEBAPP_NAME: clearlydefined-api-dev
+  CODE_ENVIRONMENT: dev
+  DEPLOY_DOCKER_TAG: ${{ github.sha }}
   DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}-dev
-  # SEMVER: '' # if you want to use semver, you will need to add a tag to the Docker build
 
 jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
 
       - name: Log into ghcr registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }} # user that kicked off the action
           password: ${{ secrets.GITHUB_TOKEN }} # token created when the action launched (short lived)
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        env:
+          DOCKER_TAGS: |
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
+        uses: docker/build-push-action@v5.1.0
         with:
           context: .
           push: true
           file: Dockerfile
-          tags: |
-            ${{ env.DOCKER_IMAGE_NAME }}:latest 
-            ${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
+          tags: ${{ env.DOCKER_TAGS }}
           labels: |
             env=${{ env.CODE_ENVIRONMENT }}
             type=${{ env.APPLICATION_TYPE }}
 
       - name: Login for Azure cli commands
-        uses: azure/login@v1
+        uses: azure/login@v1.6.1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Set DOCKER configs in Azure web app
-        uses: Azure/appservice-settings@v1
+        uses: azure/appservice-settings@v1.1.1
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
           app-settings-json: |
             [
               {
                     "name": "DOCKER_CUSTOM_IMAGE_NAME",
-                    "value": "${{ env.DOCKER_IMAGE_NAME }}:latest }}",
+                    "value": "${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}",
                     "slotSetting": false
               },
               {
@@ -79,8 +99,8 @@ jobs:
             ]
 
       - name: Deploy to Azure WebApp
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v3.0.0
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
-          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-          images: ${{ env.DOCKER_IMAGE_NAME }}:latest
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_DEV }}
+          images: '${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}'

--- a/.github/workflows/build_and_deploy_dev.yml
+++ b/.github/workflows/build_and_deploy_dev.yml
@@ -3,7 +3,8 @@ name: Build and Deploy to dev service app
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [elr/gh-action-dev-deploy]
+    # branches: [master]
 
 env:
   CODE_ENVIRONMENT: dev
@@ -23,7 +24,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}         # user that kicked off the action
+          username: ${{ github.actor }} # user that kicked off the action
           password: ${{ secrets.GITHUB_TOKEN }} # token created when the action launched (short lived)
 
       - name: Build and push Docker image

--- a/app.js
+++ b/app.js
@@ -181,7 +181,7 @@ function createApp(config) {
 
   app.use(require('./middleware/querystring'))
 
-  app.use('/', require('./routes/index'))
+  app.use('/', require('./routes/index')(config.buildsha))
   app.use('/origins/github', require('./routes/originGitHub')())
   app.use('/origins/crate', require('./routes/originCrate')())
   app.use('/origins/pod', require('./routes/originPod')())

--- a/bin/config.js
+++ b/bin/config.js
@@ -91,5 +91,6 @@ module.exports = {
     serviceKey: config.get('APPINSIGHTS_SERVICE_APIKEY'),
     crawlerId: config.get('APPINSIGHTS_CRAWLER_APPLICATIONID'),
     crawlerKey: config.get('APPINSIGHTS_CRAWLER_APIKEY')
-  }
+  },
+  buildsha : config.get('BUILD_SHA')
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,7 +4,11 @@ const express = require('express')
 const router = express.Router()
 
 router.get('/', function(req, res) {
-  res.status(200).send({ status: 'OK' })
+  const sha = require('child_process')
+    .execSync('git rev-parse HEAD')
+    .toString().trim()
+  const msg = `{ "status": "OK", "sha": "${sha}" }`
+  res.status(200).send(msg)
 })
 
 module.exports = router

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,11 +4,15 @@ const express = require('express')
 const router = express.Router()
 
 router.get('/', function(req, res) {
-  const sha = require('child_process')
-    .execSync('git rev-parse HEAD')
-    .toString().trim()
   const msg = `{ "status": "OK", "sha": "${sha}" }`
   res.status(200).send(msg)
 })
 
 module.exports = router
+
+let sha
+function setup(buildsha) {
+  sha = buildsha
+  return router
+}
+module.exports = setup


### PR DESCRIPTION
* Partially addresses #1026 

### Description

This PR adds a GitHub action to perform the deploy of service to the dev service app in Azure.  To support debugging, it also adds the sha of the current deploy to the status endpoint.

_NOTE: As part of this work, Azure auth credentials were created following this [documentation](https://github.com/Azure/login#login-with-a-service-principal-secret)._

### Follow-on Work

* create a bot user (e.g. clearlydefinedopts-bot and update credentials to use this bot
* permanently disable Azure DevOpts pipeline for dev service
* setup prod service to use a GH action to complete Issue #1026
* #1027 
