### PR TITLE
Pin runner version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Recently, ubuntu-latest is updated to ubuntu-24.04 (see https://github.com/actions/runner-images/blob/main/README.md).  This caused tests failures.  Pin runner version to ubuntu-22.04 as a resolution.

A successful test run can be found [here](https://github.com/qtomlinson/service/actions/runs/12757896561)