### PR TITLE
Ljones140/reduce logging

### DIFF
--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -289,15 +289,24 @@ class DefinitionService {
     const raw = await this.harvestStore.getAll(coordinates)
     this.logger.debug('4:compute:blob:end', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
     coordinates = this._getCasedCoordinates(raw, coordinates)
-    this.logger.debug('5:compute:summarize:start', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
+    this.logger.debug('5:compute:summarize:start', {
+      ts: new Date().toISOString(),
+      coordinates: coordinates.toString()
+    })
     const summaries = await this.summaryService.summarizeAll(coordinates, raw)
-    this.logger.debug('6:compute:aggregate:start', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
+    this.logger.debug('6:compute:aggregate:start', {
+      ts: new Date().toISOString(),
+      coordinates: coordinates.toString()
+    })
     const aggregatedDefinition = (await this.aggregationService.process(summaries, coordinates)) || {}
     this.logger.debug('6:compute:aggregate:end', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
     aggregatedDefinition.coordinates = coordinates
     this._ensureToolScores(coordinates, aggregatedDefinition)
     const definition = await this.curationService.apply(coordinates, curationSpec, aggregatedDefinition)
-    this.logger.debug('9:compute:calculate:start', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
+    this.logger.debug('9:compute:calculate:start', {
+      ts: new Date().toISOString(),
+      coordinates: coordinates.toString()
+    })
     this._finalizeDefinition(coordinates, definition)
     this._ensureCuratedScores(definition)
     this._ensureFinalScores(definition)

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -678,12 +678,12 @@ ${this._formatDefinitions(patch.patches)}`
    */
   async _getCurations(coordinates, pr = null) {
     const path = this._getCurationPath(coordinates)
-    this.logger.info('7:compute:curation_source:start', {
+    this.logger.debug('7:compute:curation_source:start', {
       ts: new Date().toISOString(),
       coordinates: coordinates.toString()
     })
     const tree = await this._getCurationTree(pr)
-    this.logger.info('7:compute:curation_source:end', {
+    this.logger.debug('7:compute:curation_source:end', {
       ts: new Date().toISOString(),
       coordinates: coordinates.toString()
     })
@@ -692,12 +692,12 @@ ${this._formatDefinitions(patch.patches)}`
     )
     const blob = get(tree, treePath)
     if (!blob) return null
-    this.logger.info('8:compute:curation_blob:start', {
+    this.logger.debug('8:compute:curation_blob:start', {
       ts: new Date().toISOString(),
       coordinates: coordinates.toString()
     })
     const data = await this.smartGit.blob(blob.object)
-    this.logger.info('8:compute:curation_blob:end', {
+    this.logger.debug('8:compute:curation_blob:end', {
       ts: new Date().toISOString(),
       coordinates: coordinates.toString()
     })

--- a/providers/logging/winstonConfig.js
+++ b/providers/logging/winstonConfig.js
@@ -11,7 +11,7 @@ function factory(options) {
   const realOptions = options || {
     key: config.get('APPINSIGHTS_INSTRUMENTATIONKEY'),
     echo: false,
-    level: 'info'
+    level: config.get('APPINSIGHTS_EXPORT_LOG_LEVEL') || 'info'
   }
   mockInsights.setup(realOptions.key || 'mock', realOptions.echo)
   const result = new winston.Logger()

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -58,11 +58,11 @@ async function getDefinition(request, response) {
   const pr = request.params.pr
   const force = request.query.force
   const expand = request.query.expand === '-files' ? '-files' : null // only support '-files' for now
-  log.info('get_definition:start', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
+  log.debug('get_definition:start', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
   const result = await definitionService.get(coordinates, pr, force, expand)
-  log.info('get_definition:prepared', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
+  log.debug('get_definition:prepared', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
   response.status(200).send(result)
-  log.info('get_definition:sent', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
+  log.debug('get_definition:sent', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
 }
 
 // Get a list of autocomplete suggestions of components for which we have any kind of definition.
@@ -119,7 +119,7 @@ async function listDefinitions(request, response) {
   const expand = request.query.expand === '-files' ? '-files' : null // only support '-files' for now
   try {
     // Tempoarily adding this verbose logging to find perf issues
-    log.info('POSTing to /definitions', {
+    log.debug('POSTing to /definitions', {
       ts: new Date().toISOString(),
       requestParams: request.params,
       normalizedCoordinates,

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -347,7 +347,7 @@ function setup(definition, coordinateSpec, curation) {
   const summary = { summarizeAll: () => Promise.resolve(null) }
   const aggregator = { process: () => Promise.resolve(definition) }
   const service = DefinitionService(harvestStore, harvestService, summary, aggregator, curator, store, search, cache)
-  service.logger = { info: sinon.stub() }
+  service.logger = { info: sinon.stub(), debug: sinon.stub() }
   service._harvest = sinon.stub()
   const coordinates = EntityCoordinates.fromString(coordinateSpec || 'npm/npmjs/-/test/1.0')
   return { coordinates, service }


### PR DESCRIPTION
# What

- Reduces high amount of logging to App Insights by reducing our busiest logs to debug level.
- Log level will default to `info` can be changed using new env var `APPINSIGHTS_EXPORT_LOG_LEVEL`
- Can be changed via App Service config without a code change

Logging library docs https://github.com/bragma/winston-azure-application-insights/blob/cfffb48e8761072a6d8aa0e9a122b46f42d26d49/README.md

# Why

App Insights is our biggest cost

Kusto query for working out busiest logs
```
traces
| summarize messageCount=count() by bin(timestamp, 1h), message
| order by messageCount
```

# Testing

Tested in dev setting `APPINSIGHTS_EXPORT_LOG_LEVEL` to `debug` and logs appeared
Set to `info` and the `debug` level logs did not appear