### PR TITLE
deprecate config TRIMMED_DEFINITION_MONGO_COLLECTION_NAME

### DIFF
--- a/providers/stores/mongoConfig.js
+++ b/providers/stores/mongoConfig.js
@@ -17,9 +17,13 @@ function definitionPaged(options) {
 }
 
 function definitionTrimmed(options) {
+  const oldConfig = config.get('TRIMMED_DEFINITION_MONGO_COLLECTION_NAME')
+  if (oldConfig) {
+    console.warn('The TRIMMED_DEFINITION_MONGO_COLLECTION_NAME environment variable is deprecated. Use DEFINITION_MONGO_TRIMMED_COLLECTION_NAME instead.')
+  }
   return TrimmedMongoDefinitionStore(options || {
     ...dbOptions,
-    collectionName: config.get('DEFINITION_MONGO_TRIMMED_COLLECTION_NAME') || 'definitions-trimmed'
+    collectionName: config.get('DEFINITION_MONGO_TRIMMED_COLLECTION_NAME') || oldConfig || 'definitions-trimmed'
   })
 }
 


### PR DESCRIPTION
Deprecated config: TRIMMED_DEFINITION_MONGO_COLLECTION_NAME
Replacement config: DEFINITION_MONGO_TRIMMED_COLLECTION_NAME

Config TRIMMED_DEFINITION_MONGO_COLLECTION_NAME was removed in PR #987.  To avoid a major version change in the next release, the config is being added back in and deprecated.

New processing:
* if the old config has a value, a deprecation message is written to the console
* if the new config is specified, its value is used and the old one is ignored if it exists
* if only the old config is specified, its value is used
* otherwise, if neither are specified, the default is used