### PR TITLE
Fix curation validation

### DIFF
--- a/lib/curation.js
+++ b/lib/curation.js
@@ -77,8 +77,10 @@ class Curation {
 
     sourceLicenseList.forEach(({ source, license }) => {
       const parsed = SPDX.normalize(license)
-      if (parsed !== license || parsed === 'NOASSERTION') {
+      if (!parsed || parsed.includes('NOASSERTION')) {
         errors.push(`${source} with value "${license}" is not SPDX compliant`)
+      } else if (parsed !== license) {
+        errors.push(`${source} with value "${license}" is not normalized. Suggest using "${parsed}"`)
       }
     })
 


### PR DESCRIPTION
When the curated license contains NOASSERTION (e.g., MIT AND NOASSERTION), the curation should be invalid.  In addition, when the curated license is not normalized, include the normalized license expression in the error message.

In the future, we can consider ignoring the cases of SPDX identifiers as per [SPDX specification](https://spdx.github.io/spdx-spec/v2-draft/SPDX-license-expressions/#d2-case-sensitivity).  For example, "MIT, Mit and mIt should all be treated as the same identifier". 