### PR TITLE
Restrict PyPI coordinates name in PypiCoordinatesMapper

### DIFF
--- a/lib/pypiCoordinatesMapper.js
+++ b/lib/pypiCoordinatesMapper.js
@@ -16,16 +16,15 @@ class PypiCoordinatesMapper {
   }
 
   _shouldResolve(coordinates) {
-    return coordinates.name.includes('.') ||
-      coordinates.name.includes('_') ||
-      coordinates.name.includes('-')
+    if (typeof coordinates.name !== 'string' || coordinates.name.includes('/')) return false
+    return coordinates.name.includes('.') || coordinates.name.includes('_') || coordinates.name.includes('-')
   }
 
   async _resolve(coordinates) {
     const url = `${this.baseUrl}/pypi/${coordinates.name}/json`
     try {
       const answer = await this._handleRequest(url)
-      return answer?.info?.name && { name: answer.info.name }  
+      return answer?.info?.name && { name: answer.info.name }
     } catch (error) {
       if (error.statusCode === 404) return null
       throw error

--- a/test/lib/pypiCoordinatesMapper.js
+++ b/test/lib/pypiCoordinatesMapper.js
@@ -55,6 +55,30 @@ describe('PypiCoordinatesMapper', () => {
     const mapped = await coordinatesMapper.map(mockPypiCoordinates('backports'))
     expect(mapped).to.be.null
   })
+  
+  it('should return null when pypi name to be mapped is invalid', async () => {
+    sinon.stub(coordinatesMapper, '_handleRequest').rejects('Should not be called')
+    const spec = {
+      type: 'pypi',
+      provider: 'pypi',
+      name: 'back.ports/test',
+      revision: '1.0.0'
+    }
+    const coordinates = EntityCoordinates.fromObject(spec)
+    const mapped = await coordinatesMapper.map(coordinates)
+    expect(mapped).to.be.null
+  })
+
+  it('should return null given no name', async () => {
+    sinon.stub(coordinatesMapper, '_handleRequest').rejects('Should not be called')
+    const spec = {
+      type: 'pypi',
+      provider: 'pypi'
+    }
+    const coordinates = EntityCoordinates.fromObject(spec)
+    const mapped = await coordinatesMapper.map(coordinates)
+    expect(mapped).to.be.null
+  })
 })
 
 


### PR DESCRIPTION
In PyPI, '/' is invalid in a package name (see https://peps.python.org/pep-0508/#names).  Add a check to restrict the coordinates name prior to querying the PyPI API.