### PR TITLE
Add the ability to queue definition recomputation

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,6 +59,8 @@ function createApp(config) {
   const harvestQueue = config.harvest.queue()
   initializers.push(async () => harvestQueue.initialize())
 
+  const upgradeHandler = config.upgrade.service()
+
   const definitionService = require('./business/definitionService')(
     harvestStore,
     harvestService,
@@ -67,7 +69,8 @@ function createApp(config) {
     curationService,
     definitionStore,
     searchService,
-    cachingService
+    cachingService,
+    upgradeHandler
   )
   // Circular dependency. Reach in and set the curationService's definitionService. Sigh.
   curationService.definitionService = definitionService

--- a/app.js
+++ b/app.js
@@ -59,9 +59,8 @@ function createApp(config) {
   const harvestQueue = config.harvest.queue()
   initializers.push(async () => harvestQueue.initialize())
 
-  const defUpgradeQueue = config.upgrade.queue()
-  initializers.push(async () => defUpgradeQueue.initialize())
-  const upgradeHandler = config.upgrade.service()
+  const upgradeHandler = config.upgrade.service({ upgrade: config.upgrade.queue })
+  initializers.push(async () => upgradeHandler.initialize())
 
   const definitionService = require('./business/definitionService')(
     harvestStore,
@@ -235,7 +234,7 @@ function createApp(config) {
         // kick off the queue processors
         require('./providers/curation/process')(curationQueue, curationService, logger)
         require('./providers/harvest/process')(harvestQueue, definitionService, logger)
-        require('./providers/upgrade/process')(defUpgradeQueue, definitionService, logger)
+        upgradeHandler.setupProcessing(definitionService, logger)
 
         // Signal system is up and ok (no error)
         callback()

--- a/app.js
+++ b/app.js
@@ -59,6 +59,8 @@ function createApp(config) {
   const harvestQueue = config.harvest.queue()
   initializers.push(async () => harvestQueue.initialize())
 
+  const defUpgradeQueue = config.upgrade.queue()
+  initializers.push(async () => defUpgradeQueue.initialize())
   const upgradeHandler = config.upgrade.service()
 
   const definitionService = require('./business/definitionService')(
@@ -233,6 +235,7 @@ function createApp(config) {
         // kick off the queue processors
         require('./providers/curation/process')(curationQueue, curationService, logger)
         require('./providers/harvest/process')(harvestQueue, definitionService, logger)
+        require('./providers/upgrade/process')(defUpgradeQueue, definitionService, logger)
 
         // Signal system is up and ok (no error)
         callback()

--- a/app.js
+++ b/app.js
@@ -59,7 +59,7 @@ function createApp(config) {
   const harvestQueue = config.harvest.queue()
   initializers.push(async () => harvestQueue.initialize())
 
-  const upgradeHandler = config.upgrade.service({ upgrade: config.upgrade.queue })
+  const upgradeHandler = config.upgrade.service({ queue: config.upgrade.queue })
   initializers.push(async () => upgradeHandler.initialize())
 
   const definitionService = require('./business/definitionService')(

--- a/bin/config.js
+++ b/bin/config.js
@@ -58,6 +58,7 @@ module.exports = {
     store: loadFactory(config.get('DEFINITION_STORE_PROVIDER') || 'file', 'definition')
   },
   upgrade: {
+    queue: loadFactory(config.get('DEFINITION_UPGRADE_QUEUE_PROVIDER') || 'memory', 'upgrade.queue'),
     service: loadFactory(config.get('DEFINITION_UPGRADE_PROVIDER') || 'versionCheck', 'upgrade.service')
   },
   attachment: {

--- a/bin/config.js
+++ b/bin/config.js
@@ -57,6 +57,9 @@ module.exports = {
   definition: {
     store: loadFactory(config.get('DEFINITION_STORE_PROVIDER') || 'file', 'definition')
   },
+  upgrade: {
+    service: loadFactory(config.get('DEFINITION_UPGRADE_PROVIDER') || 'versionCheck', 'upgrade.service')
+  },
   attachment: {
     store: loadFactory(config.get('ATTACHMENT_STORE_PROVIDER') || 'file', 'attachment')
   },

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -49,8 +49,12 @@ class DefinitionService {
     this.search = search
     this.cache = cache
     this.upgradeHandler = upgradeHandler
-    this.upgradeHandler.currentSchema = currentSchema
+    if (this.upgradeHandler) this.upgradeHandler.currentSchema = currentSchema
     this.logger = logger()
+  }
+
+  get currentSchema() {
+    return currentSchema
   }
 
   /**

--- a/providers/index.js
+++ b/providers/index.js
@@ -28,8 +28,13 @@ module.exports = {
     github: require('../middleware/githubConfig')
   },
   upgrade: {
+    queue: {
+      azure: require('../providers/upgrade/azureQueueConfig'),
+      memory: require('../providers/queueing/memoryQueue')
+    },
     service: {
-      versionCheck: require('../providers/upgrade/defVersionCheck')
+      versionCheck: require('../providers/upgrade/defVersionCheck').factory,
+      upgradeQueue: require('../providers/upgrade/defUpgradeQueueConfig')
     }
   },
   curation: {

--- a/providers/index.js
+++ b/providers/index.js
@@ -27,6 +27,11 @@ module.exports = {
   auth: {
     github: require('../middleware/githubConfig')
   },
+  upgrade: {
+    service: {
+      versionCheck: require('../providers/upgrade/defVersionCheck')
+    }
+  },
   curation: {
     queue: {
       azure: require('../providers/curation/azureQueueConfig'),

--- a/providers/index.js
+++ b/providers/index.js
@@ -30,7 +30,7 @@ module.exports = {
   upgrade: {
     queue: {
       azure: require('../providers/upgrade/azureQueueConfig'),
-      memory: require('../providers/queueing/memoryQueue')
+      memory: require('../providers/upgrade/memoryQueueConfig')
     },
     service: {
       versionCheck: require('../providers/upgrade/defVersionCheck').factory,

--- a/providers/queueing/memoryQueue.js
+++ b/providers/queueing/memoryQueue.js
@@ -40,7 +40,8 @@ class MemoryQueue {
 
   /** Similar to dequeue() but returns an array instead. See AzureStorageQueue.dequeueMultiple() */
   async dequeueMultiple() {
-    return [await this.dequeue()]
+    const message = await this.dequeue()
+    return message ? [message] : []
   }
 
   /**

--- a/providers/upgrade/azureQueueConfig.js
+++ b/providers/upgrade/azureQueueConfig.js
@@ -1,0 +1,20 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const config = require('painless-config')
+const AzureStorageQueue = require('../queueing/azureStorageQueue')
+
+function azure(options) {
+  const realOptions = options || {
+    connectionString:
+      config.get('DEFINITION_UPGRADE_QUEUE_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
+    queueName: config.get('DEFINITION_UPGRADE_QUEUE_NAME') || 'definitions-upgrade',
+    dequeueOptions: {
+      numOfMessages: 32,
+      visibilityTimeout: 10 * 60 // 10 min. The default value is 30 seconds.
+    }
+  }
+  return new AzureStorageQueue(realOptions)
+}
+
+module.exports = azure

--- a/providers/upgrade/azureQueueConfig.js
+++ b/providers/upgrade/azureQueueConfig.js
@@ -4,16 +4,18 @@
 const config = require('painless-config')
 const AzureStorageQueue = require('../queueing/azureStorageQueue')
 
-function azure(options) {
-  const realOptions = options || {
-    connectionString:
-      config.get('DEFINITION_UPGRADE_QUEUE_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
-    queueName: config.get('DEFINITION_UPGRADE_QUEUE_NAME') || 'definitions-upgrade',
-    dequeueOptions: {
-      numOfMessages: 32,
-      visibilityTimeout: 10 * 60 // 10 min. The default value is 30 seconds.
-    }
+const defaultOptions = {
+  connectionString:
+    config.get('DEFINITION_UPGRADE_QUEUE_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
+  queueName: config.get('DEFINITION_UPGRADE_QUEUE_NAME') || 'definitions-upgrade',
+  dequeueOptions: {
+    numOfMessages: 32,
+    visibilityTimeout: 10 * 60 // 10 min. The default value is 30 seconds.
   }
+}
+
+function azure(options) {
+  const realOptions = options || defaultOptions
   return new AzureStorageQueue(realOptions)
 }
 

--- a/providers/upgrade/defUpgradeQueue.js
+++ b/providers/upgrade/defUpgradeQueue.js
@@ -26,7 +26,8 @@ class DefinitionQueueUpgrader extends DefinitionVersionChecker {
 
   _constructMessage(definition) {
     const { coordinates, _meta } = definition
-    return { coordinates, _meta }
+    const content = { coordinates, _meta }
+    return Buffer.from(JSON.stringify(content)).toString('base64')
   }
 
   async initialize() {

--- a/providers/upgrade/defUpgradeQueue.js
+++ b/providers/upgrade/defUpgradeQueue.js
@@ -34,8 +34,8 @@ class DefinitionQueueUpgrader extends DefinitionVersionChecker {
     return this._upgrade.initialize()
   }
 
-  setupProcessing(definitionService, logger) {
-    return setup(this._upgrade, definitionService, logger)
+  setupProcessing(definitionService, logger, once) {
+    return setup(this._upgrade, definitionService, logger, once)
   }
 }
 

--- a/providers/upgrade/defUpgradeQueue.js
+++ b/providers/upgrade/defUpgradeQueue.js
@@ -25,8 +25,8 @@ class DefinitionQueueUpgrader extends DefinitionVersionChecker {
   }
 
   async initialize() {
-    this.upgrade = this.options.upgrade() //TODO rename to queue? app.js
-    this.upgrade.initialize()
+    this.upgrade = this.options.queue()
+    return this.upgrade.initialize()
   }
 
   setupProcessing(definitionService, logger) {

--- a/providers/upgrade/defUpgradeQueue.js
+++ b/providers/upgrade/defUpgradeQueue.js
@@ -3,7 +3,7 @@
 
 const { DefinitionVersionChecker } = require('./defVersionCheck')
 const EntityCoordinates = require('../../lib/entityCoordinates')
-const setup = require('./process')
+const { setup } = require('./process')
 
 class DefinitionQueueUpgrader extends DefinitionVersionChecker {
   async validate(definition) {
@@ -16,9 +16,9 @@ class DefinitionQueueUpgrader extends DefinitionVersionChecker {
   }
 
   async _queueUpgrade(definition) {
-    if (!this.upgrade) throw new Error('Upgrade queue is not set')
+    if (!this._upgrade) throw new Error('Upgrade queue is not set')
     const message = this._constructMessage(definition)
-    await this.upgrade.queue(JSON.stringify(message))
+    await this._upgrade.queue(JSON.stringify(message))
     this.logger.debug('Queued for definition upgrade ', {
       coordinates: EntityCoordinates.fromObject(definition.coordinates).toString()
     })
@@ -30,12 +30,12 @@ class DefinitionQueueUpgrader extends DefinitionVersionChecker {
   }
 
   async initialize() {
-    this.upgrade = this.options.queue()
-    return this.upgrade.initialize()
+    this._upgrade = this.options.queue()
+    return this._upgrade.initialize()
   }
 
   setupProcessing(definitionService, logger) {
-    setup(this.upgrade, definitionService, logger)
+    return setup(this._upgrade, definitionService, logger)
   }
 }
 

--- a/providers/upgrade/defUpgradeQueue.js
+++ b/providers/upgrade/defUpgradeQueue.js
@@ -1,7 +1,6 @@
 // (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const { lt } = require('semver')
 const { DefinitionVersionChecker } = require('./defVersionCheck')
 const EntityCoordinates = require('../../lib/entityCoordinates')
 const setup = require('./process')
@@ -20,7 +19,7 @@ class DefinitionQueueUpgrader extends DefinitionVersionChecker {
     if (!this.upgrade) throw new Error('Upgrade queue is not set')
     const message = this._constructMessage(definition)
     await this.upgrade.queue(JSON.stringify(message))
-    this.logger.debug('Queued definition upgrade: ', {
+    this.logger.debug('Queued for definition upgrade ', {
       coordinates: EntityCoordinates.fromObject(definition.coordinates).toString()
     })
   }

--- a/providers/upgrade/defUpgradeQueue.js
+++ b/providers/upgrade/defUpgradeQueue.js
@@ -1,0 +1,32 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const logger = require('../logging/logger')
+const { lt } = require('semver')
+const { DefinitionVersionChecker } = require('./defVersionCheck')
+const EntityCoordinates = require('../../lib/entityCoordinates')
+const azure = require('./azureQueueConfig')
+
+class DefinitionQueueUpgrader extends DefinitionVersionChecker {
+  constructor(options) {
+    super(options)
+    this.upgrade = options.upgrade
+  }
+
+  async validate(definition) {
+    const result = await super.validate(definition)
+    if (result) return result
+
+    //otherwise queue for upgrade before returning
+    const message = JSON.stringify(this._constructMessage(definition))
+    await this.upgrade.queue(message)
+    return definition
+  }
+
+  _constructMessage(definition) {
+    const { coordinates, _meta } = definition
+    return { coordinates, _meta }
+  }
+}
+
+module.exports = DefinitionQueueUpgrader

--- a/providers/upgrade/defUpgradeQueueConfig.js
+++ b/providers/upgrade/defUpgradeQueueConfig.js
@@ -2,13 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 const DefinitionQueueUpgrader = require('./defUpgradeQueue')
-const azure = require('./azureQueueConfig')
+const memory = require('./memoryQueueConfig')
 
 function serviceFactory(options) {
-  const realOptions = options || {
-    upgrade: azure()
-  }
-  realOptions.upgrade.initialize()
+  const realOptions = { upgrade: memory, ...options }
   return new DefinitionQueueUpgrader(realOptions)
 }
 

--- a/providers/upgrade/defUpgradeQueueConfig.js
+++ b/providers/upgrade/defUpgradeQueueConfig.js
@@ -5,7 +5,7 @@ const DefinitionQueueUpgrader = require('./defUpgradeQueue')
 const memory = require('./memoryQueueConfig')
 
 function serviceFactory(options) {
-  const realOptions = { upgrade: memory, ...options }
+  const realOptions = { queue: memory, ...options }
   return new DefinitionQueueUpgrader(realOptions)
 }
 

--- a/providers/upgrade/defUpgradeQueueConfig.js
+++ b/providers/upgrade/defUpgradeQueueConfig.js
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 const DefinitionQueueUpgrader = require('./defUpgradeQueue')
-const memory = require('./memoryQueueConfig')
+const memory = require('../queueing/memoryQueue')
 
-function serviceFactory(options) {
-  const realOptions = { queue: memory, ...options }
-  return new DefinitionQueueUpgrader(realOptions)
+function serviceFactory(options = {}) {
+  const mergedOptions = { queue: memory, ...options }
+  return new DefinitionQueueUpgrader(mergedOptions)
 }
 
 module.exports = serviceFactory

--- a/providers/upgrade/defUpgradeQueueConfig.js
+++ b/providers/upgrade/defUpgradeQueueConfig.js
@@ -1,0 +1,15 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const DefinitionQueueUpgrader = require('./defUpgradeQueue')
+const azure = require('./azureQueueConfig')
+
+function serviceFactory(options) {
+  const realOptions = options || {
+    upgrade: azure()
+  }
+  realOptions.upgrade.initialize()
+  return new DefinitionQueueUpgrader(realOptions)
+}
+
+module.exports = serviceFactory

--- a/providers/upgrade/defVersionCheck.js
+++ b/providers/upgrade/defVersionCheck.js
@@ -25,6 +25,14 @@ class DefinitionVersionChecker {
     this.logger.debug(`Definition version: %s, Current schema version: %s`, defSchemaVersion, this._currentSchema)
     if (defSchemaVersion && gte(defSchemaVersion, this._currentSchema)) return definition
   }
+
+  async initialize() {
+    //do nothing for initialization
+  }
+
+  setupProcessing() {
+    //do nothing for set up processing
+  }
 }
 
 const factory = options => new DefinitionVersionChecker(options)

--- a/providers/upgrade/defVersionCheck.js
+++ b/providers/upgrade/defVersionCheck.js
@@ -24,7 +24,7 @@ class DefinitionVersionChecker {
     if (!this._currentSchema) throw new Error('Current schema version is not set')
     const defSchemaVersion = get(definition, '_meta.schemaVersion')
     this.logger.debug(`Definition version: %s, Current schema version: %s `, defSchemaVersion, this._currentSchema, {
-      coordinates: definition?.coordinates && EntityCoordinates.fromObject(definition.coordinates).toString()
+      coordinates: DefinitionVersionChecker.getCoordinates(definition)
     })
     if (defSchemaVersion && gte(defSchemaVersion, this._currentSchema)) return definition
   }
@@ -35,6 +35,10 @@ class DefinitionVersionChecker {
 
   setupProcessing() {
     //do nothing for set up processing
+  }
+
+  static getCoordinates(definition) {
+    return definition?.coordinates && EntityCoordinates.fromObject(definition.coordinates).toString()
   }
 }
 

--- a/providers/upgrade/defVersionCheck.js
+++ b/providers/upgrade/defVersionCheck.js
@@ -1,7 +1,6 @@
 // (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-const { callFetch: requestPromise } = require('../../lib/fetch')
 const logger = require('../logging/logger')
 const { gte } = require('semver')
 const { get } = require('lodash')
@@ -28,4 +27,6 @@ class DefinitionVersionChecker {
   }
 }
 
-module.exports = options => new DefinitionVersionChecker(options)
+const factory = options => new DefinitionVersionChecker(options)
+
+module.exports = { DefinitionVersionChecker, factory }

--- a/providers/upgrade/defVersionCheck.js
+++ b/providers/upgrade/defVersionCheck.js
@@ -4,6 +4,7 @@
 const logger = require('../logging/logger')
 const { gte } = require('semver')
 const { get } = require('lodash')
+const EntityCoordinates = require('../../lib/entityCoordinates')
 
 class DefinitionVersionChecker {
   constructor(options = {}) {
@@ -22,7 +23,9 @@ class DefinitionVersionChecker {
   async validate(definition) {
     if (!this._currentSchema) throw new Error('Current schema version is not set')
     const defSchemaVersion = get(definition, '_meta.schemaVersion')
-    this.logger.debug(`Definition version: %s, Current schema version: %s`, defSchemaVersion, this._currentSchema)
+    this.logger.debug(`Definition version: %s, Current schema version: %s `, defSchemaVersion, this._currentSchema, {
+      coordinates: definition?.coordinates && EntityCoordinates.fromObject(definition.coordinates).toString()
+    })
     if (defSchemaVersion && gte(defSchemaVersion, this._currentSchema)) return definition
   }
 

--- a/providers/upgrade/defVersionCheck.js
+++ b/providers/upgrade/defVersionCheck.js
@@ -6,8 +6,8 @@ const { gte } = require('semver')
 const { get } = require('lodash')
 
 class DefinitionVersionChecker {
-  constructor(options) {
-    this.options = options || {}
+  constructor(options = {}) {
+    this.options = options
     this.logger = this.options.logger || logger()
   }
 

--- a/providers/upgrade/defVersionCheck.js
+++ b/providers/upgrade/defVersionCheck.js
@@ -1,0 +1,31 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { callFetch: requestPromise } = require('../../lib/fetch')
+const logger = require('../logging/logger')
+const { gte } = require('semver')
+const { get } = require('lodash')
+
+class DefinitionVersionChecker {
+  constructor(options) {
+    this.options = options || {}
+    this.logger = this.options.logger || logger()
+  }
+
+  set currentSchema(schemaVersion) {
+    this._currentSchema = schemaVersion
+  }
+
+  get currentSchema() {
+    return this._currentSchema
+  }
+
+  async validate(definition) {
+    if (!this._currentSchema) throw new Error('Current schema version is not set')
+    const defSchemaVersion = get(definition, '_meta.schemaVersion')
+    this.logger.debug(`Definition version: %s, Current schema version: %s`, defSchemaVersion, this._currentSchema)
+    if (defSchemaVersion && gte(defSchemaVersion, this._currentSchema)) return definition
+  }
+}
+
+module.exports = options => new DefinitionVersionChecker(options)

--- a/providers/upgrade/memoryQueueConfig.js
+++ b/providers/upgrade/memoryQueueConfig.js
@@ -1,0 +1,14 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const MemoryQueue = require('../queueing/memoryQueue')
+
+const encodedMessageQueueFactory = opts => {
+  const defaultOpts = {
+    decoder: text => Buffer.from(text, 'base64').toString('utf8')
+  }
+  const mergedOpts = { ...defaultOpts, ...opts }
+  return MemoryQueue(mergedOpts)
+}
+
+module.exports = encodedMessageQueueFactory

--- a/providers/upgrade/process.js
+++ b/providers/upgrade/process.js
@@ -22,14 +22,17 @@ async function work(once) {
 async function processMessage(message) {
   let coordinates = get(message, 'data.coordinates')
   if (!coordinates) return
-  coordinates = EntityCoordinates.fromObject(coordinates)
 
+  coordinates = EntityCoordinates.fromObject(coordinates)
   const existing = await definitionService.getStored(coordinates)
   let result = await defVersionChecker.validate(existing)
-  if (result) return //valid definition, no need to upgrade
-  await definitionService.computeStoreAndCurate(coordinates)
+  if (!result) {
+    await definitionService.computeStoreAndCurate(coordinates)
+    logger.info(`Handled definition update for ${coordinates.toString()}`)
+  } else {
+    logger.debug(`Skipped definition update for ${coordinates.toString()}`)
+  }
   await queue.delete(message)
-  logger.info(`Handled definition update for ${coordinates.toString()}`)
 }
 
 let queue

--- a/providers/upgrade/process.js
+++ b/providers/upgrade/process.js
@@ -59,7 +59,7 @@ class DefinitionUpgrader {
 let queueHandler
 let defUpgrader
 
-function setup(_queue, _definitionService, _logger, once = false, _defVersionChecker = factory()) {
+function setup(_queue, _definitionService, _logger, once = false, _defVersionChecker = factory({ logger: _logger })) {
   defUpgrader = new DefinitionUpgrader(_definitionService, _logger, _defVersionChecker)
   queueHandler = new QueueHandler(_queue, _logger, defUpgrader)
   return queueHandler.work(once)

--- a/providers/upgrade/process.js
+++ b/providers/upgrade/process.js
@@ -1,0 +1,49 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { get } = require('lodash')
+const EntityCoordinates = require('../../lib/entityCoordinates')
+const { factory } = require('./defVersionCheck')
+
+async function work(once) {
+  let isQueueEmpty = true
+  try {
+    const messages = await queue.dequeueMultiple()
+    if (messages && messages.length > 0) isQueueEmpty = false
+    const results = await Promise.allSettled(messages.map(message => processMessage(message)))
+    results.filter(result => result.status === 'rejected').forEach(result => logger.error(result.reason))
+  } catch (error) {
+    logger.error(error)
+  } finally {
+    if (!once) setTimeout(work, isQueueEmpty ? 10000 : 0)
+  }
+}
+
+async function processMessage(message) {
+  let coordinates = get(message, 'data.coordinates')
+  if (!coordinates) return
+  coordinates = EntityCoordinates.fromObject(coordinates)
+
+  const existing = await definitionService.getStored(coordinates)
+  let result = await defVersionChecker.validate(existing)
+  if (result) return //valid definition, no need to upgrade
+  await definitionService.computeStoreAndCurate(coordinates)
+  await queue.delete(message)
+  logger.info(`Handled definition update for ${coordinates.toString()}`)
+}
+
+let queue
+let definitionService
+let logger
+let defVersionChecker
+
+function setup(_queue, _definitionService, _logger, _defVersionChecker = factory(), once = false) {
+  queue = _queue
+  definitionService = _definitionService
+  logger = _logger
+  defVersionChecker = _defVersionChecker
+  defVersionChecker.currentSchema = definitionService.currentSchema
+  return work(once)
+}
+
+module.exports = setup

--- a/providers/upgrade/process.js
+++ b/providers/upgrade/process.js
@@ -59,7 +59,7 @@ class DefinitionUpgrader {
 let queueHandler
 let defUpgrader
 
-function setup(_queue, _definitionService, _logger, _defVersionChecker = factory(), once = false) {
+function setup(_queue, _definitionService, _logger, once = false, _defVersionChecker = factory()) {
   defUpgrader = new DefinitionUpgrader(_definitionService, _logger, _defVersionChecker)
   queueHandler = new QueueHandler(_queue, _logger, defUpgrader)
   return queueHandler.work(once)

--- a/providers/upgrade/process.js
+++ b/providers/upgrade/process.js
@@ -78,12 +78,9 @@ class DefinitionUpgrader {
   }
 }
 
-let queueHandler
-let defUpgrader
-
 function setup(_queue, _definitionService, _logger, once = false, _defVersionChecker = factory({ logger: _logger })) {
-  defUpgrader = new DefinitionUpgrader(_definitionService, _logger, _defVersionChecker)
-  queueHandler = new QueueHandler(_queue, _logger, defUpgrader)
+  const defUpgrader = new DefinitionUpgrader(_definitionService, _logger, _defVersionChecker)
+  const queueHandler = new QueueHandler(_queue, _logger, defUpgrader)
   return queueHandler.work(once)
 }
 

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -369,7 +369,18 @@ function setupWithDelegates(curator, harvestStore, summary, aggregator) {
   const cache = { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() }
 
   const harvestService = { harvest: () => sinon.stub() }
-  const service = DefinitionService(harvestStore, harvestService, summary, aggregator, curator, store, search, cache)
+  const upgradeHandler = { validate: def => Promise.resolve(def) }
+  const service = DefinitionService(
+    harvestStore,
+    harvestService,
+    summary,
+    aggregator,
+    curator,
+    store,
+    search,
+    cache,
+    upgradeHandler
+  )
   service.logger = { info: sinon.stub(), debug: () => {} }
   service._harvest = sinon.stub()
   return service
@@ -411,7 +422,18 @@ function setup(definition, coordinateSpec, curation) {
   const harvestService = { harvest: () => sinon.stub() }
   const summary = { summarizeAll: () => Promise.resolve(null) }
   const aggregator = { process: () => Promise.resolve(definition) }
-  const service = DefinitionService(harvestStore, harvestService, summary, aggregator, curator, store, search, cache)
+  const upgradeHandler = { validate: def => Promise.resolve(def) }
+  const service = DefinitionService(
+    harvestStore,
+    harvestService,
+    summary,
+    aggregator,
+    curator,
+    store,
+    search,
+    cache,
+    upgradeHandler
+  )
   service.logger = { info: sinon.stub(), debug: sinon.stub() }
   service._harvest = sinon.stub()
   const coordinates = EntityCoordinates.fromString(coordinateSpec || 'npm/npmjs/-/test/1.0')

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -15,6 +15,9 @@ const expect = chai.expect
 const FileHarvestStore = require('../../providers/stores/fileHarvestStore')
 const SummaryService = require('../../business/summarizer')
 const AggregatorService = require('../../business/aggregator')
+const DefinitionQueueUpgrader = require('../../providers/upgrade/defUpgradeQueue')
+const memoryQueue = require('../../providers/queueing/memoryQueue')
+const { DefinitionVersionChecker } = require('../../providers/upgrade/defVersionCheck')
 
 describe('Definition Service', () => {
   it('invalidates single coordinate', async () => {
@@ -314,26 +317,129 @@ describe('Definition Service Facet management', () => {
 })
 
 describe('Integration test', () => {
-  let fileHarvestStore
-  beforeEach(() => {
-    fileHarvestStore = createFileHarvestStore()
+  describe('compute', () => {
+    let fileHarvestStore
+    beforeEach(() => {
+      fileHarvestStore = createFileHarvestStore()
+    })
+
+    it('computes the same definition with latest harvest data', async () => {
+      const coordinates = EntityCoordinates.fromString('npm/npmjs/-/debug/3.1.0')
+      const allHarvestData = await fileHarvestStore.getAll(coordinates)
+      delete allHarvestData['scancode']['2.9.0+b1'] //remove invalid scancode version
+      let service = setupServiceToCalculateDefinition(allHarvestData)
+      const baseline_def = await service.compute(coordinates)
+
+      const latestHarvestData = await fileHarvestStore.getAllLatest(coordinates)
+      service = setupServiceToCalculateDefinition(latestHarvestData)
+      const comparison_def = await service.compute(coordinates)
+
+      //updated timestamp is not deterministic
+      expect(comparison_def._meta.updated).to.not.equal(baseline_def._meta.updated)
+      comparison_def._meta.updated = baseline_def._meta.updated
+      expect(comparison_def).to.deep.equal(baseline_def)
+    })
   })
 
-  it('computes the same definition with latest harvest data', async () => {
-    const coordinates = EntityCoordinates.fromString('npm/npmjs/-/debug/3.1.0')
-    const allHarvestData = await fileHarvestStore.getAll(coordinates)
-    delete allHarvestData['scancode']['2.9.0+b1'] //remove invalid scancode version
-    let service = setupDefinitionService(allHarvestData)
-    const baseline_def = await service.compute(coordinates)
+  describe('Handle schema version upgrade', () => {
+    const coordinates = EntityCoordinates.fromString('npm/npmjs/-/test/1.0')
+    const definition = { _meta: { schemaVersion: '1.7.0' }, coordinates }
 
-    const latestHarvestData = await fileHarvestStore.getAllLatest(coordinates)
-    service = setupDefinitionService(latestHarvestData)
-    const comparison_def = await service.compute(coordinates)
+    let logger, upgradeHandler
+    beforeEach(() => {
+      logger = { debug: sinon.stub(), error: sinon.stub(), info: sinon.stub() }
+    })
 
-    //updated timestamp is not deterministic
-    expect(comparison_def._meta.updated).to.not.equal(baseline_def._meta.updated)
-    comparison_def._meta.updated = baseline_def._meta.updated
-    expect(comparison_def).to.deep.equal(baseline_def)
+    const handleVersionedDefinition = function () {
+      describe('verify schema version', () => {
+        it('logs and harvests new definitions with empty tools', async () => {
+          const { service } = setupServiceForUpgrade(null, upgradeHandler)
+          service._harvest = sinon.stub()
+          await service.get(coordinates)
+          expect(service._harvest.calledOnce).to.be.true
+          expect(service._harvest.getCall(0).args[0]).to.eq(coordinates)
+        })
+
+        it('computes if definition does not exist', async () => {
+          const { service } = setupServiceForUpgrade(null, upgradeHandler)
+          service.computeStoreAndCurate = sinon.stub().resolves(definition)
+          await service.get(coordinates)
+          expect(service.computeStoreAndCurate.calledOnce).to.be.true
+          expect(service.computeStoreAndCurate.getCall(0).args[0]).to.eq(coordinates)
+        })
+
+        it('returns the up-to-date definition', async () => {
+          const { service } = setupServiceForUpgrade(definition, upgradeHandler)
+          service.computeStoreAndCurate = sinon.stub()
+          const result = await service.get(coordinates)
+          expect(service.computeStoreAndCurate.called).to.be.false
+          expect(result).to.deep.equal(definition)
+        })
+      })
+    }
+
+    describe('schema version check', () => {
+      beforeEach(async () => {
+        upgradeHandler = new DefinitionVersionChecker({ logger })
+        await upgradeHandler.initialize()
+      })
+
+      handleVersionedDefinition()
+
+      context('with stale definitions', () => {
+        it('recomputes a definition with the updated schema version', async () => {
+          const staleDef = { ...createDefinition(null, null, ['foo']), _meta: { schemaVersion: '1.0.0' }, coordinates }
+          const { service, store } = setupServiceForUpgrade(staleDef, upgradeHandler)
+          const result = await service.get(coordinates)
+          expect(result._meta.schemaVersion).to.eq('1.7.0')
+          expect(result.coordinates).to.deep.equal(coordinates)
+          expect(store.store.calledOnce).to.be.true
+        })
+      })
+    })
+
+    describe('queueing schema version updates', () => {
+      let queue
+      beforeEach(async () => {
+        queue = memoryQueue()
+        const queueFactory = sinon.stub().returns(queue)
+        upgradeHandler = new DefinitionQueueUpgrader({ logger, queue: queueFactory })
+        await upgradeHandler.initialize()
+      })
+
+      handleVersionedDefinition()
+
+      context('with stale definitions', () => {
+        it('returns a stale definition, queues update, recomputes and retrieves the updated definition', async () => {
+          const staleDef = { ...createDefinition(null, null, ['foo']), _meta: { schemaVersion: '1.0.0' }, coordinates }
+          const { service, store } = setupServiceForUpgrade(staleDef, upgradeHandler)
+          const result = await service.get(coordinates)
+          expect(result).to.deep.equal(staleDef)
+          expect(queue.data.length).to.eq(1)
+          await upgradeHandler.setupProcessing(service, logger, true)
+          const newResult = await service.get(coordinates)
+          expect(newResult._meta.schemaVersion).to.eq('1.7.0')
+          expect(store.store.calledOnce).to.be.true
+          expect(queue.data.length).to.eq(0)
+        })
+
+        it('computes once when the same coordinates is queued twice', async () => {
+          const staleDef = { ...createDefinition(null, null, ['foo']), _meta: { schemaVersion: '1.0.0' }, coordinates }
+          const { service, store } = setupServiceForUpgrade(staleDef, upgradeHandler)
+          await service.get(coordinates)
+          const result = await service.get(coordinates)
+          expect(result).to.deep.equal(staleDef)
+          expect(queue.data.length).to.eq(2)
+          await upgradeHandler.setupProcessing(service, logger, true)
+          expect(queue.data.length).to.eq(1)
+          await upgradeHandler.setupProcessing(service, logger, true)
+          const newResult = await service.get(coordinates)
+          expect(newResult._meta.schemaVersion).to.eq('1.7.0')
+          expect(store.store.calledOnce).to.be.true
+          expect(queue.data.length).to.eq(0)
+        })
+      })
+    })
   })
 })
 
@@ -348,7 +454,7 @@ function createFileHarvestStore() {
   return FileHarvestStore(options)
 }
 
-function setupDefinitionService(rawHarvestData) {
+function setupServiceToCalculateDefinition(rawHarvestData) {
   const harvestStore = { getAllLatest: () => Promise.resolve(rawHarvestData) }
   const summary = SummaryService({})
 
@@ -363,13 +469,35 @@ function setupDefinitionService(rawHarvestData) {
   return setupWithDelegates(curator, harvestStore, summary, aggregator)
 }
 
-function setupWithDelegates(curator, harvestStore, summary, aggregator) {
-  const store = { delete: sinon.stub(), get: sinon.stub(), store: sinon.stub() }
+function setupServiceForUpgrade(definition, upgradeHandler) {
+  let storedDef = definition && { ...definition }
+  const store = {
+    get: sinon.stub().resolves(storedDef),
+    store: sinon.stub().callsFake(def => (storedDef = def))
+  }
+  const harvestStore = { getAllLatest: () => Promise.resolve(null) }
+  const summary = { summarizeAll: () => Promise.resolve(null) }
+  const aggregator = { process: () => Promise.resolve(definition) }
+  const curator = {
+    get: () => Promise.resolve(),
+    apply: (_coordinates, _curationSpec, definition) => Promise.resolve(definition),
+    autoCurate: () => {}
+  }
+  const service = setupWithDelegates(curator, harvestStore, summary, aggregator, store, upgradeHandler)
+  return { service, store }
+}
+
+function setupWithDelegates(
+  curator,
+  harvestStore,
+  summary,
+  aggregator,
+  store = { delete: sinon.stub(), get: sinon.stub(), store: sinon.stub() },
+  upgradeHandler = { validate: def => Promise.resolve(def) }
+) {
   const search = { delete: sinon.stub(), store: sinon.stub() }
   const cache = { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() }
-
   const harvestService = { harvest: () => sinon.stub() }
-  const upgradeHandler = { validate: def => Promise.resolve(def) }
   const service = DefinitionService(
     harvestStore,
     harvestService,
@@ -382,7 +510,6 @@ function setupWithDelegates(curator, harvestStore, summary, aggregator) {
     upgradeHandler
   )
   service.logger = { info: sinon.stub(), debug: () => {} }
-  service._harvest = sinon.stub()
   return service
 }
 

--- a/test/providers/queueing/memoryQueueTest.js
+++ b/test/providers/queueing/memoryQueueTest.js
@@ -6,73 +6,103 @@ const MemoryQueue = require('../../../providers/queueing/memoryQueue')
 
 describe('memory queue operations', () => {
   let memQueue
+  context('with unecoded messages', () => {
+    beforeEach(() => {
+      memQueue = MemoryQueue()
+    })
 
-  beforeEach(() => {
-    memQueue = MemoryQueue()
+    it('queues messages', async () => {
+      await memQueue.queue(JSON.stringify({ somekey: 1 }))
+      await memQueue.queue(JSON.stringify({ somekey: 2 }))
+      assert.equal(memQueue.data.length, 2)
+    })
+
+    it('dequeues messages', async () => {
+      await memQueue.queue(JSON.stringify({ somekey: 1 }))
+      await memQueue.queue(JSON.stringify({ somekey: 2 }))
+
+      let message1 = await memQueue.dequeue()
+      assert.equal(message1.data.somekey, 1)
+
+      await memQueue.delete(message1)
+
+      let message2 = await memQueue.dequeue()
+      assert.equal(message2.data.somekey, 2)
+
+      await memQueue.delete(message2)
+
+      let message3 = await memQueue.dequeue()
+      assert.equal(message3, null)
+    })
+
+    it('dequeue count increases to 5', async () => {
+      await memQueue.queue(JSON.stringify({ somekey: 1 }))
+
+      let message = await memQueue.dequeue()
+      assert.equal(message.original.dequeueCount, 1)
+
+      message = await memQueue.dequeue()
+      assert.equal(message.original.dequeueCount, 2)
+
+      message = await memQueue.dequeue()
+      assert.equal(message.original.dequeueCount, 3)
+
+      message = await memQueue.dequeue()
+      assert.equal(message.original.dequeueCount, 4)
+
+      message = await memQueue.dequeue()
+      assert.equal(message.original.dequeueCount, 5)
+
+      message = await memQueue.dequeue()
+      assert.equal(message, null)
+    })
+
+    it('handles dequeueing multiple messages', async () => {
+      await memQueue.queue(JSON.stringify({ somekey: 1 }))
+      await memQueue.queue(JSON.stringify({ somekey: 2 }))
+
+      let messages = await memQueue.dequeueMultiple()
+      assert.equal(messages.length, 1)
+      assert.equal(messages[0].data.somekey, 1)
+      await memQueue.delete(messages[0])
+
+      messages = await memQueue.dequeueMultiple()
+      assert.equal(messages.length, 1)
+      assert.equal(messages[0].data.somekey, 2)
+    })
+
+    it('handles dequeueing multiple messages of an empty queue', async () => {
+      let messages = await memQueue.dequeueMultiple()
+      assert.equal(messages.length, 0)
+    })
   })
 
-  it('queues messages', async () => {
-    await memQueue.queue(JSON.stringify({ somekey: 1 }))
-    await memQueue.queue(JSON.stringify({ somekey: 2 }))
-    assert.equal(memQueue.data.length, 2)
-  })
+  context('with encoded messages', () => {
+    beforeEach(() => {
+      memQueue = MemoryQueue({
+        decoder: text => Buffer.from(text, 'base64').toString('utf8')
+      })
+    })
+    const encode = content => Buffer.from(JSON.stringify(content)).toString('base64')
 
-  it('dequeues messages', async () => {
-    await memQueue.queue(JSON.stringify({ somekey: 1 }))
-    await memQueue.queue(JSON.stringify({ somekey: 2 }))
+    it('queues messages', async () => {
+      await memQueue.queue(encode({ somekey: 1 }))
+      await memQueue.queue(encode({ somekey: 2 }))
+      assert.equal(memQueue.data.length, 2)
+    })
 
-    let message1 = await memQueue.dequeue()
-    assert.equal(message1.data.somekey, 1)
+    it('handles dequeueing multiple messages', async () => {
+      await memQueue.queue(encode({ somekey: 1 }))
+      await memQueue.queue(encode({ somekey: 2 }))
 
-    await memQueue.delete(message1)
+      let messages = await memQueue.dequeueMultiple()
+      assert.equal(messages.length, 1)
+      assert.equal(messages[0].data.somekey, 1)
+      await memQueue.delete(messages[0])
 
-    let message2 = await memQueue.dequeue()
-    assert.equal(message2.data.somekey, 2)
-
-    await memQueue.delete(message2)
-
-    let message3 = await memQueue.dequeue()
-    assert.equal(message3, null)
-  })
-
-  it('dequeue count increases to 5', async () => {
-    await memQueue.queue(JSON.stringify({ somekey: 1 }))
-
-    let message = await memQueue.dequeue()
-    assert.equal(message.original.dequeueCount, 1)
-
-    message = await memQueue.dequeue()
-    assert.equal(message.original.dequeueCount, 2)
-
-    message = await memQueue.dequeue()
-    assert.equal(message.original.dequeueCount, 3)
-
-    message = await memQueue.dequeue()
-    assert.equal(message.original.dequeueCount, 4)
-
-    message = await memQueue.dequeue()
-    assert.equal(message.original.dequeueCount, 5)
-
-    message = await memQueue.dequeue()
-    assert.equal(message, null)
-  })
-
-  it('handles dequeueing multiple messages', async () => {
-    await memQueue.queue(JSON.stringify({ somekey: 1 }))
-    await memQueue.queue(JSON.stringify({ somekey: 2 }))
-
-    let messages = await memQueue.dequeueMultiple()
-    assert.equal(messages.length, 1)
-    assert.equal(messages[0].data.somekey, 1)
-    await memQueue.delete(messages[0])
-
-    messages = await memQueue.dequeueMultiple()
-    assert.equal(messages.length, 1)
-    assert.equal(messages[0].data.somekey, 2)
-  })
-
-  it('handles dequeueing multiple messages of an empty queue', async () => {
-    let messages = await memQueue.dequeueMultiple()
-    assert.equal(messages.length, 0)
+      messages = await memQueue.dequeueMultiple()
+      assert.equal(messages.length, 1)
+      assert.equal(messages[0].data.somekey, 2)
+    })
   })
 })

--- a/test/providers/queueing/memoryQueueTest.js
+++ b/test/providers/queueing/memoryQueueTest.js
@@ -5,15 +5,19 @@ const assert = require('assert')
 const MemoryQueue = require('../../../providers/queueing/memoryQueue')
 
 describe('memory queue operations', () => {
+  let memQueue
+
+  beforeEach(() => {
+    memQueue = MemoryQueue()
+  })
+
   it('queues messages', async () => {
-    const memQueue = MemoryQueue()
     await memQueue.queue(JSON.stringify({ somekey: 1 }))
     await memQueue.queue(JSON.stringify({ somekey: 2 }))
     assert.equal(memQueue.data.length, 2)
   })
 
   it('dequeues messages', async () => {
-    const memQueue = MemoryQueue()
     await memQueue.queue(JSON.stringify({ somekey: 1 }))
     await memQueue.queue(JSON.stringify({ somekey: 2 }))
 
@@ -32,7 +36,6 @@ describe('memory queue operations', () => {
   })
 
   it('dequeue count increases to 5', async () => {
-    const memQueue = MemoryQueue()
     await memQueue.queue(JSON.stringify({ somekey: 1 }))
 
     let message = await memQueue.dequeue()
@@ -52,5 +55,24 @@ describe('memory queue operations', () => {
 
     message = await memQueue.dequeue()
     assert.equal(message, null)
+  })
+
+  it('handles dequeueing multiple messages', async () => {
+    await memQueue.queue(JSON.stringify({ somekey: 1 }))
+    await memQueue.queue(JSON.stringify({ somekey: 2 }))
+
+    let messages = await memQueue.dequeueMultiple()
+    assert.equal(messages.length, 1)
+    assert.equal(messages[0].data.somekey, 1)
+    await memQueue.delete(messages[0])
+
+    messages = await memQueue.dequeueMultiple()
+    assert.equal(messages.length, 1)
+    assert.equal(messages[0].data.somekey, 2)
+  })
+
+  it('handles dequeueing multiple messages of an empty queue', async () => {
+    let messages = await memQueue.dequeueMultiple()
+    assert.equal(messages.length, 0)
   })
 })

--- a/test/providers/upgrade/defUpgradeQueue.js
+++ b/test/providers/upgrade/defUpgradeQueue.js
@@ -7,80 +7,131 @@ chai.use(chaiAsPromised)
 const { expect } = require('chai')
 const sinon = require('sinon')
 const DefinitionQueueUpgrader = require('../../../providers/upgrade/defUpgradeQueue')
+const MemoryQueue = require('../../../providers/upgrade/memoryQueueConfig')
 
 describe('DefinitionQueueUpgrader', () => {
-  const definition = { coordinates: 'test', _meta: { schemaVersion: '1.0.0' } }
-  let queue, upgrader
+  const logger = { debug: sinon.stub(), error: sinon.stub() }
 
-  beforeEach(async () => {
-    const logger = { debug: sinon.stub() }
-    queue = {
-      queue: sinon.stub().resolves(),
-      initialize: sinon.stub().resolves()
-    }
-    const queueFactory = sinon.stub().returns(queue)
-    upgrader = new DefinitionQueueUpgrader({ logger, queue: queueFactory })
-  })
+  describe('Unit tests', () => {
+    const definition = { coordinates: 'test', _meta: { schemaVersion: '1.0.0' } }
+    let queue, upgrader
 
-  it('returns an instance of DefinitionQueueUpgrader', () => {
-    expect(upgrader).to.be.an.instanceOf(DefinitionQueueUpgrader)
-  })
-
-  it('sets and gets current schema version', () => {
-    upgrader.currentSchema = '1.0.0'
-    expect(upgrader.currentSchema).to.equal('1.0.0')
-  })
-
-  it('initializes', async () => {
-    await upgrader.initialize()
-    expect(queue.initialize.calledOnce).to.be.true
-  })
-
-  it('connects to queue after setupProcessing', async () => {
-    await upgrader.initialize()
-    const definitionService = { currentSchema: '1.0.0' }
-    const logger = { debug: sinon.stub() }
-    queue.dequeueMultiple = sinon.stub().resolves([])
-    upgrader.setupProcessing(definitionService, logger, true)
-    expect(queue.dequeueMultiple.calledOnce).to.be.true
-  })
-
-  context('validate', () => {
-    it('fails if current schema version is not set', async () => {
-      await expect(upgrader.validate(definition)).to.be.rejectedWith(Error)
-    })
-
-    it('fails if it is not initialized', async () => {
-      upgrader.currentSchema = '1.0.0'
-      const stale = { coordinates: 'test', _meta: { schemaVersion: '0.0.1' } }
-      await expect(upgrader.validate(stale)).to.be.rejectedWith(Error)
-    })
-  })
-
-  context('validate after set up', () => {
     beforeEach(async () => {
+      queue = {
+        queue: sinon.stub().resolves(),
+        initialize: sinon.stub().resolves()
+      }
+      const queueFactory = sinon.stub().returns(queue)
+      upgrader = new DefinitionQueueUpgrader({ logger, queue: queueFactory })
+    })
+
+    it('returns an instance of DefinitionQueueUpgrader', () => {
+      expect(upgrader).to.be.an.instanceOf(DefinitionQueueUpgrader)
+    })
+
+    it('sets and gets current schema version', () => {
+      upgrader.currentSchema = '1.0.0'
+      expect(upgrader.currentSchema).to.equal('1.0.0')
+    })
+
+    it('initializes', async () => {
+      await upgrader.initialize()
+      expect(queue.initialize.calledOnce).to.be.true
+    })
+
+    it('connects to queue after setupProcessing', async () => {
+      await upgrader.initialize()
+      const definitionService = { currentSchema: '1.0.0' }
+      queue.dequeueMultiple = sinon.stub().resolves([])
+      upgrader.setupProcessing(definitionService, logger, true)
+      expect(queue.dequeueMultiple.calledOnce).to.be.true
+    })
+
+    context('validate', () => {
+      it('fails if current schema version is not set', async () => {
+        await expect(upgrader.validate(definition)).to.be.rejectedWith(Error)
+      })
+
+      it('fails if it is not initialized', async () => {
+        upgrader.currentSchema = '1.0.0'
+        const stale = { coordinates: 'test', _meta: { schemaVersion: '0.0.1' } }
+        await expect(upgrader.validate(stale)).to.be.rejectedWith(Error)
+      })
+    })
+
+    context('validate after set up', () => {
+      beforeEach(async () => {
+        await upgrader.initialize()
+        upgrader.currentSchema = '1.0.0'
+      })
+
+      it('does not queue null definition', async () => {
+        const result = await upgrader.validate(null)
+        expect(result).to.be.not.ok
+        expect(queue.queue.called).to.be.false
+      })
+
+      it('does not queue an up-to-date definition', async () => {
+        const definition = { coordinates: 'test', _meta: { schemaVersion: '1.0.0' } }
+        const result = await upgrader.validate(definition)
+        expect(result).to.deep.equal(definition)
+        expect(queue.queue.called).to.be.false
+      })
+
+      it('queues and returns a stale definition', async () => {
+        const definition = { coordinates: 'test', _meta: { schemaVersion: '0.0.1' } }
+        const result = await upgrader.validate(definition)
+        expect(result).to.deep.equal(definition)
+        expect(queue.queue.calledOnce).to.be.true
+      })
+
+      it('logs erorr when queueing throws', async () => {
+        const staleDef = {
+          coordinates: {
+            type: 'npm',
+            provider: 'npmjs',
+            name: 'lodash',
+            revision: '4.17.11'
+          },
+          _meta: { schemaVersion: '0.0.1' }
+        }
+        queue.queue.rejects(new Error('test'))
+        const result = await upgrader.validate(staleDef)
+        expect(result).to.deep.equal(staleDef)
+        expect(logger.error.calledOnce).to.be.true
+        const { coordinates } = logger.error.args[0][1]
+        expect(coordinates).to.eq('npm/npmjs/-/lodash/4.17.11')
+      })
+    })
+  })
+
+  describe('Integration tests', () => {
+    let queue, upgrader
+
+    beforeEach(async () => {
+      queue = MemoryQueue()
+      upgrader = new DefinitionQueueUpgrader({ logger, queue: sinon.stub().returns(queue) })
       await upgrader.initialize()
       upgrader.currentSchema = '1.0.0'
     })
 
-    it('does not queue null definition', async () => {
-      const result = await upgrader.validate(null)
-      expect(result).to.be.not.ok
-      expect(queue.queue.called).to.be.false
-    })
+    it('queues the correct message that can be decoded correctly', async () => {
+      const staleDef = {
+        coordinates: {
+          type: 'npm',
+          provider: 'npmjs',
+          name: 'lodash',
+          revision: '4.17.11'
+        },
+        _meta: { schemaVersion: '0.0.1' }
+      }
+      const result = await upgrader.validate(staleDef)
+      expect(result).to.deep.equal(staleDef)
+      expect(queue.data.length).to.equal(1)
 
-    it('does not queue an up-to-date definition', async () => {
-      const definition = { coordinates: 'test', _meta: { schemaVersion: '1.0.0' } }
-      const result = await upgrader.validate(definition)
-      expect(result).to.deep.equal(definition)
-      expect(queue.queue.called).to.be.false
-    })
-
-    it('queues and returns a stale definition', async () => {
-      const definition = { coordinates: 'test', _meta: { schemaVersion: '0.0.1' } }
-      const result = await upgrader.validate(definition)
-      expect(result).to.deep.equal(definition)
-      expect(queue.queue.calledOnce).to.be.true
+      const message = await queue.dequeue()
+      const coordinates = message.data.coordinates
+      expect(coordinates).to.deep.equal(staleDef.coordinates)
     })
   })
 })

--- a/test/providers/upgrade/defUpgradeQueue.js
+++ b/test/providers/upgrade/defUpgradeQueue.js
@@ -1,0 +1,86 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const chaiAsPromised = require('chai-as-promised')
+const chai = require('chai')
+chai.use(chaiAsPromised)
+const { expect } = require('chai')
+const sinon = require('sinon')
+const DefinitionQueueUpgrader = require('../../../providers/upgrade/defUpgradeQueue')
+
+describe('DefinitionQueueUpgrader', () => {
+  const definition = { coordinates: 'test', _meta: { schemaVersion: '1.0.0' } }
+  let queue, upgrader
+
+  beforeEach(async () => {
+    const logger = { debug: sinon.stub() }
+    queue = {
+      queue: sinon.stub().resolves(),
+      initialize: sinon.stub().resolves()
+    }
+    const queueFactory = sinon.stub().returns(queue)
+    upgrader = new DefinitionQueueUpgrader({ logger, queue: queueFactory })
+  })
+
+  it('returns an instance of DefinitionQueueUpgrader', () => {
+    expect(upgrader).to.be.an.instanceOf(DefinitionQueueUpgrader)
+  })
+
+  it('sets and gets current schema version', () => {
+    upgrader.currentSchema = '1.0.0'
+    expect(upgrader.currentSchema).to.equal('1.0.0')
+  })
+
+  it('initializes', async () => {
+    await upgrader.initialize()
+    expect(queue.initialize.calledOnce).to.be.true
+  })
+
+  it('connects to queue after setupProcessing', async () => {
+    await upgrader.initialize()
+    const definitionService = { currentSchema: '1.0.0' }
+    const logger = { debug: sinon.stub() }
+    queue.dequeueMultiple = sinon.stub().resolves([])
+    upgrader.setupProcessing(definitionService, logger, true)
+    expect(queue.dequeueMultiple.calledOnce).to.be.true
+  })
+
+  context('validate', () => {
+    it('fails if current schema version is not set', async () => {
+      await expect(upgrader.validate(definition)).to.be.rejectedWith(Error)
+    })
+
+    it('fails if it is not initialized', async () => {
+      upgrader.currentSchema = '1.0.0'
+      const stale = { coordinates: 'test', _meta: { schemaVersion: '0.0.1' } }
+      await expect(upgrader.validate(stale)).to.be.rejectedWith(Error)
+    })
+  })
+
+  context('validate after set up', () => {
+    beforeEach(async () => {
+      await upgrader.initialize()
+      upgrader.currentSchema = '1.0.0'
+    })
+
+    it('does not queue null definition', async () => {
+      const result = await upgrader.validate(null)
+      expect(result).to.be.not.ok
+      expect(queue.queue.called).to.be.false
+    })
+
+    it('does not queue an up-to-date definition', async () => {
+      const definition = { coordinates: 'test', _meta: { schemaVersion: '1.0.0' } }
+      const result = await upgrader.validate(definition)
+      expect(result).to.deep.equal(definition)
+      expect(queue.queue.called).to.be.false
+    })
+
+    it('queues and returns a stale definition', async () => {
+      const definition = { coordinates: 'test', _meta: { schemaVersion: '0.0.1' } }
+      const result = await upgrader.validate(definition)
+      expect(result).to.deep.equal(definition)
+      expect(queue.queue.calledOnce).to.be.true
+    })
+  })
+})

--- a/test/providers/upgrade/defVersionCheck.js
+++ b/test/providers/upgrade/defVersionCheck.js
@@ -1,0 +1,76 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const chaiAsPromised = require('chai-as-promised')
+const chai = require('chai')
+chai.use(chaiAsPromised)
+const { expect } = require('chai')
+const sinon = require('sinon')
+const { DefinitionVersionChecker, factory } = require('../../../providers/upgrade/defVersionCheck')
+
+describe('DefinitionVersionChecker', () => {
+  let logger, checker
+  beforeEach(() => {
+    logger = { debug: sinon.stub() }
+    checker = new DefinitionVersionChecker({ logger })
+  })
+
+  it('returns an instance of DefinitionVersionChecker', () => {
+    expect(checker).to.be.an.instanceOf(DefinitionVersionChecker)
+  })
+
+  it('creates a new instance of DefinitionVersionChecker using factory', () => {
+    const checker = factory({ logger: logger })
+    expect(checker).to.be.an.instanceOf(DefinitionVersionChecker)
+  })
+
+  it('sets and gets current schema version', () => {
+    checker.currentSchema = '1.0.0'
+    expect(checker.currentSchema).to.equal('1.0.0')
+  })
+
+  it('initializes and returns undefined', async () => {
+    const result = await checker.initialize()
+    expect(result).to.be.not.ok
+  })
+
+  it('returns after setupProcessing', async () => {
+    const result = checker.setupProcessing()
+    expect(result).to.be.not.ok
+  })
+
+  it('throws an error in validate if current schema version is not set', async () => {
+    const definition = { _meta: { schemaVersion: '1.0.0' } }
+    await expect(checker.validate(definition)).to.be.rejectedWith(Error)
+  })
+
+  context('validate after current schema version is set', () => {
+    beforeEach(() => {
+      checker.currentSchema = '1.0.0'
+    })
+
+    it('returns the definition if it is up-to-date', async () => {
+      const definition = { _meta: { schemaVersion: '1.0.0' } }
+      const result = await checker.validate(definition)
+      expect(result).to.deep.equal(definition)
+    })
+
+    it('returns undefined for a stale definition', async () => {
+      const definition = { _meta: { schemaVersion: '0.1.0' } }
+      const result = await checker.validate(definition)
+      expect(result).to.be.undefined
+    })
+
+    it('returns undefined for a definition without schema version', async () => {
+      const definition = {}
+      const result = await checker.validate(definition)
+      expect(result).to.be.undefined
+    })
+
+    it('handles null', async () => {
+      checker.currentSchema = '1.0.0'
+      const result = await checker.validate(null)
+      expect(result).to.be.not.ok
+    })
+  })
+})

--- a/test/providers/upgrade/process.js
+++ b/test/providers/upgrade/process.js
@@ -1,0 +1,103 @@
+// (c) Copyright 2024, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const sinon = require('sinon')
+const { QueueHandler, DefinitionUpgrader } = require('../../../providers/upgrade/process')
+
+describe('Definition Upgrade Queue Processing', () => {
+  describe('QueueHandler', () => {
+    let logger, queue, messageHandler, handler
+    beforeEach(() => {
+      logger = {
+        info: sinon.stub(),
+        error: sinon.stub()
+      }
+      queue = {
+        dequeueMultiple: sinon.stub(),
+        delete: sinon.stub().resolves()
+      }
+      messageHandler = {
+        processMessage: sinon.stub()
+      }
+      handler = new QueueHandler(queue, logger, messageHandler)
+    })
+
+    it('should return an instance of QueueHandler', () => {
+      expect(handler).to.be.an.instanceOf(QueueHandler)
+    })
+
+    it('should work on a queue', () => {
+      queue.dequeueMultiple.resolves([])
+      handler.work(true)
+      expect(queue.dequeueMultiple.calledOnce).to.be.true
+      expect(messageHandler.processMessage.notCalled).to.be.true
+      expect(queue.delete.notCalled).to.be.true
+    })
+
+    it('should process one message', async () => {
+      queue.dequeueMultiple.resolves([{ message: 'test' }])
+      await handler.work(true)
+      expect(queue.dequeueMultiple.calledOnce).to.be.true
+      expect(messageHandler.processMessage.calledOnce).to.be.true
+      expect(queue.delete.calledOnce).to.be.true
+    })
+
+    it('should process multiple messages', async () => {
+      queue.dequeueMultiple.resolves([{ message: 'testA' }, { message: 'testB' }])
+      await handler.work(true)
+      expect(queue.dequeueMultiple.calledOnce).to.be.true
+      expect(messageHandler.processMessage.calledTwice).to.be.true
+      expect(queue.delete.calledTwice).to.be.true
+    })
+
+    it('should log error and not delete the message', async () => {
+      queue.dequeueMultiple.resolves([{ message: 'testA' }, { message: 'testB' }])
+      messageHandler.processMessage = sinon.stub().onFirstCall().throws().onSecondCall().resolves()
+      await handler.work(true)
+      expect(queue.dequeueMultiple.calledOnce).to.be.true
+      expect(messageHandler.processMessage.calledTwice).to.be.true
+      expect(queue.delete.calledOnce).to.be.true
+      expect(logger.error.calledOnce).to.be.true
+    })
+  })
+
+  describe('DefinitionUpgrader', () => {
+    const definition = { coordinates: 'pypi/pypi/-/test/revision' }
+    let logger, definitionService, versionChecker, upgrader
+    beforeEach(() => {
+      logger = {
+        info: sinon.stub(),
+        debug: sinon.stub()
+      }
+      definitionService = {
+        getStored: sinon.stub(),
+        computeStoreAndCurate: sinon.stub().resolves()
+      }
+      versionChecker = {
+        validate: sinon.stub()
+      }
+      upgrader = new DefinitionUpgrader(definitionService, logger, versionChecker)
+    })
+
+    it('should recompute a definition', async () => {
+      definitionService.getStored.resolves(definition)
+      versionChecker.validate.resolves()
+
+      await upgrader.processMessage({ data: { coordinates: 'pypi/pypi/-/test/revision' } })
+      expect(definitionService.getStored.calledOnce).to.be.true
+      expect(versionChecker.validate.calledOnce).to.be.true
+      expect(definitionService.computeStoreAndCurate.calledOnce).to.be.true
+    })
+
+    it('should skip compute when a definition is up-to-date', async () => {
+      definitionService.getStored.resolves(definition)
+      versionChecker.validate.resolves(definition)
+
+      await upgrader.processMessage({ data: { coordinates: 'pypi/pypi/-/test/revision' } })
+      expect(definitionService.getStored.calledOnce).to.be.true
+      expect(versionChecker.validate.calledOnce).to.be.true
+      expect(definitionService.computeStoreAndCurate.notCalled).to.be.true
+    })
+  })
+})


### PR DESCRIPTION

**Performance Degradation During Schema Version Upgrade**

During the process of upgrading the definition schema version, performance degradation has been observed. Currently, schema version updates are handled by recomputing the definition on the fly, which causes slower performance. These updates are critical for data correctness and to introduce the LicenseRef marker.

**Proposed Solution:**

1. **Current Implementation (versionCheck):**
- Checks the schema version and recomputes the definition on demand if it is stale.
- This approach is currently in production.

2. **Preferred Approach (upgradeQueue):**
- When a request is received, return the existing definition.
- If the schema has changed, trigger a recompute after returning the result.
- Use a queue to handle the upgrade, similar to how the service computes definitions for harvested components.
- This allows the system to function more smoothly without immediate performance degradation.
- The tech steering committee has agreed on this approach (discussed on Nov 26).

3. **Switching Methods:**
- Once the majority of the migration is complete, the system can switch back to calculating on the fly via configuration.

**PR Details:**

This PR introduces two implementations for the upgrade handler:
- **versionCheck:** Current implementation in production.
- **upgradeQueue:** Preferred approach as described above.

**Environment Variables:**
- **DEFINITION_UPGRADE_PROVIDER:** Controls the upgrade behavior (versionCheck, upgradeQueue) with `versionCheck` as the default.
- **DEFINITION_UPGRADE_QUEUE_PROVIDER:** Controls the queuing of upgrades (memory, azure) with `memory` as the default.
- **DEFINITION_UPGRADE_QUEUE_CONNECTION_STRING:** Connection string to the Azure Storage Queue.
- If not present, `HARVEST_AZBLOB_CONNECTION_STRING` is used for connection information.
- **DEFINITION_UPGRADE_QUEUE_NAME:** Name of the upgrade queue, defaulting to `definitions-upgrade`.