### PR TITLE
auto-start test workflow when PR into prod

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,14 @@
 name: Run Docker build and tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
   pull_request:
     branches:
       - master
+      - prod
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description

When merging master into prod as part of the deploy process, the test workflow should be automatically started.  This also provides the option to run the test workflow manually.

This is consistent with the same workflow in the crawler.
