### PR TITLE
Fixed origins api for maven components throwing 500 error when invalid group id is provided

### DIFF
--- a/routes/originMaven.js
+++ b/routes/originMaven.js
@@ -50,12 +50,13 @@ function getSuggestions(answer, group) {
     return docs.map(item => {
       return { id: item.id }
     })
-  const suggestions = answer.spellcheck.suggestions[1]
+  const suggestions = answer.spellcheck?.suggestions?.[1]
   const result = suggestions ? suggestions.suggestion : []
   return group ? result.map(entry => `${group}:${entry}`) : result
 }
 
-function setup() {
+function setup(testFlag = false) {
+  if (testFlag) router._getSuggestions = getSuggestions
   return router
 }
 

--- a/test/fixtures/origins/maven/12345-1234.json
+++ b/test/fixtures/origins/maven/12345-1234.json
@@ -1,0 +1,22 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 2,
+    "params": {
+      "q": "g:\"12345\" AND a:\"1234\"",
+      "core": "gav",
+      "indent": "off",
+      "fl": "id,g,a,v,p,ec,timestamp,tags",
+      "start": "",
+      "sort": "score desc,timestamp desc,g asc,a asc,v desc",
+      "rows": "100",
+      "wt": "json",
+      "version": "2.2"
+    }
+  },
+  "response": {
+    "numFound": 0,
+    "start": 0,
+    "docs": []
+  }
+}

--- a/test/fixtures/origins/maven/12345.json
+++ b/test/fixtures/origins/maven/12345.json
@@ -1,0 +1,26 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 1,
+    "params": {
+      "q": "12345",
+      "core": "",
+      "defType": "dismax",
+      "qf": "text^20 g^5 a^10",
+      "indent": "off",
+      "spellcheck": "true",
+      "fl": "id,g,a,latestVersion,p,ec,repositoryId,text,timestamp,versionCount",
+      "start": "",
+      "spellcheck.count": "5",
+      "sort": "score desc,timestamp desc,g asc,a asc",
+      "rows": "100",
+      "wt": "json",
+      "version": "2.2"
+    }
+  },
+  "response": {
+    "numFound": 0,
+    "start": 0,
+    "docs": []
+  }
+}

--- a/test/fixtures/origins/maven/org.apache.httpcom.json
+++ b/test/fixtures/origins/maven/org.apache.httpcom.json
@@ -1,0 +1,46 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 2,
+    "params": {
+      "q": "org.apache.httpcomp",
+      "core": "",
+      "defType": "dismax",
+      "qf": "text^20 g^5 a^10",
+      "indent": "off",
+      "spellcheck": "true",
+      "fl": "id,g,a,latestVersion,p,ec,repositoryId,text,timestamp,versionCount",
+      "start": "",
+      "spellcheck.count": "5",
+      "sort": "score desc,timestamp desc,g asc,a asc",
+      "rows": "100",
+      "wt": "json",
+      "version": "2.2"
+    }
+  },
+  "response": {
+    "numFound": 0,
+    "start": 0,
+    "docs": []
+  },
+  "spellcheck": {
+    "suggestions": [
+      "httpcomp",
+      {
+        "numFound": 5,
+        "startOffset": 11,
+        "endOffset": 19,
+        "suggestion": [
+          "httpcore",
+          "httpconn",
+          "httpcodec",
+          "httpcommons",
+          "httprox"
+        ]
+      }
+    ]
+  },
+  "alternate": [
+    "fc:org.apache.httpcomp"
+  ]
+}

--- a/test/fixtures/origins/maven/org.apache.httpcomponents-response.json
+++ b/test/fixtures/origins/maven/org.apache.httpcomponents-response.json
@@ -1,0 +1,158 @@
+[
+  {
+    "id": "org.apache.httpcomponents:project"
+  },
+  {
+    "id": "org.apache.httpcomponents:hc-stylecheck"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpcore-niossl"
+  },
+  {
+    "id": "org.apache.httpcomponents:jakarta-httpcore"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpmime"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpcomponents-client"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpcore-osgi"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpcomponents-core"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpasyncclient-osgi"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpasyncclient"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpcomponents-asyncclient"
+  },
+  {
+    "id": "org.wso2.orbit.org.apache.httpcomponents:httpasyncclient"
+  },
+  {
+    "id": "org.wso2.orbit.org.apache.httpcomponents:httpmime"
+  },
+  {
+    "id": "org.wso2.orbit.org.apache.httpcomponents:httpclient"
+  },
+  {
+    "id": "org.apache.httpcomponents.core5:httpcore5-osgi"
+  },
+  {
+    "id": "org.kie.modules:org-apache-httpcomponents-main"
+  },
+  {
+    "id": "org.apache.httpcomponents:maven-site-skin"
+  },
+  {
+    "id": "org.apache.httpcomponents:maven-notice-plugin"
+  },
+  {
+    "id": "org.apache.httpcomponents:jakarta-httpcore-niossl"
+  },
+  {
+    "id": "org.apache.httpcomponents:jakarta-httpcore-nio"
+  },
+  {
+    "id": "org.apache.httpcomponents.client5:httpclient5-testing"
+  },
+  {
+    "id": "org.apache.httpcomponents.client5:httpclient5-cache"
+  },
+  {
+    "id": "org.apache.httpcomponents.client5:httpclient5-fluent"
+  },
+  {
+    "id": "org.apache.httpcomponents.client5:httpclient5"
+  },
+  {
+    "id": "org.apache.httpcomponents.client5:httpclient5-parent"
+  },
+  {
+    "id": "org.apache.httpcomponents.core5:httpcore5-testing"
+  },
+  {
+    "id": "org.apache.httpcomponents.core5:httpcore5-reactive"
+  },
+  {
+    "id": "org.apache.httpcomponents.core5:httpcore5-h2"
+  },
+  {
+    "id": "org.apache.httpcomponents.core5:httpcore5"
+  },
+  {
+    "id": "org.apache.httpcomponents.core5:httpcore5-parent"
+  },
+  {
+    "id": "org.bedework.deploy:bw-wfmodules-org-apache-httpcomponents-httpcore"
+  },
+  {
+    "id": "org.bedework.deploy:bw-wfmodules-org-apache-httpcomponents-httpclient"
+  },
+  {
+    "id": "org.apache.httpcomponents.client5:httpclient5-win"
+  },
+  {
+    "id": "com.basistech.org.apache.httpcomponents:httpclient-osgi"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpclient-osgi"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpclient-win"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpclient-cache"
+  },
+  {
+    "id": "org.apache.httpcomponents:fluent-hc"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpclient"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpcore-ab"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpcore-nio"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpcore"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpcomponents-parent"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpasyncclient-cache"
+  },
+  {
+    "id": "com.liferay:org.apache.httpcomponents.httpclient"
+  },
+  {
+    "id": "org.apache.httpcomponents.client5:httpclient5-osgi"
+  },
+  {
+    "id": "org.eclipse.ecf:org.apache.httpcomponents.httpcore"
+  },
+  {
+    "id": "org.eclipse.ecf:org.apache.httpcomponents.httpclient"
+  },
+  {
+    "id": "org.apache.httpcomponents.core5:httpcore5-ab"
+  },
+  {
+    "id": "org.apache.httpcomponents:httpclient-android"
+  },
+  {
+    "id": "org.apache.directory.studio:org.apache.httpcomponents.httpclient"
+  },
+  {
+    "id": "org.apache.directory.studio:org.apache.httpcomponents.httpcore"
+  }
+]

--- a/test/fixtures/origins/maven/org.apache.httpcomponents.json
+++ b/test/fixtures/origins/maven/org.apache.httpcomponents.json
@@ -1,0 +1,1210 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 4,
+    "params": {
+      "q": "org.apache.httpcomponents",
+      "core": "",
+      "defType": "dismax",
+      "qf": "text^20 g^5 a^10",
+      "indent": "off",
+      "spellcheck": "true",
+      "fl": "id,g,a,latestVersion,p,ec,repositoryId,text,timestamp,versionCount",
+      "start": "",
+      "spellcheck.count": "5",
+      "sort": "score desc,timestamp desc,g asc,a asc",
+      "rows": "100",
+      "wt": "json",
+      "version": "2.2"
+    }
+  },
+  "response": {
+    "numFound": 52,
+    "start": 0,
+    "docs": [
+      {
+        "id": "org.apache.httpcomponents:project",
+        "g": "org.apache.httpcomponents",
+        "a": "project",
+        "latestVersion": "8",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1480239346000,
+        "versionCount": 7,
+        "text": [
+          "org.apache.httpcomponents",
+          "project",
+          ".pom"
+        ],
+        "ec": [
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:hc-stylecheck",
+        "g": "org.apache.httpcomponents",
+        "a": "hc-stylecheck",
+        "latestVersion": "2",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1508670213000,
+        "versionCount": 2,
+        "text": [
+          "org.apache.httpcomponents",
+          "hc-stylecheck",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpcore-niossl",
+        "g": "org.apache.httpcomponents",
+        "a": "httpcore-niossl",
+        "latestVersion": "4.0-alpha6",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1191841121000,
+        "versionCount": 2,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpcore-niossl",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:jakarta-httpcore",
+        "g": "org.apache.httpcomponents",
+        "a": "jakarta-httpcore",
+        "latestVersion": "4.0-alpha4",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1175013456000,
+        "versionCount": 3,
+        "text": [
+          "org.apache.httpcomponents",
+          "jakarta-httpcore",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpmime",
+        "g": "org.apache.httpcomponents",
+        "a": "httpmime",
+        "latestVersion": "4.5.14",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1669833664000,
+        "versionCount": 53,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpmime",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpcomponents-client",
+        "g": "org.apache.httpcomponents",
+        "a": "httpcomponents-client",
+        "latestVersion": "4.5.14",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1669833619000,
+        "versionCount": 55,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpcomponents-client",
+          ".pom",
+          "-source-release.zip"
+        ],
+        "ec": [
+          ".pom",
+          "-source-release.zip"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpcore-osgi",
+        "g": "org.apache.httpcomponents",
+        "a": "httpcore-osgi",
+        "latestVersion": "4.4.16",
+        "repositoryId": "central",
+        "p": "bundle",
+        "timestamp": 1669455929000,
+        "versionCount": 46,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpcore-osgi",
+          "-sources.jar",
+          ".pom",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpcomponents-core",
+        "g": "org.apache.httpcomponents",
+        "a": "httpcomponents-core",
+        "latestVersion": "4.4.16",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1669455884000,
+        "versionCount": 50,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpcomponents-core",
+          ".pom",
+          "-source-release.zip"
+        ],
+        "ec": [
+          ".pom",
+          "-source-release.zip"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpasyncclient-osgi",
+        "g": "org.apache.httpcomponents",
+        "a": "httpasyncclient-osgi",
+        "latestVersion": "4.1.5",
+        "repositoryId": "central",
+        "p": "bundle",
+        "timestamp": 1638998545000,
+        "versionCount": 14,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpasyncclient-osgi",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpasyncclient",
+        "g": "org.apache.httpcomponents",
+        "a": "httpasyncclient",
+        "latestVersion": "4.1.5",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1638998516000,
+        "versionCount": 17,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpasyncclient",
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpcomponents-asyncclient",
+        "g": "org.apache.httpcomponents",
+        "a": "httpcomponents-asyncclient",
+        "latestVersion": "4.1.5",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1638998494000,
+        "versionCount": 17,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpcomponents-asyncclient",
+          ".pom",
+          "-source-release.zip"
+        ],
+        "ec": [
+          ".pom",
+          "-source-release.zip"
+        ]
+      },
+      {
+        "id": "org.wso2.orbit.org.apache.httpcomponents:httpasyncclient",
+        "g": "org.wso2.orbit.org.apache.httpcomponents",
+        "a": "httpasyncclient",
+        "latestVersion": "4.1.3.wso2v1",
+        "repositoryId": "central",
+        "p": "bundle",
+        "timestamp": 1638263058000,
+        "versionCount": 2,
+        "text": [
+          "org.wso2.orbit.org.apache.httpcomponents",
+          "httpasyncclient",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.wso2.orbit.org.apache.httpcomponents:httpmime",
+        "g": "org.wso2.orbit.org.apache.httpcomponents",
+        "a": "httpmime",
+        "latestVersion": "4.5.13.wso2v1",
+        "repositoryId": "central",
+        "p": "bundle",
+        "timestamp": 1629455520000,
+        "versionCount": 1,
+        "text": [
+          "org.wso2.orbit.org.apache.httpcomponents",
+          "httpmime",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.wso2.orbit.org.apache.httpcomponents:httpclient",
+        "g": "org.wso2.orbit.org.apache.httpcomponents",
+        "a": "httpclient",
+        "latestVersion": "4.5.13.wso2v1",
+        "repositoryId": "central",
+        "p": "bundle",
+        "timestamp": 1608659834000,
+        "versionCount": 5,
+        "text": [
+          "org.wso2.orbit.org.apache.httpcomponents",
+          "httpclient",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.core5:httpcore5-osgi",
+        "g": "org.apache.httpcomponents.core5",
+        "a": "httpcore5-osgi",
+        "latestVersion": "5.0-beta5",
+        "repositoryId": "central",
+        "p": "bundle",
+        "timestamp": 1539881929000,
+        "versionCount": 9,
+        "text": [
+          "org.apache.httpcomponents.core5",
+          "httpcore5-osgi",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.kie.modules:org-apache-httpcomponents-main",
+        "g": "org.kie.modules",
+        "a": "org-apache-httpcomponents-main",
+        "latestVersion": "6.5.0.Final",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1476807195000,
+        "versionCount": 27,
+        "text": [
+          "org.kie.modules",
+          "org-apache-httpcomponents-main",
+          "-tests.jar",
+          ".pom"
+        ],
+        "ec": [
+          "-tests.jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:maven-site-skin",
+        "g": "org.apache.httpcomponents",
+        "a": "maven-site-skin",
+        "latestVersion": "1.1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1297788471000,
+        "versionCount": 2,
+        "text": [
+          "org.apache.httpcomponents",
+          "maven-site-skin",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:maven-notice-plugin",
+        "g": "org.apache.httpcomponents",
+        "a": "maven-notice-plugin",
+        "latestVersion": "0.0.2",
+        "repositoryId": "central",
+        "p": "maven-plugin",
+        "timestamp": 1289481508000,
+        "versionCount": 2,
+        "text": [
+          "org.apache.httpcomponents",
+          "maven-notice-plugin",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:jakarta-httpcore-niossl",
+        "g": "org.apache.httpcomponents",
+        "a": "jakarta-httpcore-niossl",
+        "latestVersion": "4.0-alpha4",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1175013517000,
+        "versionCount": 1,
+        "text": [
+          "org.apache.httpcomponents",
+          "jakarta-httpcore-niossl",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:jakarta-httpcore-nio",
+        "g": "org.apache.httpcomponents",
+        "a": "jakarta-httpcore-nio",
+        "latestVersion": "4.0-alpha4",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1175013475000,
+        "versionCount": 2,
+        "text": [
+          "org.apache.httpcomponents",
+          "jakarta-httpcore-nio",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.client5:httpclient5-testing",
+        "g": "org.apache.httpcomponents.client5",
+        "a": "httpclient5-testing",
+        "latestVersion": "5.4-beta1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1719133384000,
+        "versionCount": 32,
+        "text": [
+          "org.apache.httpcomponents.client5",
+          "httpclient5-testing",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.client5:httpclient5-cache",
+        "g": "org.apache.httpcomponents.client5",
+        "a": "httpclient5-cache",
+        "latestVersion": "5.4-beta1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1719133339000,
+        "versionCount": 33,
+        "text": [
+          "org.apache.httpcomponents.client5",
+          "httpclient5-cache",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.client5:httpclient5-fluent",
+        "g": "org.apache.httpcomponents.client5",
+        "a": "httpclient5-fluent",
+        "latestVersion": "5.4-beta1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1719133326000,
+        "versionCount": 33,
+        "text": [
+          "org.apache.httpcomponents.client5",
+          "httpclient5-fluent",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.client5:httpclient5",
+        "g": "org.apache.httpcomponents.client5",
+        "a": "httpclient5",
+        "latestVersion": "5.4-beta1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1719133316000,
+        "versionCount": 33,
+        "text": [
+          "org.apache.httpcomponents.client5",
+          "httpclient5",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.client5:httpclient5-parent",
+        "g": "org.apache.httpcomponents.client5",
+        "a": "httpclient5-parent",
+        "latestVersion": "5.4-beta1",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1719133292000,
+        "versionCount": 33,
+        "text": [
+          "org.apache.httpcomponents.client5",
+          "httpclient5-parent",
+          ".pom",
+          "-site.xml",
+          "-source-release.zip.sha512",
+          "-source-release.zip"
+        ],
+        "ec": [
+          ".pom",
+          "-site.xml",
+          "-source-release.zip.sha512",
+          "-source-release.zip"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.core5:httpcore5-testing",
+        "g": "org.apache.httpcomponents.core5",
+        "a": "httpcore5-testing",
+        "latestVersion": "5.3-beta1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1718641065000,
+        "versionCount": 41,
+        "text": [
+          "org.apache.httpcomponents.core5",
+          "httpcore5-testing",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.core5:httpcore5-reactive",
+        "g": "org.apache.httpcomponents.core5",
+        "a": "httpcore5-reactive",
+        "latestVersion": "5.3-beta1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1718640963000,
+        "versionCount": 35,
+        "text": [
+          "org.apache.httpcomponents.core5",
+          "httpcore5-reactive",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.core5:httpcore5-h2",
+        "g": "org.apache.httpcomponents.core5",
+        "a": "httpcore5-h2",
+        "latestVersion": "5.3-beta1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1718640953000,
+        "versionCount": 41,
+        "text": [
+          "org.apache.httpcomponents.core5",
+          "httpcore5-h2",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.core5:httpcore5",
+        "g": "org.apache.httpcomponents.core5",
+        "a": "httpcore5",
+        "latestVersion": "5.3-beta1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1718640934000,
+        "versionCount": 42,
+        "text": [
+          "org.apache.httpcomponents.core5",
+          "httpcore5",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.core5:httpcore5-parent",
+        "g": "org.apache.httpcomponents.core5",
+        "a": "httpcore5-parent",
+        "latestVersion": "5.3-beta1",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1718640902000,
+        "versionCount": 42,
+        "text": [
+          "org.apache.httpcomponents.core5",
+          "httpcore5-parent",
+          ".pom",
+          "-site.xml",
+          "-source-release.zip.sha512",
+          "-source-release.zip"
+        ],
+        "ec": [
+          ".pom",
+          "-site.xml",
+          "-source-release.zip.sha512",
+          "-source-release.zip"
+        ]
+      },
+      {
+        "id": "org.bedework.deploy:bw-wfmodules-org-apache-httpcomponents-httpcore",
+        "g": "org.bedework.deploy",
+        "a": "bw-wfmodules-org-apache-httpcomponents-httpcore",
+        "latestVersion": "1.0.5",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1712197600811,
+        "versionCount": 6,
+        "text": [
+          "org.bedework.deploy",
+          "bw-wfmodules-org-apache-httpcomponents-httpcore",
+          ".zip",
+          ".pom"
+        ],
+        "ec": [
+          ".zip",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.bedework.deploy:bw-wfmodules-org-apache-httpcomponents-httpclient",
+        "g": "org.bedework.deploy",
+        "a": "bw-wfmodules-org-apache-httpcomponents-httpclient",
+        "latestVersion": "1.0.5",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1712197446656,
+        "versionCount": 6,
+        "text": [
+          "org.bedework.deploy",
+          "bw-wfmodules-org-apache-httpcomponents-httpclient",
+          ".zip",
+          ".pom"
+        ],
+        "ec": [
+          ".zip",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.client5:httpclient5-win",
+        "g": "org.apache.httpcomponents.client5",
+        "a": "httpclient5-win",
+        "latestVersion": "5.2.3",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1701182166000,
+        "versionCount": 27,
+        "text": [
+          "org.apache.httpcomponents.client5",
+          "httpclient5-win",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "com.basistech.org.apache.httpcomponents:httpclient-osgi",
+        "g": "com.basistech.org.apache.httpcomponents",
+        "a": "httpclient-osgi",
+        "latestVersion": "4.5.14-1",
+        "repositoryId": "central",
+        "p": "bundle",
+        "timestamp": 1683742407000,
+        "versionCount": 4,
+        "text": [
+          "com.basistech.org.apache.httpcomponents",
+          "httpclient-osgi",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpclient-osgi",
+        "g": "org.apache.httpcomponents",
+        "a": "httpclient-osgi",
+        "latestVersion": "4.5.14",
+        "repositoryId": "central",
+        "p": "bundle",
+        "timestamp": 1669833704000,
+        "versionCount": 50,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpclient-osgi",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpclient-win",
+        "g": "org.apache.httpcomponents",
+        "a": "httpclient-win",
+        "latestVersion": "4.5.14",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1669833694000,
+        "versionCount": 19,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpclient-win",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpclient-cache",
+        "g": "org.apache.httpcomponents",
+        "a": "httpclient-cache",
+        "latestVersion": "4.5.14",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1669833687000,
+        "versionCount": 44,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpclient-cache",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:fluent-hc",
+        "g": "org.apache.httpcomponents",
+        "a": "fluent-hc",
+        "latestVersion": "4.5.14",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1669833671000,
+        "versionCount": 38,
+        "text": [
+          "org.apache.httpcomponents",
+          "fluent-hc",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpclient",
+        "g": "org.apache.httpcomponents",
+        "a": "httpclient",
+        "latestVersion": "4.5.14",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1669833654000,
+        "versionCount": 55,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpclient",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpcore-ab",
+        "g": "org.apache.httpcomponents",
+        "a": "httpcore-ab",
+        "latestVersion": "4.4.16",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1669455941000,
+        "versionCount": 32,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpcore-ab",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpcore-nio",
+        "g": "org.apache.httpcomponents",
+        "a": "httpcore-nio",
+        "latestVersion": "4.4.16",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1669455922000,
+        "versionCount": 50,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpcore-nio",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpcore",
+        "g": "org.apache.httpcomponents",
+        "a": "httpcore",
+        "latestVersion": "4.4.16",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1669455901000,
+        "versionCount": 52,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpcore",
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".pom",
+          "-javadoc.jar",
+          "-tests.jar",
+          ".jar"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpcomponents-parent",
+        "g": "org.apache.httpcomponents",
+        "a": "httpcomponents-parent",
+        "latestVersion": "13",
+        "repositoryId": "central",
+        "p": "pom",
+        "timestamp": 1667044575000,
+        "versionCount": 5,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpcomponents-parent",
+          ".pom",
+          "-source-release.zip.sha512",
+          "-source-release.zip"
+        ],
+        "ec": [
+          ".pom",
+          "-source-release.zip.sha512",
+          "-source-release.zip"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpasyncclient-cache",
+        "g": "org.apache.httpcomponents",
+        "a": "httpasyncclient-cache",
+        "latestVersion": "4.1.5",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1638998533000,
+        "versionCount": 13,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpasyncclient-cache",
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "com.liferay:org.apache.httpcomponents.httpclient",
+        "g": "com.liferay",
+        "a": "org.apache.httpcomponents.httpclient",
+        "latestVersion": "4.1.3.LIFERAY-PATCHED-1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1550691308000,
+        "versionCount": 1,
+        "text": [
+          "com.liferay",
+          "org.apache.httpcomponents.httpclient",
+          "-sources-commercial.jar",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources-commercial.jar",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.client5:httpclient5-osgi",
+        "g": "org.apache.httpcomponents.client5",
+        "a": "httpclient5-osgi",
+        "latestVersion": "5.0-beta2",
+        "repositoryId": "central",
+        "p": "bundle",
+        "timestamp": 1540302516000,
+        "versionCount": 5,
+        "text": [
+          "org.apache.httpcomponents.client5",
+          "httpclient5-osgi",
+          "-javadoc.jar",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-javadoc.jar",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.eclipse.ecf:org.apache.httpcomponents.httpcore",
+        "g": "org.eclipse.ecf",
+        "a": "org.apache.httpcomponents.httpcore",
+        "latestVersion": "4.4.6.v20170210-0925",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1494159782000,
+        "versionCount": 1,
+        "text": [
+          "org.eclipse.ecf",
+          "org.apache.httpcomponents.httpcore",
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.eclipse.ecf:org.apache.httpcomponents.httpclient",
+        "g": "org.eclipse.ecf",
+        "a": "org.apache.httpcomponents.httpclient",
+        "latestVersion": "4.5.2.v20170210-0925",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1494159774000,
+        "versionCount": 1,
+        "text": [
+          "org.eclipse.ecf",
+          "org.apache.httpcomponents.httpclient",
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents.core5:httpcore5-ab",
+        "g": "org.apache.httpcomponents.core5",
+        "a": "httpcore5-ab",
+        "latestVersion": "5.0-alpha3",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1493321325000,
+        "versionCount": 3,
+        "text": [
+          "org.apache.httpcomponents.core5",
+          "httpcore5-ab",
+          "-javadoc.jar",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-javadoc.jar",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.httpcomponents:httpclient-android",
+        "g": "org.apache.httpcomponents",
+        "a": "httpclient-android",
+        "latestVersion": "4.3.5.1",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1421007446000,
+        "versionCount": 3,
+        "text": [
+          "org.apache.httpcomponents",
+          "httpclient-android",
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          "-javadoc.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.directory.studio:org.apache.httpcomponents.httpclient",
+        "g": "org.apache.directory.studio",
+        "a": "org.apache.httpcomponents.httpclient",
+        "latestVersion": "4.1.2",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1330103792000,
+        "versionCount": 2,
+        "text": [
+          "org.apache.directory.studio",
+          "org.apache.httpcomponents.httpclient",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ]
+      },
+      {
+        "id": "org.apache.directory.studio:org.apache.httpcomponents.httpcore",
+        "g": "org.apache.directory.studio",
+        "a": "org.apache.httpcomponents.httpcore",
+        "latestVersion": "4.1.2",
+        "repositoryId": "central",
+        "p": "jar",
+        "timestamp": 1330103778000,
+        "versionCount": 2,
+        "text": [
+          "org.apache.directory.studio",
+          "org.apache.httpcomponents.httpcore",
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ],
+        "ec": [
+          "-sources.jar",
+          ".jar",
+          ".pom"
+        ]
+      }
+    ]
+  },
+  "spellcheck": {
+    "suggestions": []
+  }
+}

--- a/test/routes/origins.js
+++ b/test/routes/origins.js
@@ -20,30 +20,31 @@ describe('Maven Origin routes', () => {
     expect(getResponse(groupId)).to.be.deep.equal(['httpcore', 'httpconn', 'httpcodec', 'httpcommons', 'httprox'])
   })
 
-  it('should not return suggestions when complete group id is provided as input', async () => {
+  it('should return list of artefacts when complete group id is provided as input', async () => {
     const groupId = 'org.apache.httpcomponents'
     expect(getResponse(groupId)).to.be.deep.equal(loadFixture(`${groupId}-response`))
   })
 
-  it('should return blank response when suggestions are not present', async () => {
+  it('should return blank response when group id is invalid and suggestions are not present', async () => {
     const groupId = '12345'
     expect(getResponse(groupId)).to.be.deep.equal([])
   })
 
-  it('should return blank response when group id and artefact id are provided as input and suggestions are not present', async () => {
+  it('should return blank response when group id and artefact id are invalid and suggestions are not present', async () => {
     const groupId = '12345'
     const artefactId = '1234'
     expect(getResponse(`${groupId}-${artefactId}`)).to.be.deep.equal([])
   })
 
-  function loadFixture(coordinate){
-    const body = fs.readFileSync(`test/fixtures/origins/maven/${coordinate}.json`)
-    return JSON.parse(body)
-  }
   function getResponse(coordinate) {
     return router._getSuggestions(loadFixture(coordinate))
   }
 })
+
+function loadFixture(coordinate) {
+  const body = fs.readFileSync(`test/fixtures/origins/maven/${coordinate}.json`)
+  return JSON.parse(body)
+}
 
 describe('Conda origin routes', () => {
   it('accepts a good revisions GET request', async () => {

--- a/test/routes/origins.js
+++ b/test/routes/origins.js
@@ -11,38 +11,50 @@ const fs = require('fs')
 
 describe('Maven Origin routes', () => {
   let router
+  const fixturePath = 'test/fixtures/origins/maven'
+
   before(() => {
     router = originMavenRoutes(true)
   })
 
   it('should return suggestions when incomplete group id is provided as input', async () => {
-    const groupId = 'org.apache.httpcom'
-    expect(getResponse(groupId)).to.be.deep.equal(['httpcore', 'httpconn', 'httpcodec', 'httpcommons', 'httprox'])
+    const partialGroupId = 'org.apache.httpcom'
+    expect(getResponse(partialGroupId)).to.be.deep.equal([
+      'httpcore',
+      'httpconn',
+      'httpcodec',
+      'httpcommons',
+      'httprox'
+    ])
   })
 
   it('should return list of artefacts when complete group id is provided as input', async () => {
-    const groupId = 'org.apache.httpcomponents'
-    expect(getResponse(groupId)).to.be.deep.equal(loadFixture(`${groupId}-response`))
+    const completeGroupId = 'org.apache.httpcomponents'
+    expect(getResponse(completeGroupId)).to.be.deep.equal(
+      loadFixture(`${fixturePath}/${completeGroupId}-response.json`)
+    )
   })
 
   it('should return blank response when group id is invalid and suggestions are not present', async () => {
-    const groupId = '12345'
-    expect(getResponse(groupId)).to.be.deep.equal([])
+    const invalidGroupId = '12345'
+    expect(getResponse(invalidGroupId)).to.be.deep.equal([])
   })
 
   it('should return blank response when group id and artefact id are invalid and suggestions are not present', async () => {
-    const groupId = '12345'
-    const artefactId = '1234'
-    expect(getResponse(`${groupId}-${artefactId}`)).to.be.deep.equal([])
+    const invalidGroupId = '12345'
+    const invalidArtifactId = '1234'
+    expect(
+      router._getSuggestions(loadFixture(`${fixturePath}/${invalidGroupId}-${invalidArtifactId}.json`), invalidGroupId)
+    ).to.be.deep.equal([])
   })
 
-  function getResponse(coordinate) {
-    return router._getSuggestions(loadFixture(coordinate))
+  function getResponse(filename) {
+    return router._getSuggestions(loadFixture(`${fixturePath}/${filename}.json`))
   }
 })
 
-function loadFixture(coordinate) {
-  const body = fs.readFileSync(`test/fixtures/origins/maven/${coordinate}.json`)
+function loadFixture(path) {
+  const body = fs.readFileSync(path)
   return JSON.parse(body)
 }
 

--- a/test/routes/origins.js
+++ b/test/routes/origins.js
@@ -22,7 +22,7 @@ describe('Maven Origin routes', () => {
 
   it('should not return suggestions when complete group id is provided as input', async () => {
     const groupId = 'org.apache.httpcomponents'
-    expect(getResponse(groupId)).to.be.deep.equal(getResponse(`${groupId}-response`))
+    expect(getResponse(groupId)).to.be.deep.equal(loadFixture(`${groupId}-response`))
   })
 
   it('should return blank response when suggestions are not present', async () => {
@@ -36,10 +36,12 @@ describe('Maven Origin routes', () => {
     expect(getResponse(`${groupId}-${artefactId}`)).to.be.deep.equal([])
   })
 
-  function getResponse(coordinate) {
+  function loadFixture(coordinate){
     const body = fs.readFileSync(`test/fixtures/origins/maven/${coordinate}.json`)
-    if (coordinate.endsWith('-response')) return JSON.parse(body)
-    return router._getSuggestions(JSON.parse(body))
+    return JSON.parse(body)
+  }
+  function getResponse(coordinate) {
+    return router._getSuggestions(loadFixture(coordinate))
   }
 })
 

--- a/test/routes/origins.js
+++ b/test/routes/origins.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // Copyright (c) The Linux Foundation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
@@ -5,6 +6,42 @@ const { expect } = require('chai')
 const httpMocks = require('node-mocks-http')
 const sinon = require('sinon')
 const originCondaRoutes = require('../../routes/originConda')
+const originMavenRoutes = require('../../routes/originMaven')
+const fs = require('fs')
+
+describe('Maven Origin routes', () => {
+  let router
+  before(() => {
+    router = originMavenRoutes(true)
+  })
+
+  it('should return suggestions when incomplete group id is provided as input', async () => {
+    const groupId = 'org.apache.httpcom'
+    expect(getResponse(groupId)).to.be.deep.equal(['httpcore', 'httpconn', 'httpcodec', 'httpcommons', 'httprox'])
+  })
+
+  it('should not return suggestions when complete group id is provided as input', async () => {
+    const groupId = 'org.apache.httpcomponents'
+    expect(getResponse(groupId)).to.be.deep.equal(getResponse(`${groupId}-response`))
+  })
+
+  it('should return blank response when suggestions are not present', async () => {
+    const groupId = '12345'
+    expect(getResponse(groupId)).to.be.deep.equal([])
+  })
+
+  it('should return blank response when group id and artefact id are provided as input and suggestions are not present', async () => {
+    const groupId = '12345'
+    const artefactId = '1234'
+    expect(getResponse(`${groupId}-${artefactId}`)).to.be.deep.equal([])
+  })
+
+  function getResponse(coordinate) {
+    const body = fs.readFileSync(`test/fixtures/origins/maven/${coordinate}.json`)
+    if (coordinate.endsWith('-response')) return JSON.parse(body)
+    return router._getSuggestions(JSON.parse(body))
+  }
+})
 
 describe('Conda origin routes', () => {
   it('accepts a good revisions GET request', async () => {

--- a/test/routes/origins.js
+++ b/test/routes/origins.js
@@ -43,9 +43,8 @@ describe('Maven Origin routes', () => {
   it('should return blank response when group id and artefact id are invalid and suggestions are not present', async () => {
     const invalidGroupId = '12345'
     const invalidArtifactId = '1234'
-    expect(
-      router._getSuggestions(loadFixture(`${fixturePath}/${invalidGroupId}-${invalidArtifactId}.json`), invalidGroupId)
-    ).to.be.deep.equal([])
+    const responseFilePath = loadFixture(`${fixturePath}/${invalidGroupId}-${invalidArtifactId}.json`)
+    expect(router._getSuggestions(responseFilePath, invalidGroupId)).to.be.deep.equal([])
   })
 
   function getResponse(filename) {


### PR DESCRIPTION
Below are the tasks completed as a part of this fix -

- [x]  Code updated to check if the value exist and test case added to verify the changes.
- [x]  New Test cases added for happy paths and all the error scenarios.
- [x]  Fixtures added for the input and one of the response.
- [x] getResponse function reads the fixture having response from [maven repo](https://search.maven.org/solrsearch/select?q=123&rows=100&wt=json) for each query (group id or artefact id) converts it to json object and then it is passed to getSuggestions function from originMaven.js file.

List of testcases added in the origins.js file related to the changes -

- Return suggestions when incomplete group id is provided as input
- Return list of artefacts when complete group id is provided as input
- Return blank response when group id is invalid and suggestions are not present
- Return blank response when group id and artefact id are invalid and suggestions are not present

This fix is related to [Issue 1167](https://github.com/clearlydefined/service/issues/1167)
