### PR TITLE
fix failure of prod deploy due to invalid `is-release` value

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-deploy-prod:
-    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v1.0.0
+    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v1.1.0
     secrets: 
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD }}

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -7,20 +7,8 @@ on:
     types: [published]
 
 jobs:
-  determine-trigger:
-    name: Determine if this was triggered by a release or workflow_dispatch
-    runs-on: ubuntu-latest
-    outputs:
-      is-release: ${{ env.IS_RELEASE }}
-    steps:
-      - name: Check if this was triggered by a release
-        id: release
-        run: |
-          echo "IS_RELEASE"=${{ github.event_name == 'release' }} >> $GITHUB_ENV
-
   build-and-deploy-prod:
     uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v1.0.0
-    needs: determine-trigger
     secrets: 
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD }}
@@ -33,4 +21,3 @@ jobs:
       azure-app-base-name: clearlydefined-api
       azure-app-name-postfix: -prod
       secondary-azure-app-name-postfix: -prod-europe
-      is-release: ${{ needs.determine-trigger.outputs.is-release }}


### PR DESCRIPTION
The reusuable workflow was expecting a boolean value for `is-release`.  It was passing `'true'` instead of `true`.

Instead of fixing that type mismatch here, the is-release check was moved to the reusable `app-build-and-deploy` workflow.  See [operations release v1.1.0](https://github.com/clearlydefined/operations/releases/tag/v1.1.0) for more information.