### PR TITLE
Add now-required env vars to docs and minimal.env.json

### DIFF
--- a/docs/rampup.md
+++ b/docs/rampup.md
@@ -45,6 +45,8 @@ Better to use a copy of the real dev environment, can change queue names to be y
    - "CURATION_GITHUB_REPO"
    - "CURATION_GITHUB_TOKEN"
    - "CRAWLER_GITHUB_TOKEN"
+   - "WEBHOOK_GITHUB_SECRET"
+   - "WEBHOOK_CRAWLER_SECRET"
    - "SCANCODE_HOME"
 5. Any other environmental variable values you might need can be found in the Clearly Defined subscription in Azure Portal under App Services -> clearlydefined-api-dev -> Settings -> Configuration
 6. Consider all the vars and what you need for testing what you will test.

--- a/minimal.env.json
+++ b/minimal.env.json
@@ -2,6 +2,10 @@
   "========== Service Harvest settings ==========": "",
   "FILE_STORE_LOCATION": "< path to cloned harvested-data repo, other local store location, or omit for default >",
 
+  "========== Service Webhooks settings ==========": "",
+  "WEBHOOK_CRAWLER_SECRET": "<crawler webhook secret here>",
+  "WEBHOOK_GITHUB_SECRET": "<GitHub webhook secret here>",
+
   "========== Service Curation settings ==========": "",
   "CURATION_GITHUB_REPO": "sample-curated-data",
   "CURATION_GITHUB_TOKEN": "<GitHub token here>"


### PR DESCRIPTION
Updates the `minimal.env.json` file and the `rampup.md` files to mention the now-required `WEBHOOK_GITHUB_SECRET` and `WEBHOOK_CRAWLER_SECRET` secrets. This is a follow-up to changes in #1058 