### PR TITLE
Optimize Queueing and Definition Retrieval for Component Requested For Harvest

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,9 +28,12 @@ function createApp(config) {
 
   const summaryService = require('./business/summarizer')(config.summary)
 
+  const cachingService = config.caching.service()
+  initializers.push(async () => cachingService.initialize())
+
   const harvestStore = config.harvest.store()
   initializers.push(async () => harvestStore.initialize())
-  const harvestService = config.harvest.service()
+  const harvestService = config.harvest.service({ cachingService })
   const harvestRoute = require('./routes/harvest')(harvestService, harvestStore, summaryService)
 
   const aggregatorService = require('./business/aggregator')(config.aggregator)
@@ -46,9 +49,6 @@ function createApp(config) {
 
   const searchService = config.search.service()
   initializers.push(async () => searchService.initialize())
-
-  const cachingService = config.caching.service()
-  initializers.push(async () => cachingService.initialize())
 
   const curationService = config.curation.service(null, curationStore, config.endpoints, cachingService, harvestStore)
 

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -278,6 +278,7 @@ class DefinitionService {
   async _store(definition) {
     await this.definitionStore.store(definition)
     await this._setDefinitionInCache(this._getCacheKey(definition.coordinates), definition)
+    await this.harvestService.done(definition)
   }
 
   /**

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -78,7 +78,7 @@ class DefinitionService {
     if (result) {
       // Log line used for /status page insights
       this.logger.info('computed definition available', { coordinates: coordinates.toString() })
-    } else if (!force && (await this.harvestService.isTracked({ coordinates }))) {
+    } else if (!force && (await this.harvestService.isTracked(coordinates))) {
       this.logger.info('definition harvest in progress', { coordinates: coordinates.toString() })
       return this._computePlaceHolder(coordinates)
     } else result = force ? await this.computeAndStore(coordinates) : await this.computeStoreAndCurate(coordinates)
@@ -281,7 +281,7 @@ class DefinitionService {
   async _store(definition) {
     await this.definitionStore.store(definition)
     await this._setDefinitionInCache(this._getCacheKey(definition.coordinates), definition)
-    await this.harvestService.done(definition)
+    await this.harvestService.done(definition.coordinates)
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
       },
       "devDependencies": {
         "@types/express": "4.17.17",
+        "@types/lodash": "4.17.16",
         "@types/mocha": "8.2.3",
         "@types/node": "18.15.11",
         "chai": "^4.1.2",
@@ -2718,6 +2719,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@types/express": "4.17.17",
+    "@types/lodash": "4.17.16",
     "@types/mocha": "8.2.3",
     "@types/node": "18.15.11",
     "chai": "^4.1.2",

--- a/providers/harvest/cacheBasedCrawler.js
+++ b/providers/harvest/cacheBasedCrawler.js
@@ -3,6 +3,7 @@
 // @ts-check
 const logger = require('../logging/logger')
 const throat = require('throat')
+const { uniqBy, isEqual } = require('lodash')
 
 const cacheTTLInSeconds = 60 * 60 * 24 /* 1d */
 const concurrencyLimit = 10
@@ -10,7 +11,7 @@ const concurrencyLimit = 10
 /**
  *  @typedef {Object} Harvester
  *  @property {function} harvest - Function to harvest entries.
- *  @property {function} toUrl - Function to convert entry to URL.
+ *  @property {function} toHarvestItem - Function to convert entry to URL.
  */
 
 /**
@@ -46,6 +47,7 @@ class CacheBasedHarvester {
     this._cache = options.cachingService
     this._harvester = options.harvester
     this.concurrencyLimit = options.concurrencyLimit || concurrencyLimit
+    this.cacheTTLInSeconds = options.cacheTTLInSeconds || cacheTTLInSeconds
   }
 
   /**
@@ -54,7 +56,7 @@ class CacheBasedHarvester {
    */
   async harvest(spec, turbo) {
     const entries = Array.isArray(spec) ? spec : [spec]
-    const uniqueEntries = this._filterOutDuplicates(entries)
+    const uniqueEntries = this._filterOutDuplicatedCoordinates(entries)
     const harvests = await this._filterOutTracked(uniqueEntries)
     if (!harvests.length) {
       this.logger.debug('No new harvests to process.')
@@ -72,7 +74,7 @@ class CacheBasedHarvester {
     const results = await Promise.allSettled(
       harvestEntries.map(
         throat(this.concurrencyLimit, async entry => {
-          await this._track(entry.coordinates)
+          await this._track(entry)
         })
       )
     )
@@ -87,29 +89,27 @@ class CacheBasedHarvester {
    */
   async _filterOutTracked(entries) {
     const filteredEntries = await Promise.all(
-      entries.map(
-        throat(this.concurrencyLimit, async entry => {
-          const tracked = await this.isTracked(entry?.coordinates)
-          return tracked ? null : entry
-        })
-      )
+      entries.map(throat(this.concurrencyLimit, async entry => ((await this._isTrackedHarvest(entry)) ? null : entry)))
     )
     //@ts-ignore
-    return filteredEntries.filter(e => e !== null)
+    return filteredEntries.filter(e => e)
+  }
+
+  async _isTrackedHarvest(entry) {
+    const newHarvest = this._getHarvest(entry)
+    const { harvests: trackedHarvests } = await this._getTrackedForCoordinates(entry.coordinates)
+    const isTracked = trackedHarvests.some(harvest => isEqual(harvest, newHarvest))
+    if (isTracked) this.logger.debug('Entry with coordinates %s is already tracked.', entry.coordinates)
+    return isTracked
   }
 
   /**
    * @param {HarvestEntry[]} entries - Array of entries to filter.
    * @returns {HarvestEntry[]} - An array of entries with unique coordinates.
    */
-  _filterOutDuplicates(entries) {
-    if (entries.length === 0) return []
-    const uniqueEntries = new Map()
-    for (const entry of entries) {
-      const key = this._getCacheKey(entry?.coordinates)
-      if (key) uniqueEntries.set(key, entry)
-    }
-    return Array.from(uniqueEntries.values())
+  _filterOutDuplicatedCoordinates(entries) {
+    const validEntries = entries.filter(entry => entry?.coordinates)
+    return uniqBy(validEntries, entry => this._getCacheKey(entry?.coordinates))
   }
 
   /**
@@ -117,28 +117,40 @@ class CacheBasedHarvester {
    * @returns {Promise<boolean>} - A promise that resolves to true if the coordinates is tracked, false otherwise.
    */
   async isTracked(coordinates) {
-    const cacheKey = this._getCacheKey(coordinates)
-    if (!cacheKey) return false
+    const { harvests: trackedHarvests }  = await this._getTrackedForCoordinates(coordinates)
+    return trackedHarvests.length > 0
+  }
+
+  async _getTrackedForCoordinates(coordinates) {
+    const key = this._getCacheKey(coordinates)
+    const harvests = await this._getCached(key)
+    return { key, harvests }
+  }
+
+  async _getCached(key) {
+    if (!key) return []
     try {
-      const cached = await this._cache.get(cacheKey)
-      return cached || false
+      const harvests = await this._cache.get(key)
+      return harvests || []
     } catch (error) {
-      this.logger.error(`Error checking tracking status for ${cacheKey}:`, error)
-      return false
+      this.logger.error(`Error checking tracked harvests for ${key}:`, error)
+      return []
     }
   }
 
   /**
-   * @param {Coordinates} coordinates - The entry to track.
+   * @param {HarvestEntry} entry - The entry to track.
    * @returns {Promise<void>} - A promise that resolves when the cache is set.
    */
-  async _track(coordinates) {
-    const cacheKey = this._getCacheKey(coordinates)
-    if (!cacheKey) return
+  async _track(entry) {
+    const newHarvest = this._getHarvest(entry)
+    const { key, harvests } = await this._getTrackedForCoordinates(entry.coordinates)
     try {
-      await this._cache.set(cacheKey, true, cacheTTLInSeconds)
+      harvests.push(newHarvest)
+      await this._cache.set(key, harvests, this.cacheTTLInSeconds)
+      this.logger.debug(`Cached ${key} with ${harvests.length} harvests.`)
     } catch (error) {
-      this.logger.error(`Error caching ${cacheKey}:`, error)
+      this.logger.error(`Error caching ${key}:`, error)
     }
   }
 
@@ -151,6 +163,7 @@ class CacheBasedHarvester {
     if (!cacheKey) return
     try {
       await this._cache.delete(cacheKey)
+      this.logger.debug(`Removed cache for ${cacheKey}.`)
     } catch (error) {
       this.logger.error(`Error removing cache for ${cacheKey}:`, error)
     }
@@ -161,8 +174,12 @@ class CacheBasedHarvester {
    * @returns {string} - The cache key.
    */
   _getCacheKey(coordinates) {
-    const url = coordinates && this._harvester.toUrl(coordinates)
-    return url && `hrv_${url}`
+    //Cache key is generated from the coordinates, same as in definition service.
+    return coordinates && `hrv_${coordinates.toString().toLowerCase()}`
+  }
+
+  _getHarvest(entry) {
+    return entry && this._harvester.toHarvestItem(entry)
   }
 }
 

--- a/providers/harvest/cacheBasedCrawler.js
+++ b/providers/harvest/cacheBasedCrawler.js
@@ -1,13 +1,46 @@
 // (c) Copyright 2025, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
-
+// @ts-check
 const logger = require('../logging/logger')
 const throat = require('throat')
 
 const cacheTTLInSeconds = 60 * 60 * 24 /* 1d */
 const concurrencyLimit = 10
 
+/**
+ *  @typedef {Object} Harvester
+ *  @property {function} harvest - Function to harvest entries.
+ *  @property {function} toUrl - Function to convert entry to URL.
+ */
+
+/**
+ * @typedef {Object} CachingService
+ * @property {function} get - Function to get a value from the cache.
+ * @property {function} set - Function to set a value in the cache.
+ * @property {function} delete - Function to delete a value from the cache.
+ */
+
+/**
+ * @typedef {Object} Options
+ * @property {Object} [logger] - Optional logger instance.
+ * @property {CachingService} cachingService - Caching service instance.
+ * @property {Harvester} harvester - Harvester instance.
+ * @property {number} [concurrencyLimit] - Optional concurrency limit.
+ */
+
+/**
+ * @typedef {Object} HarvestEntry
+ * @property {Object} coordinates
+ */
+
+/**
+ * @typedef {Object} Coordinates
+ */
+
 class CacheBasedHarvester {
+  /**
+   * @param {Options} options
+   */
   constructor(options) {
     this.logger = options.logger || logger()
     this._cache = options.cachingService
@@ -15,6 +48,10 @@ class CacheBasedHarvester {
     this.concurrencyLimit = options.concurrencyLimit || concurrencyLimit
   }
 
+  /**
+   * @param {*} spec - The spec to harvest. Can be a single entry or an array of entries.
+   * @param {boolean} turbo - If true, harvest in turbo mode.
+   */
   async harvest(spec, turbo) {
     const entries = Array.isArray(spec) ? spec : [spec]
     const harvests = await this._filterOutTracked(entries)
@@ -27,26 +64,45 @@ class CacheBasedHarvester {
     await this._trackHarvests(harvests)
   }
 
-  async _trackHarvests(harvestItems) {
+  /**
+   * @param {HarvestEntry[]} harvestEntries - Array of items to track.
+   */
+  async _trackHarvests(harvestEntries) {
     const results = await Promise.allSettled(
-      harvestItems.map(
+      harvestEntries.map(
         throat(this.concurrencyLimit, async entry => {
-          await this._track(entry)
+          await this._track(entry.coordinates)
         })
       )
     )
-    results.filter(result => result.status === 'rejected').forEach(result => this.logger.error(result.reason))
+    results.forEach(result => {
+      if (result.status === 'rejected') this.logger.error(result.reason)
+    })
   }
 
+  /**
+   * @param {HarvestEntry[]} entries - Array of entries to filter.
+   * @returns {Promise<HarvestEntry[]>} - A promise that resolves to an array of entries that are not tracked.
+   */
   async _filterOutTracked(entries) {
     const filteredEntries = await Promise.all(
-      entries.map(throat(this.concurrencyLimit, async entry => ((await this.isTracked(entry)) ? null : entry)))
+      entries.map(
+        throat(this.concurrencyLimit, async entry => {
+          const tracked = await this.isTracked(entry?.coordinates)
+          return tracked ? null : entry
+        })
+      )
     )
-    return filteredEntries.filter(e => e)
+    //@ts-ignore
+    return filteredEntries.filter(e => e !== null)
   }
 
-  async isTracked(entry) {
-    const cacheKey = this._getCacheKey(entry)
+  /**
+   * @param {Coordinates} coordinates - The coordinates to check.
+   * @returns {Promise<boolean>} - A promise that resolves to true if the coordinates is tracked, false otherwise.
+   */
+  async isTracked(coordinates) {
+    const cacheKey = this._getCacheKey(coordinates)
     if (!cacheKey) return false
     try {
       const cached = await this._cache.get(cacheKey)
@@ -57,30 +113,45 @@ class CacheBasedHarvester {
     }
   }
 
-  async _track(entry) {
-    const cacheKey = this._getCacheKey(entry)
+  /**
+   * @param {Coordinates} coordinates - The entry to track.
+   * @returns {Promise<void>} - A promise that resolves when the cache is set.
+   */
+  async _track(coordinates) {
+    const cacheKey = this._getCacheKey(coordinates)
     if (!cacheKey) return
     try {
       await this._cache.set(cacheKey, true, cacheTTLInSeconds)
     } catch (error) {
-      this.logger.error(`Error caching coordinates ${cacheKey}:`, error)
+      this.logger.error(`Error caching ${cacheKey}:`, error)
     }
   }
 
-  async done(entry) {
-    const cacheKey = this._getCacheKey(entry)
+  /**
+   * @param {Coordinates} coordinates - The entry to remove from the cache.
+   * @returns {Promise<void>} - A promise that resolves when the cache is removed.
+   */
+  async done(coordinates) {
+    const cacheKey = this._getCacheKey(coordinates)
     if (!cacheKey) return
     try {
       await this._cache.delete(cacheKey)
     } catch (error) {
-      this.logger.error(`Error removing cache for coordinates ${cacheKey}:`, error)
+      this.logger.error(`Error removing cache for ${cacheKey}:`, error)
     }
   }
 
-  _getCacheKey(entry) {
-    const url = this._harvester.toUrl(entry)
+  /**
+   * @param {Coordinates} coordinates - The coordinates to generate a cache key for.
+   * @returns {string} - The cache key.
+   */
+  _getCacheKey(coordinates) {
+    const url = this._harvester.toUrl(coordinates)
     return url && `hrv_${url}`
   }
 }
 
+/**
+ * @param {Options} options
+ */
 module.exports = options => new CacheBasedHarvester(options)

--- a/providers/harvest/cacheBasedCrawler.js
+++ b/providers/harvest/cacheBasedCrawler.js
@@ -1,0 +1,81 @@
+// (c) Copyright 2025, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const logger = require('../logging/logger')
+const throat = require('throat')
+
+const cacheTTLInSeconds = 60 * 60 * 24 /* 1d */
+const concurrencyLimit = 10
+
+class CacheBasedHarvester {
+  constructor(options) {
+    this.logger = options.logger || logger()
+    this._cache = options.cache
+    this._harvester = options.harvester
+    this.concurrencyLimit = options.concurrencyLimit || concurrencyLimit
+  }
+
+  async harvest(spec, turbo) {
+    const entries = Array.isArray(spec) ? spec : [spec]
+    const harvests = await this._filterOutTracked(entries)
+    this.logger.debug(`Starting harvest for ${harvests.length} entries.`)
+    await this._harvester.harvest(harvests, turbo)
+    await this._trackHarvests(harvests)
+  }
+
+  async _trackHarvests(harvestItems) {
+    const results = await Promise.allSettled(
+      harvestItems.map(
+        throat(this.concurrencyLimit, async entry => {
+          await this._track(entry)
+        })
+      )
+    )
+    results.filter(result => result.status === 'rejected').forEach(result => this.logger.error(result.reason))
+  }
+
+  async _filterOutTracked(entries) {
+    const filteredEntries = await Promise.all(
+      entries.map(throat(this.concurrencyLimit, async entry => ((await this.isTracked(entry)) ? null : entry)))
+    )
+    return filteredEntries.filter(e => e)
+  }
+
+  async isTracked(entry) {
+    const cacheKey = this._getCacheKey(entry)
+    if (!cacheKey) return false
+    try {
+      return (await this._cache.get(cacheKey)) || false
+    } catch (error) {
+      this.logger.error(`Error checking tracking status for ${cacheKey}:`, error)
+      return false
+    }
+  }
+
+  async _track(entry) {
+    const cacheKey = this._getCacheKey(entry)
+    if (!cacheKey) return
+    try {
+      await this._cache.set(cacheKey, true, cacheTTLInSeconds)
+    } catch (error) {
+      this.logger.error(`Error caching coordinates ${cacheKey}:`, error)
+    }
+  }
+
+  async done(entry) {
+    const cacheKey = this._getCacheKey(entry)
+    if (!cacheKey) return
+    try {
+      await this._cache.delete(cacheKey)
+    } catch (error) {
+      this.logger.error(`Error removing cache for coordinates ${cacheKey}:`, error)
+    }
+  }
+
+  _getCacheKey(entry) {
+    const url = this._harvester.toUrl(entry)
+    return url && `hrv_${url}`
+  }
+}
+
+module.exports = options => new CacheBasedHarvester(options)

--- a/providers/harvest/crawler.js
+++ b/providers/harvest/crawler.js
@@ -32,7 +32,7 @@ class CrawlingHarvester {
   }
 
   toUrl(coordinates) {
-    return coordinates?.toString().replace(/[/]+/g, '/')
+    return coordinates.toString().replace(/[/]+/g, '/')
   }
 }
 

--- a/providers/harvest/crawler.js
+++ b/providers/harvest/crawler.js
@@ -17,7 +17,7 @@ class CrawlingHarvester {
     const body = (Array.isArray(spec) ? spec : [spec]).map(entry => {
       return {
         type: entry.tool || 'component',
-        url: `cd:/${this.toUrl(entry)}`,
+        url: `cd:/${this.toUrl(entry.coordinates)}`,
         policy: entry.policy
       }
     })
@@ -31,8 +31,8 @@ class CrawlingHarvester {
     })
   }
 
-  toUrl(entry) {
-    return entry?.coordinates?.toString().replace(/[/]+/g, '/')
+  toUrl(coordinates) {
+    return coordinates?.toString().replace(/[/]+/g, '/')
   }
 }
 

--- a/providers/harvest/crawler.js
+++ b/providers/harvest/crawler.js
@@ -17,7 +17,7 @@ class CrawlingHarvester {
     const body = (Array.isArray(spec) ? spec : [spec]).map(entry => {
       return {
         type: entry.tool || 'component',
-        url: `cd:/${entry.coordinates.toString().replace(/[/]+/g, '/')}`,
+        url: `cd:/${this.toUrl(entry)}`,
         policy: entry.policy
       }
     })
@@ -29,6 +29,10 @@ class CrawlingHarvester {
       headers,
       json: true
     })
+  }
+
+  toUrl(entry) {
+    return entry?.coordinates?.toString().replace(/[/]+/g, '/')
   }
 }
 

--- a/providers/harvest/crawler.js
+++ b/providers/harvest/crawler.js
@@ -14,13 +14,7 @@ class CrawlingHarvester {
     const headers = {
       'X-token': this.options.authToken
     }
-    const body = (Array.isArray(spec) ? spec : [spec]).map(entry => {
-      return {
-        type: entry.tool || 'component',
-        url: `cd:/${this.toUrl(entry.coordinates)}`,
-        policy: entry.policy
-      }
-    })
+    const body = (Array.isArray(spec) ? spec : [spec]).map(entry => this.toHarvestItem(entry))
     const url = turbo ? `${this.options.url}/requests` : `${this.options.url}/requests/later`
     return requestPromise({
       url,
@@ -31,8 +25,12 @@ class CrawlingHarvester {
     })
   }
 
-  toUrl(coordinates) {
-    return coordinates.toString().replace(/[/]+/g, '/')
+  toHarvestItem(entry) {
+    return {
+      type: entry.tool || 'component',
+      url: `cd:/${entry.coordinates.toString().replace(/[/]+/g, '/')}`,
+      policy: entry.policy
+    }
   }
 }
 

--- a/providers/harvest/crawlerConfig.js
+++ b/providers/harvest/crawlerConfig.js
@@ -3,13 +3,17 @@
 
 const config = require('painless-config')
 const crawler = require('./crawler')
+const cacheBasedCrawler = require('./cacheBasedCrawler')
+
+const defaultOpts = {
+  authToken: config.get('CRAWLER_API_AUTH_TOKEN'),
+  url: config.get('CRAWLER_API_URL') || 'http://localhost:5000'
+}
 
 function serviceFactory(options) {
-  const realOptions = options || {
-    authToken: config.get('CRAWLER_API_AUTH_TOKEN'),
-    url: config.get('CRAWLER_API_URL') || 'http://localhost:5000'
-  }
-  return crawler(realOptions)
+  const crawlerOptions = { ...defaultOpts, ...options }
+  const harvester = crawler(crawlerOptions)
+  return cacheBasedCrawler({ ...options, harvester })
 }
 
 module.exports = serviceFactory

--- a/providers/harvest/crawlerQueue.js
+++ b/providers/harvest/crawlerQueue.js
@@ -28,7 +28,7 @@ class CrawlingQueueHarvester {
   }
 
   toUrl(coordinates) {
-    return coordinates?.toString().replace(/[/]+/g, '/')
+    return coordinates.toString().replace(/[/]+/g, '/')
   }
 }
 

--- a/providers/harvest/crawlerQueue.js
+++ b/providers/harvest/crawlerQueue.js
@@ -15,7 +15,7 @@ class CrawlingQueueHarvester {
     for (let entry of entries) {
       let message = JSON.stringify({
         type: entry.tool || 'component',
-        url: `cd:/${entry.coordinates.toString().replace(/[/]+/g, '/')}`,
+        url: `cd:/${this.toUrl(entry)}`,
         policy: entry.policy || {
           fetch: 'mutables',
           freshness: 'match',
@@ -26,6 +26,11 @@ class CrawlingQueueHarvester {
       else this.laterQueue.queue(message)
     }
   }
+
+  toUrl(entry) {
+    return entry?.coordinates?.toString().replace(/[/]+/g, '/')
+  }
+
 }
 
 module.exports = options => new CrawlingQueueHarvester(options)

--- a/providers/harvest/crawlerQueue.js
+++ b/providers/harvest/crawlerQueue.js
@@ -30,7 +30,6 @@ class CrawlingQueueHarvester {
   toUrl(entry) {
     return entry?.coordinates?.toString().replace(/[/]+/g, '/')
   }
-
 }
 
 module.exports = options => new CrawlingQueueHarvester(options)

--- a/providers/harvest/crawlerQueue.js
+++ b/providers/harvest/crawlerQueue.js
@@ -15,7 +15,7 @@ class CrawlingQueueHarvester {
     for (let entry of entries) {
       let message = JSON.stringify({
         type: entry.tool || 'component',
-        url: `cd:/${this.toUrl(entry)}`,
+        url: `cd:/${this.toUrl(entry.coordinates)}`,
         policy: entry.policy || {
           fetch: 'mutables',
           freshness: 'match',
@@ -27,8 +27,8 @@ class CrawlingQueueHarvester {
     }
   }
 
-  toUrl(entry) {
-    return entry?.coordinates?.toString().replace(/[/]+/g, '/')
+  toUrl(coordinates) {
+    return coordinates?.toString().replace(/[/]+/g, '/')
   }
 }
 

--- a/providers/harvest/crawlerQueue.js
+++ b/providers/harvest/crawlerQueue.js
@@ -13,22 +13,22 @@ class CrawlingQueueHarvester {
   async harvest(spec, turbo) {
     const entries = Array.isArray(spec) ? spec : [spec]
     for (let entry of entries) {
-      let message = JSON.stringify({
-        type: entry.tool || 'component',
-        url: `cd:/${this.toUrl(entry.coordinates)}`,
-        policy: entry.policy || {
-          fetch: 'mutables',
-          freshness: 'match',
-          map: { name: entry.tool || 'component', path: '/' }
-        }
-      })
+      let message = JSON.stringify(this.toHarvestItem(entry))
       if (turbo) this.normalQueue.queue(message)
       else this.laterQueue.queue(message)
     }
   }
 
-  toUrl(coordinates) {
-    return coordinates.toString().replace(/[/]+/g, '/')
+  toHarvestItem(entry) {
+    return {
+      type: entry.tool || 'component',
+      url: `cd:/${entry.coordinates.toString().replace(/[/]+/g, '/')}`,
+      policy: entry.policy || {
+        fetch: 'mutables',
+        freshness: 'match',
+        map: { name: entry.tool || 'component', path: '/' }
+      }
+    }
   }
 }
 

--- a/providers/harvest/crawlerQueueConfig.js
+++ b/providers/harvest/crawlerQueueConfig.js
@@ -4,6 +4,7 @@
 const config = require('painless-config')
 const AzureStorageQueue = require('../queueing/azureStorageQueue')
 const crawler = require('./crawlerQueue')
+const cacheBasedCrawler = require('./cacheBasedCrawler')
 
 function later(options) {
   const realOptions = options || {
@@ -22,13 +23,14 @@ function normal(options) {
 }
 
 function serviceFactory(options) {
-  const realOptions = options || {
-    later: later(),
-    normal: normal()
+  const crawlerOptions = {
+    later: options?.later || later(),
+    normal: options?.normal || normal()
   }
-  realOptions.later.initialize()
-  realOptions.normal.initialize()
-  return crawler(realOptions)
+  crawlerOptions.later.initialize()
+  crawlerOptions.normal.initialize()
+  const harvester = crawler(crawlerOptions)
+  return cacheBasedCrawler({ ...options, harvester })
 }
 
 module.exports = serviceFactory

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -513,7 +513,7 @@ function setupWithDelegates(
 ) {
   const search = { delete: sinon.stub(), store: sinon.stub() }
   const cache = { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() }
-  const harvestService = { harvest: () => sinon.stub() }
+  const harvestService = { harvest: () => sinon.stub(), done: () => Promise.resolve() }
   const service = DefinitionService(
     harvestStore,
     harvestService,
@@ -562,7 +562,7 @@ function setup(definition, coordinateSpec, curation) {
     }
   }
   const harvestStore = { getAllLatest: () => Promise.resolve(null) }
-  const harvestService = { harvest: () => sinon.stub() }
+  const harvestService = { harvest: () => sinon.stub(), done: () => Promise.resolve() }
   const summary = { summarizeAll: () => Promise.resolve(null) }
   const aggregator = { process: () => Promise.resolve(definition) }
   const upgradeHandler = { validate: def => Promise.resolve(def) }

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -457,6 +457,55 @@ describe('Integration test', () => {
       })
     })
   })
+
+  describe('Placeholder definition and Cache', () => {
+    let service, coordinates, harvestService
+
+    describe('placeholder definition', () => {
+      beforeEach(() => {
+        ;({ service, coordinates, harvestService } = setup(createDefinition(null, null, null)))
+        sinon.spy(service, 'compute')
+        sinon.spy(service, '_computePlaceHolder')
+        sinon.spy(harvestService, 'isTracked')
+      })
+
+      it('returns a placeholder definition same as computed', async () => {
+        const computed = await service.get(coordinates)
+        const placeholder = service._computePlaceHolder(coordinates)
+        placeholder._meta.updated = 'ignore_time_stamp'
+        computed._meta.updated = 'ignore_time_stamp'
+        expect(placeholder).to.deep.equal(computed)
+      })
+
+      it('triggers a harvest for a new component', async () => {
+        harvestService.isTracked = sinon.stub().resolves(false)
+        await service.get(coordinates)
+        expect(service.compute.called).to.be.true
+        expect(service._harvest.called).to.be.true
+        expect(service._computePlaceHolder.calledOnce).to.be.false
+        expect(harvestService.isTracked.calledOnce).to.be.true
+        expect(harvestService.isTracked.args[0][0]).to.be.deep.equal(coordinates)
+      })
+
+      it('returns a placeholder definition with a tracked harvest', async () => {
+        harvestService.isTracked = sinon.stub().resolves(true)
+        await service.get(coordinates)
+        expect(service._computePlaceHolder.calledOnce).to.be.true
+        expect(service.compute.called).to.be.false
+        expect(service._harvest.called).to.be.false
+        expect(harvestService.isTracked.calledOnce).to.be.true
+        expect(harvestService.isTracked.args[0][0]).to.be.deep.equal(coordinates)
+      })
+    })
+
+    it('deletes the tracked in progress harvest after definition is computed', async () => {
+      ;({ service, coordinates, harvestService } = setup(createDefinition(null, null, ['foo'])))
+      harvestService.done = sinon.stub().resolves(true)
+      await service.computeAndStore(coordinates)
+      expect(harvestService.done.calledOnce).to.be.true
+      expect(harvestService.done.args[0][0]).to.be.deep.equal(coordinates)
+    })
+  })
 })
 
 function createFileHarvestStore() {
@@ -580,7 +629,7 @@ function setup(definition, coordinateSpec, curation) {
   service.logger = { info: sinon.stub(), debug: sinon.stub() }
   service._harvest = sinon.stub()
   const coordinates = EntityCoordinates.fromString(coordinateSpec || 'npm/npmjs/-/test/1.0')
-  return { coordinates, service }
+  return { coordinates, service, harvestService }
 }
 
 function mockHarvestService() {

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -513,7 +513,7 @@ function setupWithDelegates(
 ) {
   const search = { delete: sinon.stub(), store: sinon.stub() }
   const cache = { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() }
-  const harvestService = { harvest: () => sinon.stub(), done: () => Promise.resolve() }
+  const harvestService = mockHarvestService()
   const service = DefinitionService(
     harvestStore,
     harvestService,
@@ -562,7 +562,7 @@ function setup(definition, coordinateSpec, curation) {
     }
   }
   const harvestStore = { getAllLatest: () => Promise.resolve(null) }
-  const harvestService = { harvest: () => sinon.stub(), done: () => Promise.resolve() }
+  const harvestService = mockHarvestService()
   const summary = { summarizeAll: () => Promise.resolve(null) }
   const aggregator = { process: () => Promise.resolve(definition) }
   const upgradeHandler = { validate: def => Promise.resolve(def) }
@@ -581,4 +581,12 @@ function setup(definition, coordinateSpec, curation) {
   service._harvest = sinon.stub()
   const coordinates = EntityCoordinates.fromString(coordinateSpec || 'npm/npmjs/-/test/1.0')
   return { coordinates, service }
+}
+
+function mockHarvestService() {
+  return {
+    harvest: () => sinon.stub(),
+    done: () => Promise.resolve(),
+    isTracked: () => Promise.resolve(false)
+  }
 }

--- a/test/providers/harvest/cacheBasedCrawlerTest.js
+++ b/test/providers/harvest/cacheBasedCrawlerTest.js
@@ -76,6 +76,18 @@ describe('CacheBasedHarvester', () => {
       assert.strictEqual(cacheMock.store[cacheKeyBar], true, 'Expected cache to be set for bar')
     })
 
+    it('removes duplicates before harvest', async () => {
+      await crawler.harvest([foo, foo], false)
+      assert.strictEqual(cacheMock.get.callCount, 1, 'get should be called once')
+      assert.strictEqual(cacheMock.set.callCount, 1, 'set should be called once')
+      assert.ok(harvesterMock.harvest.calledOnce, 'harvest should be called once')
+      assert.deepStrictEqual(
+        harvesterMock.harvest.args[0][0],
+        [foo],
+        'Expected harvester to be called with the correct entries'
+      )
+    })
+
     it('filters out tracked entries and calls harvester', async () => {
       cacheMock.store[cacheKeyFoo] = true
       await crawler.harvest(spec, false)

--- a/test/providers/harvest/cacheBasedCrawlerTest.js
+++ b/test/providers/harvest/cacheBasedCrawlerTest.js
@@ -1,3 +1,6 @@
+// (c) Copyright 2025, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
 const assert = require('assert')
 const sinon = require('sinon')
 const cacheBasedHarvester = require('../../../providers/harvest/cacheBasedCrawler')

--- a/test/providers/harvest/cacheBasedCrawlerTest.js
+++ b/test/providers/harvest/cacheBasedCrawlerTest.js
@@ -3,9 +3,9 @@ const sinon = require('sinon')
 const cacheBasedHarvester = require('../../../providers/harvest/cacheBasedCrawler')
 
 describe('CacheBasedHarvester', () => {
-  const foo = {coordinates: 'pkg/npm/foo/1.0.0'}
+  const foo = { coordinates: 'pkg/npm/foo/1.0.0' }
   const bar = { coordinates: 'pkg/npm/bar/2.0.0' }
-  
+
   const loggerMock = {
     debug: sinon.stub(),
     error: sinon.stub()
@@ -16,15 +16,15 @@ describe('CacheBasedHarvester', () => {
   beforeEach(() => {
     harvesterMock = {
       harvest: sinon.stub(),
-      toUrl: sinon.stub().callsFake((entry) => entry.coordinates)
+      toUrl: sinon.stub().callsFake(entry => entry.coordinates)
     }
-    
+
     cacheMock = {
       store: {},
       async get(key) {
         return this.store[key] || false
       },
-      async set(key, value, ttl) {
+      async set(key, value) {
         this.store[key] = value
       },
       async delete(key) {
@@ -36,7 +36,7 @@ describe('CacheBasedHarvester', () => {
     sinon.spy(cacheMock, 'delete')
 
     crawler = cacheBasedHarvester({
-      cache: cacheMock,
+      cachingService: cacheMock,
       harvester: harvesterMock,
       logger: loggerMock
     })
@@ -49,8 +49,12 @@ describe('CacheBasedHarvester', () => {
 
       assert.strictEqual(cacheMock.get.callCount, 2, 'get should be called twice')
       assert.strictEqual(cacheMock.set.callCount, 2, 'set should be called twice')
-      assert(harvesterMock.harvest.calledOnce,'harvest should be called once')
-      assert.deepStrictEqual(harvesterMock.harvest.args[0][0], [ foo, bar ],  'Expected harvester to be called with the correct entries')
+      assert(harvesterMock.harvest.calledOnce, 'harvest should be called once')
+      assert.deepStrictEqual(
+        harvesterMock.harvest.args[0][0],
+        [foo, bar],
+        'Expected harvester to be called with the correct entries'
+      )
       // Check if the cache was set correctly
       const isFooTracked = await crawler.isTracked(foo)
       assert.ok(isFooTracked, 'Expected cache to be set for foo')
@@ -66,7 +70,11 @@ describe('CacheBasedHarvester', () => {
       cacheMock.store['hrv_pkg/npm/foo/1.0.0'] = true
       await crawler.harvest(spec, false)
 
-      assert.deepStrictEqual(harvesterMock.harvest.args[0][0], [bar], 'Expected harvester to be called with the correct entries')
+      assert.deepStrictEqual(
+        harvesterMock.harvest.args[0][0],
+        [bar],
+        'Expected harvester to be called with the correct entries'
+      )
       //Check if the cache was set correctly
       assert.ok(await crawler.isTracked(foo), 'Expected cache to be set for foo')
       assert.ok(await crawler.isTracked(bar), 'Expected cache to be set for bar')

--- a/test/providers/harvest/cacheBasedCrawlerTest.js
+++ b/test/providers/harvest/cacheBasedCrawlerTest.js
@@ -1,0 +1,101 @@
+const assert = require('assert')
+const sinon = require('sinon')
+const cacheBasedHarvester = require('../../../providers/harvest/cacheBasedCrawler')
+
+describe('CacheBasedHarvester', () => {
+  const foo = {coordinates: 'pkg/npm/foo/1.0.0'}
+  const bar = { coordinates: 'pkg/npm/bar/2.0.0' }
+  
+  const loggerMock = {
+    debug: sinon.stub(),
+    error: sinon.stub()
+  }
+
+  let cacheMock, crawler, harvesterMock
+
+  beforeEach(() => {
+    harvesterMock = {
+      harvest: sinon.stub(),
+      toUrl: sinon.stub().callsFake((entry) => entry.coordinates)
+    }
+    
+    cacheMock = {
+      store: {},
+      async get(key) {
+        return this.store[key] || false
+      },
+      async set(key, value, ttl) {
+        this.store[key] = value
+      },
+      async delete(key) {
+        delete this.store[key]
+      }
+    }
+    sinon.spy(cacheMock, 'get')
+    sinon.spy(cacheMock, 'set')
+    sinon.spy(cacheMock, 'delete')
+
+    crawler = cacheBasedHarvester({
+      cache: cacheMock,
+      harvester: harvesterMock,
+      logger: loggerMock
+    })
+  })
+
+  describe('harvest', () => {
+    it('calls harvester with correct entries and adds to cache', async () => {
+      const spec = [foo, bar]
+      await crawler.harvest(spec, false)
+
+      assert.strictEqual(cacheMock.get.callCount, 2, 'get should be called twice')
+      assert.strictEqual(cacheMock.set.callCount, 2, 'set should be called twice')
+      assert(harvesterMock.harvest.calledOnce,'harvest should be called once')
+      assert.deepStrictEqual(harvesterMock.harvest.args[0][0], [ foo, bar ],  'Expected harvester to be called with the correct entries')
+      // Check if the cache was set correctly
+      const isFooTracked = await crawler.isTracked(foo)
+      assert.ok(isFooTracked, 'Expected cache to be set for foo')
+      assert.strictEqual(cacheMock.store['hrv_pkg/npm/foo/1.0.0'], true, 'Expected cache to be set for foo')
+      const isBarTracked = await crawler.isTracked(bar)
+      assert.ok(isBarTracked, 'Expected cache to be set for bar')
+      assert.strictEqual(cacheMock.store['hrv_pkg/npm/bar/2.0.0'], true, 'Expected cache to be set for bar')
+    })
+
+    it('filters out tracked entries and calls harvester', async () => {
+      const spec = [foo, bar]
+      //filter out first and keep second
+      cacheMock.store['hrv_pkg/npm/foo/1.0.0'] = true
+      await crawler.harvest(spec, false)
+
+      assert.deepStrictEqual(harvesterMock.harvest.args[0][0], [bar], 'Expected harvester to be called with the correct entries')
+      //Check if the cache was set correctly
+      assert.ok(await crawler.isTracked(foo), 'Expected cache to be set for foo')
+      assert.ok(await crawler.isTracked(bar), 'Expected cache to be set for bar')
+    })
+  })
+
+  describe('isTracked', () => {
+    it('returns true if the entry is tracked', async () => {
+      cacheMock.store['hrv_pkg/npm/foo/1.0.0'] = true
+      const result = await crawler.isTracked(foo)
+      assert.strictEqual(result, true, 'Expected entry to be tracked')
+      assert(cacheMock.get.calledWith('hrv_pkg/npm/foo/1.0.0'), 'Expected cache get to be called with the correct key')
+    })
+
+    it('returns false if the entry is not tracked', async () => {
+      const result = await crawler.isTracked(foo)
+      assert.strictEqual(result, false)
+    })
+  })
+
+  describe('done', () => {
+    it('deletes the cache for the given coordinates', async () => {
+      cacheMock.store['hrv_pkg/npm/foo/1.0.0'] = true
+      await crawler.done(foo)
+
+      assert(cacheMock.delete.calledWith('hrv_pkg/npm/foo/1.0.0'))
+      assert.strictEqual(cacheMock.store['hrv_pkg/npm/foo/1.0.0'], undefined)
+      const isFooTracked = await crawler.isTracked(foo)
+      assert.ok(!isFooTracked, 'Expected cache to be deleted for foo')
+    })
+  })
+})


### PR DESCRIPTION
#### Background:
Stats from 2025-03-16 to 2025-04-17 for the "get definition" process:
- Averaging 17 million "definition not available" counts daily (with 8.5 million definition computations triggering harvest requests).
- Averaging 250,000 distinct coordinates with "definition not available" daily.
![image](https://github.com/user-attachments/assets/430199bb-93c8-43eb-804c-ada9067bbd9a)
![image](https://github.com/user-attachments/assets/77569b79-5767-4de7-96b9-5bc5da013baf)

#### Problems Identified:
1. **Duplicate Harvest Requests**:
    - **Queue Growth**: The queue expands due to redundant harvest requests.
    - **Scanner Tool Failures**: The crawler retries a failed request up to 5 times. The additional repeated queuing of the failed components forces the crawler to fail-retry more than necessary, thereby hindering overall progress.
  
2. **Duplicate Definition Computations**:
    - Definition computations for unavailable definitions involve 4 network calls, adding load on internal dependencies (stores and queue).

#### Solution:
**Introducing CacheBasedHarvester**:
- **Caching Mechanism**: Cache harvest coordinates to mark them as 'in-progress'. 
- Cache entries expire daily.
- Cached entries are removed when a definition is successfully recomputed after crawler tool results are available.

**Benefits**:
- Reduced queueing of duplicated harvest requests.
- Optimized definition computation: By tracking in-progress harvest coordinates, definition computations can return placeholders without triggering network calls. This reduces daily definition computations for those "definition not available" cases from 8.5 million to 250,000 (one per unique coordinate).

#### Impact:
- Provisioned cache capacity needs confirmation to ensure sufficient resources for the additional caching.

#### Future Work:
- Transitioning definition computations during definition retrieval to the background to improve the responsiveness of API calls.
