### PR TITLE
Fix originConda route

### DIFF
--- a/routes/originConda.js
+++ b/routes/originConda.js
@@ -34,7 +34,7 @@ async function fetchCondaRepoData(channel, subdir) {
   return repoData
 }
 
-router.get('/:channel/:subdir/:name/revisions', asyncMiddleware(getOriginCondaRevisions()))
+router.get('/:channel/:subdir/:name/revisions', asyncMiddleware(getOriginCondaRevisions))
 
 async function getOriginCondaRevisions(request, response) {
   let { channel, subdir, name } = request.params


### PR DESCRIPTION
Service App fails to start with the following exception:
service-1  | Exception:
service-1  | TypeError: Cannot read properties of undefined (reading 'params')
service-1  |     at getOriginCondaRevisions (/opt/service/routes/originConda.js:40:43)
service-1  |     at Object.<anonymous> (/opt/service/routes/originConda.js:37:65)
service-1  |     at Module._compile (node:internal/modules/cjs/loader:1364:14)
service-1  |     at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
service-1  |     at Module.load (node:internal/modules/cjs/loader:1203:32)
service-1  |     at Module._load (node:internal/modules/cjs/loader:1019:12)
service-1  |     at Module.require (node:internal/modules/cjs/loader:1231:19)
service-1  |     at Module.patchedRequire [as require] (/opt/service/node_modules/diagnostic-channel/dist/src/patchRequire.js:14:46)
service-1  |     at require (node:internal/modules/helpers:177:18)
service-1  |     at createApp (/opt/service/app.js:182:29)
service-1  | [I] Service initialized{"buildNumber":"0"}

Fix this by passing in the getOriginCondaRevisions function