### PR TITLE
set version to v2.0.1 in prep for bug release including deploy with operations v3.1.2

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -23,7 +23,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     needs: upload-package-lock-json
-    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v3.1.1
+    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v3.1.2
     secrets: 
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_DEV }}

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -22,7 +22,7 @@ jobs:
 
   build-and-deploy-prod:
     needs: upload-package-lock-json
-    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v3.1.1
+    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v3.1.2
     secrets: 
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "service",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "service",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Service side of clearlydefined.io.",
   "scripts": {
     "test": "npm run mocha && npm run lint",


### PR DESCRIPTION
### Description

Updates the CD/service version to 2.0.1 in prep for a bug release that includes a bug fix in the deploy process.

operations v3.1.1 had a bug that prevented a successful deploy.  The operations v3.1.2 release fixed that bug.  Need to use this version and re-deploy.

