### PR TITLE
get version from package.json instead of release

### DIFF
--- a/.github/workflows/build_and_deploy_prod.yml
+++ b/.github/workflows/build_and_deploy_prod.yml
@@ -22,8 +22,7 @@ on:
 #   AZURE_WEBAPP_NAME:    name of the Azure WebApp being deployed
 #   AZURE_EU_WEBAPP_NAME: name of the Azure WebApp being deployed
 #   DEPLOY_ENVIRONMENT:   environment that the code is being deployed to; used to add a label to the Docker image (values: dev | prod)
-#   DEPLOY_DOCKER_TAG:    the tag used for deploying a specific Docker image to Azure.  For dev, use the `github.sha`.  For production, use the SEMVER
-#                         version of the release.  Make sure to add this tag to the `DOCKER_TAGS` in the `Build and push Docker image` step.
+#   DEPLOY_DOCKER_TAG:    _NOT used as a ENV for production.  To be able to always have the version, get it from package.json._
 #   DOCKER_IMAGE_NAME:    name of the Docker image that is being built and pushed to ghcr.io.
 
 env:
@@ -31,7 +30,7 @@ env:
   AZURE_WEBAPP_NAME: clearlydefined-api-prod
   AZURE_EU_WEBAPP_NAME: clearlydefined-api-prod-europe
   DEPLOY_ENVIRONMENT: prod
-  DEPLOY_DOCKER_TAG: ${{ github.event.release.tag_name }}
+  # DEPLOY_DOCKER_TAG: ${{ github.event.release.tag_name }}
   DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
 
 jobs:
@@ -39,6 +38,17 @@ jobs:
     name: Build and Deploy
     runs-on: ubuntu-latest
     steps:
+      - name: Get version
+        id: package
+        run: |
+          echo "::set-output name=version::$(node -p "require('./package.json').version")"
+        shell: bash
+
+      - name: Use version
+        run: |
+          echo "Version is ${{ steps.package.outputs.version }}"
+        shell: bash
+
       - uses: actions/checkout@v4.1.1
 
       - name: Log into ghcr registry
@@ -51,7 +61,7 @@ jobs:
       - name: Build and push Docker image
         env:
           DOCKER_TAGS: |
-            ${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.package.outputs.version }}
         uses: docker/build-push-action@v5.1.0
         with:
           context: .
@@ -75,7 +85,7 @@ jobs:
             [
               {
                 "name": "DOCKER_CUSTOM_IMAGE_NAME",
-                "value": "${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}",
+                "value": "${{ env.DOCKER_IMAGE_NAME }}:${{ steps.package.outputs.version }}",
                 "slotSetting": false
               },
               {
@@ -85,7 +95,7 @@ jobs:
               },
               {
                 "name": "APP_VERSION",
-                "value": "${{ github.event.release.tag_name }}",
+                "value": "${{ steps.package.outputs.version }}",
                 "slotSetting": false
               },
               {
@@ -100,7 +110,7 @@ jobs:
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD }}
-          images: '${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}'
+          images: '${{ env.DOCKER_IMAGE_NAME }}:${{ steps.package.outputs.version }}'
 
       - name: Set DOCKER configs in Azure EU web app
         uses: azure/appservice-settings@v1.1.1
@@ -110,7 +120,7 @@ jobs:
             [
               {
                 "name": "DOCKER_CUSTOM_IMAGE_NAME",
-                "value": "${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}",
+                "value": "${{ env.DOCKER_IMAGE_NAME }}:${{ steps.package.outputs.version }}",
                 "slotSetting": false
               },
               {
@@ -120,7 +130,7 @@ jobs:
               },
               {
                 "name": "APP_VERSION",
-                "value": "${{ github.event.release.tag_name }}",
+                "value": "${{ steps.package.outputs.version }}",
                 "slotSetting": false
               },
               {
@@ -135,4 +145,4 @@ jobs:
         with:
           app-name: ${{ env.AZURE_EU_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD_EU }}
-          images: '${{ env.DOCKER_IMAGE_NAME }}:${{ env.DEPLOY_DOCKER_TAG }}'
+          images: '${{ env.DOCKER_IMAGE_NAME }}:${{ steps.package.outputs.version }}'


### PR DESCRIPTION
If the action is triggered by a release, `${{ github.event.release.tag_name }}` has the version.  If we manually run this action manually, `${{ github.event.release.tag_name }}` is empty.

To always have the version for tagging the created docker image and to pass to the webapp, this PR gets the version directly from the package.json file.

_NOTE: The package.json file must have the correct version when running manually._