### PR TITLE
Adjust logging and allow configuration of batch size for dequeueMultiple

### DIFF
--- a/providers/upgrade/azureQueueConfig.js
+++ b/providers/upgrade/azureQueueConfig.js
@@ -9,7 +9,7 @@ const defaultOptions = {
     config.get('DEFINITION_UPGRADE_QUEUE_CONNECTION_STRING') || config.get('HARVEST_AZBLOB_CONNECTION_STRING'),
   queueName: config.get('DEFINITION_UPGRADE_QUEUE_NAME') || 'definitions-upgrade',
   dequeueOptions: {
-    numOfMessages: 32,
+    numOfMessages: config.get('DEFINITION_UPGRADE_DEQUEUE_BATCH_SIZE') || 16,
     visibilityTimeout: 10 * 60 // 10 min. The default value is 30 seconds.
   }
 }

--- a/providers/upgrade/defUpgradeQueue.js
+++ b/providers/upgrade/defUpgradeQueue.js
@@ -19,12 +19,12 @@ class DefinitionQueueUpgrader extends DefinitionVersionChecker {
     try {
       const message = this._constructMessage(definition)
       await this._upgrade.queue(message)
-      this.logger.debug('Queued for definition upgrade ', {
+      this.logger.info('Queued for definition upgrade ', {
         coordinates: DefinitionVersionChecker.getCoordinates(definition)
       })
     } catch (error) {
-      //continue if queuing fails and requeue at the next request.
-      this.logger.error(`Error queuing for definition upgrade ${error.message}`, {
+      //continue if queueing fails and requeue at the next request.
+      this.logger.error(`Error queueing for definition upgrade ${error.message}`, {
         error,
         coordinates: DefinitionVersionChecker.getCoordinates(definition)
       })

--- a/providers/upgrade/process.js
+++ b/providers/upgrade/process.js
@@ -67,13 +67,20 @@ class DefinitionUpgrader {
   }
 
   async _upgradeIfNecessary(coordinates) {
-    const existing = await this._definitionService.getStored(coordinates)
-    let result = await this._defVersionChecker.validate(existing)
-    if (!result) {
-      await this._definitionService.computeStoreAndCurate(coordinates)
-      this.logger.info(`Handled definition update for ${coordinates.toString()}`)
-    } else {
-      this.logger.debug(`Skipped definition update for ${coordinates.toString()}`)
+    try {
+      const existing = await this._definitionService.getStored(coordinates)
+      let result = await this._defVersionChecker.validate(existing)
+      if (!result) {
+        await this._definitionService.computeStoreAndCurate(coordinates)
+        this.logger.info('Handled definition upgrade for %s', coordinates)
+      } else {
+        this.logger.debug('Skipped definition upgrade for %s', coordinates)
+      }
+    } catch (error) {
+      const context = `Error handling definition upgrade for ${coordinates.toString()}`
+      const newError = new Error(`${context}: ${error.message}`)
+      newError.stack = error.stack
+      throw newError
     }
   }
 }

--- a/test/providers/upgrade/defUpgradeQueue.js
+++ b/test/providers/upgrade/defUpgradeQueue.js
@@ -10,7 +10,10 @@ const DefinitionQueueUpgrader = require('../../../providers/upgrade/defUpgradeQu
 const MemoryQueue = require('../../../providers/upgrade/memoryQueueConfig')
 
 describe('DefinitionQueueUpgrader', () => {
-  const logger = { debug: sinon.stub(), error: sinon.stub() }
+  let logger
+  beforeEach(() => {
+    logger = { debug: sinon.stub(), error: sinon.stub() }
+  })
 
   describe('Unit tests', () => {
     const definition = { coordinates: 'test', _meta: { schemaVersion: '1.0.0' } }


### PR DESCRIPTION
-Adjust logging
-Add context information to errors thrown during definition recomputation. 
-Add more tests
-Introduce DEFINITION_UPGRADE_DEQUEUE_BATCH_SIZE