### PR TITLE
remove docker secrets from deploy action

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -71,30 +71,20 @@ jobs:
           app-settings-json: |
             [
               {
-                    "name": "DOCKER_CUSTOM_IMAGE_NAME",
-                    "value": "${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}",
-                    "slotSetting": false
+                "name": "DOCKER_CUSTOM_IMAGE_NAME",
+                "value": "${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}",
+                "slotSetting": false
               },
               {
-                    "name": "DOCKER_REGISTRY_SERVER_URL",
-                    "value": "https://ghcr.io",
-                    "slotSetting": false
-                },
-                {
-                    "name": "DOCKER_REGISTRY_SERVER_USERNAME",
-                    "value": "${{ secrets.REGISTRY_USERNAME  }}",
-                    "slotSetting": false
-                },
-                {
-                    "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
-                    "value": "${{ secrets.REGISTRY_PASSWORD }}",
-                    "slotSetting": false
-                },
-                {
-                    "name": "BUILD_SHA",
-                    "value": "${{ github.sha }}",
-                    "slotSetting": false
-                }
+                "name": "DOCKER_REGISTRY_SERVER_URL",
+                "value": "https://ghcr.io",
+                "slotSetting": false
+              },
+              {
+                  "name": "BUILD_SHA",
+                  "value": "${{ github.sha }}",
+                  "slotSetting": false
+              }
             ]
 
       - name: Deploy to Azure WebApp


### PR DESCRIPTION
### Description

This removes the login credentials for getting the ghcr Docker image from the dev deploy action.  They are now stored in the secrets vault in Azure and do not need to be passed.

### Reviewer Attention

This includes some cleanup of spacing in the configuration array.  Other than whitespace changes, the only change is the removal of the two Docker credential configs.