### PR TITLE
Add groups to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     schedule:
       interval: 'weekly'
     groups:
-      actions:
+      github-actions:
         patterns:
           - 'actions/*'
+          - 'github/*'
+      azure-actions:
+        patterns:
+          - 'azure/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,13 @@ updates:
     schedule:
       interval: 'weekly'
     groups:
+      azure-actions:
+        patterns:
+          - 'azure/*'
+      docker-actions:
+        patterns:
+          - 'docker/*'
       github-actions:
         patterns:
           - 'actions/*'
           - 'github/*'
-      azure-actions:
-        patterns:
-          - 'azure/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,15 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      actions:
+        patterns:
+          - 'actions/*'


### PR DESCRIPTION
This will hopefully reduce the number of Dependabot PRs by grouping some dependencies and thereby make continuous maintenance of dependency updates a little easier.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups