### PR TITLE
Update pypi base url

### DIFF
--- a/lib/pypiCoordinatesMapper.js
+++ b/lib/pypiCoordinatesMapper.js
@@ -6,7 +6,7 @@ const EntityCoordinates = require('./entityCoordinates')
 
 class PypiCoordinatesMapper {
   constructor(fetch = requestPromise) {
-    this.baseUrl = 'https://pypi.python.org'
+    this.baseUrl = 'https://pypi.org'
     this._fetch = fetch
   }
 
@@ -23,7 +23,8 @@ class PypiCoordinatesMapper {
 
   async _resolve(coordinates) {
     if (coordinates.name === '..') return null
-    const url = new URL(`/pypi/${coordinates.name}/json`, this.baseUrl).toString()
+    const encodedName = encodeURIComponent(coordinates.name)
+    const url = new URL(`/pypi/${encodedName}/json`, this.baseUrl).toString()
     try {
       const answer = await this._fetch({ url, method: 'GET', json: true })
       return answer?.info?.name && { name: answer.info.name }

--- a/routes/originPyPi.js
+++ b/routes/originPyPi.js
@@ -28,7 +28,7 @@ router.get(
   })
 )
 async function getPypiData(name) {
-  const url = `https://pypi.python.org/pypi/${encodeURIComponent(name)}/json`
+  const url = `https://pypi.org/pypi/${encodeURIComponent(name)}/json`
   try {
     return await requestPromise({ url, method: 'GET', json: true })
   } catch (error) {


### PR DESCRIPTION
Based on docs at https://packaging.python.org/en/latest/guides/migrating-to-pypi-org/, "the default interface for browsing packages is pypi.org. The domain pypi.python.org now redirects to pypi.org, and may be disabled sometime in the future."

Also see pypi json api documentation at https://docs.pypi.org/api/json/

Update the urls for the pypi json api in originPypi and pypiCoordinatesMapper to reflect this.