### PR TITLE
add APP_VERSION & BUILD_SHA to Dockerfiles

### DIFF
--- a/DevDockerfile
+++ b/DevDockerfile
@@ -15,8 +15,14 @@ ENV APPDIR=/opt/service
 # COPY init_container.sh /bin/
 # RUN chmod 755 /bin/init_container.sh
 # CMD ["/bin/init_container.sh"]
+
+# Set environment variables from build arguments
 ARG BUILD_NUMBER=0
-ENV BUILD_NUMBER=$BUILD_NUMBER
+ENV BUILD_NUMBER=$APP_VERSION
+ARG APP_VERSION="UNKNOWN"
+ENV APP_VERSION=$APP_VERSION
+ARG BUILD_SHA="UNKNOWN"
+ENV BUILD_SHA=$BUILD_SHA
 
 COPY patches /tmp/patches
 COPY .npmrc package*.json /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,14 @@ ENV APPDIR=/opt/service
 # COPY init_container.sh /bin/
 # RUN chmod 755 /bin/init_container.sh
 # CMD ["/bin/init_container.sh"]
+
+# Set environment variables from build arguments
 ARG BUILD_NUMBER=0
-ENV BUILD_NUMBER=$BUILD_NUMBER
+ENV BUILD_NUMBER=$APP_VERSION
+ARG APP_VERSION="UNKNOWN"
+ENV APP_VERSION=$APP_VERSION
+ARG BUILD_SHA="UNKNOWN"
+ENV BUILD_SHA=$BUILD_SHA
 
 COPY patches /tmp/patches
 COPY .npmrc package*.json /tmp/

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,7 +4,7 @@ const express = require('express')
 const router = express.Router()
 
 router.get('/', function (req, res) {
-  const msg = `{ "status": "OK", "version": "${version}", "sha": "${sha}"`
+  const msg = `{ "status": "OK", "version": "${version}", "sha": "${sha}" }`
   res.status(200).send(msg)
 })
 


### PR DESCRIPTION
### Description

This sets up the docker image to hold the version and sha that are used to verify which version is actually running.  The previous approach used Azure configs that get set just before the deploy.  If the deploy were to fail, those configs stay the same leading to a false report on the version and sha.

This change requires the change in the operations shared workflows before it will start drawing from the environment variables set in the docker image.  It is OK to merge this as the same named Azure configs will still be available.

### Related Work

* https://github.com/clearlydefined/crawler/pull/574

### Remaining Work

* need to add status check with version and sha to website
* consider using a different endpoint (e.g. status-check) because the website will not be able to use `/` because that goes to a page that already has content (i.e. homepage)