### PR TITLE
update deploy scripts to v2.0.0 

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -7,8 +7,23 @@ on:
     branches: [master]
 
 jobs:
+  upload-package-lock-json:
+    name: Upload package-lock.json from this repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Upload package-lock.json
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-lock.json
+          path: package-lock.json
+
   build-and-deploy:
-    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v1.1.0
+    name: Build and Deploy
+    needs: upload-package-lock-json
+    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v2.0.0
     secrets: 
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_DEV }}


### PR DESCRIPTION
Fixes #1155 

----

## Description

The v2.0.0 deploy workflows moved many of the complex scripts to files that can be tested.  This identified several bugs that when fixed allowed the service-dev to deploy successfully.  The change also adds a new job to upload the package-lock.json file to the build artifacts.  This is needed for the build-and-deploy job to be able to get the version from that file.

### Related Work

* https://github.com/clearlydefined/operations/pull/86
* https://github.com/clearlydefined/website/pull/1058
