### PR TITLE
add GitHub action for deploy of production service

### DIFF
--- a/.github/workflows/build_and_deploy_prod.yml
+++ b/.github/workflows/build_and_deploy_prod.yml
@@ -1,0 +1,138 @@
+# This workflow will build a docker image, push it to ghcr.io, and deploy it to an Azure WebApp.
+name: Build and Deploy to prod service app
+
+# Update the triggers based on the environment that is being deployed to.
+#   Triggers for dev deployments:  1) manually triggered, 2) push to branch `master`
+#   Triggers for prod deployments: 1) manually triggered, 2) release [published]
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+# There are secrets and environment variables that need to be set that control what is pushed to
+# ghcr and Azure.
+#
+# Secrets:
+#   AZURE_CREDENTIALS:               service principal that has access to the Azure WebApp
+#   AZURE_WEBAPP_PUBLISH_PROFILE:    publish profile for the Azure WebApp
+#   AZURE_WEBAPP_PUBLISH_PROFILE_EU: publish profile for the Azure WebApp in Europe
+#
+# Environment Variables:
+#   APPLICATION_TYPE:     type of application that is being deployed; used to add a label to the Docker image (values: api | web | worker)
+#   AZURE_WEBAPP_NAME:    name of the Azure WebApp being deployed
+#   AZURE_EU_WEBAPP_NAME: name of the Azure WebApp being deployed
+#   DEPLOY_ENVIRONMENT:   environment that the code is being deployed to; used to add a label to the Docker image (values: dev | prod)
+#   DEPLOY_DOCKER_TAG:    the tag used for deploying a specific Docker image to Azure.  For dev, use the `github.sha`.  For production, use the SEMVER
+#                         version of the release.  Make sure to add this tag to the `DOCKER_TAGS` in the `Build and push Docker image` step.
+#   DOCKER_IMAGE_NAME:    name of the Docker image that is being built and pushed to ghcr.io.
+
+env:
+  APPLICATION_TYPE: api
+  AZURE_WEBAPP_NAME: clearlydefined-api-prod
+  AZURE_EU_WEBAPP_NAME: clearlydefined-api-prod-europe
+  DEPLOY_ENVIRONMENT: prod
+  DEPLOY_DOCKER_TAG: ${{ github.event.release.tag_name }}
+  DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: Log into ghcr registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }} # user that kicked off the action
+          password: ${{ secrets.GITHUB_TOKEN }} # token created when the action launched (short lived)
+
+      - name: Build and push Docker image
+        env:
+          DOCKER_TAGS: |
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}
+        uses: docker/build-push-action@v5.1.0
+        with:
+          context: .
+          push: true
+          file: Dockerfile
+          tags: ${{ env.DOCKER_TAGS }}
+          labels: |
+            env=${{ env.DEPLOY_ENVIRONMENT }}
+            type=${{ env.APPLICATION_TYPE }}
+
+      - name: Login for Azure cli commands
+        uses: azure/login@v1.6.1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set DOCKER configs in Azure web app
+        uses: azure/appservice-settings@v1.1.1
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          app-settings-json: |
+            [
+              {
+                "name": "DOCKER_CUSTOM_IMAGE_NAME",
+                "value": "${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}",
+                "slotSetting": false
+              },
+              {
+                "name": "DOCKER_REGISTRY_SERVER_URL",
+                "value": "https://ghcr.io",
+                "slotSetting": false
+              },
+              {
+                "name": "APP_VERSION",
+                "value": "${{ github.event.release.tag_name }}",
+                "slotSetting": false
+              },
+              {
+                "name": "BUILD_SHA",
+                "value": "${{ github.sha }}",
+                "slotSetting": false
+              }
+            ]
+
+      - name: Deploy to Azure WebApp
+        uses: azure/webapps-deploy@v3.0.0
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD }}
+          images: '${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}'
+
+      - name: Set DOCKER configs in Azure EU web app
+        uses: azure/appservice-settings@v1.1.1
+        with:
+          app-name: ${{ env.AZURE_EU_WEBAPP_NAME }}
+          app-settings-json: |
+            [
+              {
+                "name": "DOCKER_CUSTOM_IMAGE_NAME",
+                "value": "${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}",
+                "slotSetting": false
+              },
+              {
+                "name": "DOCKER_REGISTRY_SERVER_URL",
+                "value": "https://ghcr.io",
+                "slotSetting": false
+              },
+              {
+                "name": "APP_VERSION",
+                "value": "${{ github.event.release.tag_name }}",
+                "slotSetting": false
+              },
+              {
+                "name": "BUILD_SHA",
+                "value": "${{ github.sha }}",
+                "slotSetting": false
+              }
+            ]
+
+      - name: Deploy to Azure EU WebApp
+        uses: azure/webapps-deploy@v3.0.0
+        with:
+          app-name: ${{ env.AZURE_EU_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD_EU }}
+          images: '${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}'


### PR DESCRIPTION
_NOTE: This will merge into prod and then be back ported to master._

----

### Description

The GitHub action in this PR deploys prod branch to the production service webapps in US and Europe.  It uses the docker image built by the action and published to ghcr.

### Related Work

The action in this PR is very similar to the action for dev deploy in PR #1021.  Once this is merged in both prod and master, consider merging the two actions.

The main differences are:

* deploy on release
* deploy to US prod and EU prod


This is the same action that was being merged into master.  Because of the need to have this in prod for the release, this PR is replacing PR #1030.
