### PR TITLE
Update spdx to v0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1622,12 +1622,11 @@
       }
     },
     "node_modules/@clearlydefined/spdx": {
-      "version": "0.1.8",
-      "resolved": "git+ssh://git@github.com/clearlydefined/spdx.git#b1cf4be4733ef148fe8abf9df77c614bf06fdc73",
-      "license": "MIT",
+      "version": "0.1.9",
+      "resolved": "git+ssh://git@github.com/clearlydefined/spdx.git#93916093259bc8593400948b679b0dc32a5a12dd",
       "dependencies": {
         "spdx-expression-parse": "github:clearlydefined/spdx-expression-parse.js#fork",
-        "spdx-license-ids": "^3.0.18",
+        "spdx-license-ids": "^3.0.20",
         "spdx-license-list": "^6.9.0",
         "spdx-satisfies": "github:clearlydefined/spdx-satisfies.js#parse-override"
       }
@@ -10095,18 +10094,16 @@
       }
     },
     "node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "git+ssh://git@github.com/clearlydefined/spdx-expression-parse.js.git#cf496b97100705445e7cfb48b65a0c7587ea4672",
-      "integrity": "sha512-iZZpzTTKhXPYiXaXgFaUxm0WvZOr3q7GiUuKXbYuwlbjXpBXoNqbVYEhlt5Q66k+9cg63aGRXawP7tE6OtvOyg==",
-      "license": "MIT",
+      "resolved": "git+ssh://git@github.com/clearlydefined/spdx-expression-parse.js.git#86fda6a3f84bb9da35d3536822804ac3fd1e587d",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-license-ids": "^3.0.13"
       }
     },
     "node_modules/spdx-license-ids": {
@@ -10133,7 +10130,6 @@
     "node_modules/spdx-satisfies": {
       "version": "5.0.0",
       "resolved": "git+ssh://git@github.com/clearlydefined/spdx-satisfies.js.git#b9571c0180dd95f160e7ddd522761c9e6a153259",
-      "license": "MIT",
       "dependencies": {
         "spdx-compare": "^1.0.0",
         "spdx-expression-parse": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@clearlydefined/spdx": "github:clearlydefined/spdx#v0.1.8",
+        "@clearlydefined/spdx": "github:clearlydefined/spdx#v0.1.9",
         "@gitbeaker/node": "^29.2.4",
         "@octokit/rest": "^14.0.9",
         "ajv": "^6.12.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/clearlydefined/service.git"
   },
   "dependencies": {
-    "@clearlydefined/spdx": "github:clearlydefined/spdx#v0.1.8",
+    "@clearlydefined/spdx": "github:clearlydefined/spdx#v0.1.9",
     "@gitbeaker/node": "^29.2.4",
     "@octokit/rest": "^14.0.9",
     "ajv": "^6.12.3",


### PR DESCRIPTION
### Description

The latest version of clearlydefined/spdx that includes the LicenseRef support in parser and scanner are in v0.1.9.