### PR TITLE
prepare for release v1.1.0 by updating the version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "service",
-  "version": "0.1.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "service",
-      "version": "0.1.1",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service",
-  "version": "0.1.1",
+  "version": "1.1.0",
   "description": "Service side of clearlydefined.io.",
   "scripts": {
     "test": "nyc mocha --exit \"test/**/*.js\" && eslint .",


### PR DESCRIPTION
* MERGE AFTER PR #1046

Normally, setting the version happens in master just before it is merged into prod in preparation of a release.  Since the code to be released is already in prod branch and master branch has newer commits, this needs to be added directly to prod.  Once merged into prod branch, it will be backported to master.

Used `npm version 1.1.0` to generate.  ([documentation](https://docs.npmjs.com/cli/v8/commands/npm-version)]
