### PR TITLE
Fix previously broken test

### DIFF
--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -80,7 +80,7 @@ class ScanCodeSummarizer {
         return SPDX.normalize(declared_license)
       }
       default:
-        throw new Error(`Invalid version of scancode: ${scancodeVersion}`)
+        throw new Error(`Invalid version of ScanCode: ${scancodeVersion}`)
     }
   }
 

--- a/test/fixtures/scancode/0.0.0/npm-basic.json
+++ b/test/fixtures/scancode/0.0.0/npm-basic.json
@@ -5,7 +5,7 @@
     "fetchedAt": "2018-02-27T20:03:11.607Z",
     "links": {
       "self": {
-        "href": "urn:npm:npmjs:-:glob:revision:7.1.2:tool:scancode:2.2.1",
+        "href": "urn:npm:npmjs:-:glob:revision:7.1.2:tool:scancode:0.0.0",
         "type": "resource"
       },
       "siblings": {
@@ -13,14 +13,14 @@
         "type": "collection"
       }
     },
-    "version": "2.2.1",
+    "version": "0.0.0",
     "contentType": "application/json",
     "releaseDate": "2017-05-19T20:15:25.471Z",
     "processedAt": "2018-02-27T20:05:25.944Z"
   },
   "content": {
     "scancode_notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
-    "scancode_version": "2.2.1",
+    "scancode_version": "0.0.0",
     "scancode_options": {
       "--copyright": true,
       "--license": true,

--- a/test/providers/summary/scancode.js
+++ b/test/providers/summary/scancode.js
@@ -116,9 +116,8 @@ describe('ScancodeSummarizer basic compatability', () => {
     const harvestData = getHarvestData(version, 'npm-basic')
     try {
       summarizer.summarize(coordinates, harvestData)
-      throw new Error('Invalid version of ScanCode')
     } catch (error) {
-      expect(error.message).to.eq('Invalid version of ScanCode')
+      expect(error.message).to.eq(`Invalid version of ScanCode: ${version}`)
     }
   })
 


### PR DESCRIPTION
Instead of triggering the code path at https://github.com/clearlydefined/service/blob/4ae722e9eaad2bada374df687c0a5dad9e1efe18/providers/summary/scancode.js#L82-L83, this test previously just tested its own `throw new Error` line. This is now fixed and the expected error message and fixture adjusted to make the test actually work.