### PR TITLE
Avoid definition computation if results are in the existing definition

### DIFF
--- a/providers/harvest/process.js
+++ b/providers/harvest/process.js
@@ -4,10 +4,6 @@
 const { get } = require('lodash')
 const EntityCoordinates = require('../../lib/entityCoordinates')
 const { parseUrn } = require('../../lib/utils')
-const Cache = require('../caching/memory')
-
-const defaultTtlSeconds = 60 * 5 /* 5 mins */
-const retryDelayInMSeconds = 500
 
 async function work(once) {
   let isQueueEmpty = true
@@ -28,45 +24,24 @@ async function processMessage(message) {
   const urn = get(message, 'data._metadata.links.self.href')
   if (!urn) return
   const coordinates = EntityCoordinates.fromUrn(urn)
-
-  while (computeLock.get(coordinates.toString())) {
-    await new Promise(resolve => setTimeout(resolve, retryDelayInMSeconds))
-  }
-  try {
-    computeLock.set(coordinates.toString(), true)
-    await computeIfNecessary(coordinates, urn)
-  } finally {
-    computeLock.delete(coordinates.toString())
+  const { tool, toolRevision } = parseUrn(urn)
+  if (tool === 'clearlydefined') {
+    await definitionService.computeStoreAndCurate(coordinates)
+  } else {
+    await definitionService.computeAndStoreIfNecessary(coordinates, tool, toolRevision)
   }
   await queue.delete(message)
   logger.info(`Handled Crawler update event for ${urn}`)
 }
 
-async function computeIfNecessary(coordinates, urn) {
-  const { tool, toolRevision } = parseUrn(urn)
-  if (tool === 'clearlydefined') {
-    await definitionService.computeStoreAndCurate(coordinates)
-  } else {
-    const definitionFound = await definitionService.getStored(coordinates)
-    const urnToolVersion = `${tool}/${toolRevision}`
-    if (definitionFound?.described?.tools.includes(urnToolVersion)) {
-      logger.info('Skip definition computation as the tool result has already been processed', { urn })
-    } else {
-      await definitionService.computeAndStore(coordinates)
-    }
-  }
-}
-
 let queue
 let definitionService
 let logger
-let computeLock
 
-function setup(_queue, _definitionService, _logger, once = false, lock = Cache({ defaultTtlSeconds })) {
+function setup(_queue, _definitionService, _logger, once = false) {
   queue = _queue
   definitionService = _definitionService
   logger = _logger
-  computeLock = lock
   return work(once)
 }
 

--- a/providers/harvest/process.js
+++ b/providers/harvest/process.js
@@ -4,6 +4,10 @@
 const { get } = require('lodash')
 const EntityCoordinates = require('../../lib/entityCoordinates')
 const { parseUrn } = require('../../lib/utils')
+const Cache = require('../caching/memory')
+
+const defaultTtlSeconds = 60 * 5 /* 5 mins */
+const retryDelayInMSeconds = 500
 
 async function work(once) {
   let isQueueEmpty = true
@@ -24,24 +28,45 @@ async function processMessage(message) {
   const urn = get(message, 'data._metadata.links.self.href')
   if (!urn) return
   const coordinates = EntityCoordinates.fromUrn(urn)
-  const { tool } = parseUrn(urn)
-  if (tool === 'clearlydefined') {
-    await definitionService.computeStoreAndCurate(coordinates)
-  } else {
-    await definitionService.computeAndStore(coordinates)
+
+  while (computeLock.get(coordinates.toString())) {
+    await new Promise(resolve => setTimeout(resolve, retryDelayInMSeconds))
+  }
+  try {
+    computeLock.set(coordinates.toString(), true)
+    await computeIfNecessary(coordinates, urn)
+  } finally {
+    computeLock.delete(coordinates.toString())
   }
   await queue.delete(message)
   logger.info(`Handled Crawler update event for ${urn}`)
 }
 
+async function computeIfNecessary(coordinates, urn) {
+  const { tool, toolRevision } = parseUrn(urn)
+  if (tool === 'clearlydefined') {
+    await definitionService.computeStoreAndCurate(coordinates)
+  } else {
+    const definitionFound = await definitionService.getStored(coordinates)
+    const urnToolVersion = `${tool}/${toolRevision}`
+    if (definitionFound?.described?.tools.includes(urnToolVersion)) {
+      logger.info('Skip definition computation as the tool result has already been processed', { urn })
+    } else {
+      await definitionService.computeAndStore(coordinates)
+    }
+  }
+}
+
 let queue
 let definitionService
 let logger
+let computeLock
 
-function setup(_queue, _definitionService, _logger, once = false) {
+function setup(_queue, _definitionService, _logger, once = false, lock = Cache({ defaultTtlSeconds })) {
   queue = _queue
   definitionService = _definitionService
   logger = _logger
+  computeLock = lock
   return work(once)
 }
 

--- a/test/providers/harvest/processTest.js
+++ b/test/providers/harvest/processTest.js
@@ -8,7 +8,7 @@ const sinon = require('sinon')
 
 describe('Harvest queue processing', () => {
   it('handles new message from clearlydefined tool', async () => {
-    const { queue, definitionService, logger } = await setup(
+    const { queue, definitionService, logger } = setup(
       'urn:gem:rubygems:-:0mq:revision:0.5.2:tool:clearlydefined:1.3.3'
     )
     await process(queue, definitionService, logger, true)
@@ -28,13 +28,13 @@ describe('Harvest queue processing', () => {
   })
 
   it('handles new message from non-clearlydefined tool', async () => {
-    const { queue, definitionService, logger } = await setup(
+    const { queue, definitionService, logger } = setup(
       'urn:pypi:pypi:-:backports.ssl_match_hostname:revision:3.2a3:tool:scancode:3.2.2'
     )
     await process(queue, definitionService, logger, true)
 
-    expect(definitionService.computeAndStore.calledOnce).to.be.true
-    expect(definitionService.computeAndStore.getCall(0).args[0]).to.deep.eq({
+    expect(definitionService.computeAndStoreIfNecessary.calledOnce).to.be.true
+    expect(definitionService.computeAndStoreIfNecessary.getCall(0).args[0]).to.deep.eq({
       type: 'pypi',
       provider: 'pypi',
       name: 'backports.ssl_match_hostname',
@@ -47,114 +47,8 @@ describe('Harvest queue processing', () => {
     expect(queue.data.length).to.eq(0)
   })
 
-  it('handles processed message from non-clearlydefined tool', async () => {
-    const { queue, definitionService, logger } = await setup(
-      'urn:pypi:pypi:-:backports.ssl_match_hostname:revision:3.2a3:tool:scancode:3.2.2'
-    )
-    definitionService.getStored.resolves({
-      described: {
-        tools: ['scancode/3.2.2']
-      }
-    })
-    await process(queue, definitionService, logger, true)
-
-    expect(definitionService.computeAndStore.called).to.be.false
-    expect(logger.info.calledTwice).to.be.true
-    expect(logger.info.getCall(0).args[0]).to.eq(
-      'Skip definition computation as the tool result has already been processed'
-    )
-    expect(logger.info.getCall(1).args[0]).to.eq(
-      'Handled Crawler update event for urn:pypi:pypi:-:backports.ssl_match_hostname:revision:3.2a3:tool:scancode:3.2.2'
-    )
-    expect(queue.data.length).to.eq(0)
-  })
-
-  it('handles two messages for the same coordinates: computes the first and skip the second', async () => {
-    const { queue, definitionService, logger, lock } = await setup(
-      'urn:pypi:pypi:-:dnspython:revision:2.6.0:tool:clearlydefined:1.4.1',
-      'urn:pypi:pypi:-:dnspython:revision:2.6.0:tool:licensee:9.18.1'
-    )
-    definitionService.getStored.resolves({
-      described: {
-        tools: ['clearlydefined/1.4.1', 'licensee/9.18.1']
-      }
-    })
-
-    await process(queue, definitionService, logger, true, lock)
-
-    const coordinates = {
-      type: 'pypi',
-      provider: 'pypi',
-      name: 'dnspython',
-      revision: '2.6.0'
-    }
-    const coordinatesString = 'pypi/pypi/-/dnspython/2.6.0'
-
-    expect(lock.set.calledTwice).to.be.true
-    expect(lock.set.getCall(0).args[0]).to.eq(coordinatesString)
-    expect(lock.set.getCall(1).args[0]).to.eq(coordinatesString)
-
-    expect(definitionService.computeStoreAndCurate.calledOnce).to.be.true
-    expect(definitionService.computeStoreAndCurate.getCall(0).args[0]).to.deep.eq(coordinates)
-
-    expect(definitionService.getStored.calledOnce).to.be.true
-    expect(definitionService.getStored.getCall(0).args[0]).to.deep.eq(coordinates)
-
-    expect(lock.delete.calledTwice).to.be.true
-    expect(lock.delete.getCall(0).args[0]).to.eq(coordinatesString)
-    expect(lock.delete.getCall(1).args[0]).to.eq(coordinatesString)
-    //lock is released before the second message is processed
-    expect(lock.delete.firstCall.calledBefore(definitionService.getStored.firstCall)).to.be.true
-    expect(definitionService.computeAndStore.called).to.be.false
-  })
-
-  it('handles three messages for the same coordinates: computes the first, skip the second and computes the third', async () => {
-    const { queue, definitionService, logger, lock } = await setup(
-      'urn:pypi:pypi:-:dnspython:revision:2.6.0:tool:clearlydefined:1.4.1',
-      'urn:pypi:pypi:-:dnspython:revision:2.6.0:tool:licensee:9.18.1',
-      'urn:pypi:pypi:-:dnspython:revision:2.6.0:tool:reuse:3.2.1'
-    )
-    definitionService.getStored.resolves({
-      described: {
-        tools: ['clearlydefined/1.4.1', 'licensee/9.18.1']
-      }
-    })
-    await process(queue, definitionService, logger, true, lock)
-
-    const coordinates = {
-      type: 'pypi',
-      provider: 'pypi',
-      name: 'dnspython',
-      revision: '2.6.0'
-    }
-    const coordinatesString = 'pypi/pypi/-/dnspython/2.6.0'
-    expect(definitionService.computeStoreAndCurate.calledOnce).to.be.true
-    expect(definitionService.computeStoreAndCurate.getCall(0).args[0]).to.deep.eq(coordinates)
-
-    expect(definitionService.getStored.calledTwice).to.be.true
-    expect(definitionService.getStored.getCall(0).args[0]).to.deep.eq(coordinates)
-    expect(definitionService.getStored.getCall(1).args[0]).to.deep.eq(coordinates)
-
-    expect(definitionService.computeAndStore.calledOnce).to.be.true
-    expect(definitionService.computeAndStore.getCall(0).args[0]).to.deep.eq(coordinates)
-
-    expect(lock.delete.callCount).to.eq(3)
-    expect(lock.delete.getCall(0).args[0]).to.eq(coordinatesString)
-    expect(lock.delete.getCall(1).args[0]).to.eq(coordinatesString)
-    expect(lock.delete.getCall(2).args[0]).to.eq(coordinatesString)
-
-    //lock is released after processing and before the subsequent message is processed
-    expect(definitionService.computeStoreAndCurate.firstCall.calledBefore(lock.delete.firstCall)).to.be.true
-    expect(definitionService.getStored.firstCall.calledAfter(lock.delete.firstCall)).to.be.true
-
-    expect(definitionService.getStored.firstCall.calledBefore(lock.delete.secondCall)).to.be.true
-    expect(definitionService.getStored.secondCall.calledAfter(lock.delete.secondCall)).to.be.true
-
-    expect(definitionService.computeAndStore.firstCall.calledBefore(lock.delete.getCall(2))).to.be.true
-  })
-
   it('handles bogus message', async () => {
-    const { queue, definitionService, logger } = await setup({ junk: 'here' })
+    const { queue, definitionService, logger } = setup({ junk: 'here' })
     await process(queue, definitionService, logger, true)
 
     expect(definitionService.computeStoreAndCurate.called).to.be.false
@@ -163,38 +57,19 @@ describe('Harvest queue processing', () => {
   })
 })
 
-async function setup(urn, ...additionalUrns) {
+function setup(urn) {
   const queue = memoryQueue()
   queue.queue(JSON.stringify(createMessage(urn)))
-  if (additionalUrns.length > 0) {
-    await mockDequeueMultiple(queue, urn, additionalUrns)
-  }
   const definitionService = {
-    getStored: sinon.stub().resolves(null),
     computeStoreAndCurate: sinon.stub().resolves({}),
-    computeAndStore: sinon.stub().resolves({})
+    computeAndStoreIfNecessary: sinon.stub().resolves({})
   }
   const logger = {
     info: sinon.stub(),
     error: sinon.stub()
   }
 
-  const lock = mockLock()
-
-  return { queue, definitionService, logger, lock }
-}
-
-function mockLock() {
-  const data = {}
-  const lock = {
-    get: key => data[key],
-    set: (key, value) => (data[key] = value),
-    delete: key => delete data[key]
-  }
-  sinon.spy(lock, 'get')
-  sinon.spy(lock, 'set')
-  sinon.spy(lock, 'delete')
-  return lock
+  return { queue, definitionService, logger }
 }
 
 function createMessage(href) {
@@ -205,15 +80,4 @@ function createMessage(href) {
       }
     }
   }
-}
-
-// memoryQueue only dequeues one message at a time with dequeueMultiple,
-// so we need to mock it to dequeue multiple messages
-// with the same coordinates but different tool versions
-async function mockDequeueMultiple(queue, replaceText, toolVersions) {
-  const message1 = await queue.dequeue()
-  const messages = toolVersions.map(toolVersion =>
-    JSON.parse(JSON.stringify(message1).replaceAll(replaceText, toolVersion))
-  )
-  queue.dequeueMultiple = sinon.stub().resolves([message1, ...messages])
 }

--- a/test/providers/harvest/processTest.js
+++ b/test/providers/harvest/processTest.js
@@ -8,9 +8,9 @@ const sinon = require('sinon')
 
 describe('Harvest queue processing', () => {
   it('handles new message from clearlydefined tool', async () => {
-    const { queue, definitionService, logger } = setup({
-      _metadata: { links: { self: { href: 'urn:gem:rubygems:-:0mq:revision:0.5.2:tool:clearlydefined:1.3.3' } } }
-    })
+    const { queue, definitionService, logger } = await setup(
+      'urn:gem:rubygems:-:0mq:revision:0.5.2:tool:clearlydefined:1.3.3'
+    )
     await process(queue, definitionService, logger, true)
 
     expect(definitionService.computeStoreAndCurate.calledOnce).to.be.true
@@ -28,11 +28,9 @@ describe('Harvest queue processing', () => {
   })
 
   it('handles new message from non-clearlydefined tool', async () => {
-    const { queue, definitionService, logger } = setup({
-      _metadata: {
-        links: { self: { href: 'urn:pypi:pypi:-:backports.ssl_match_hostname:revision:3.2a3:tool:scancode:3.2.2' } }
-      }
-    })
+    const { queue, definitionService, logger } = await setup(
+      'urn:pypi:pypi:-:backports.ssl_match_hostname:revision:3.2a3:tool:scancode:3.2.2'
+    )
     await process(queue, definitionService, logger, true)
 
     expect(definitionService.computeAndStore.calledOnce).to.be.true
@@ -50,11 +48,9 @@ describe('Harvest queue processing', () => {
   })
 
   it('handles processed message from non-clearlydefined tool', async () => {
-    const { queue, definitionService, logger } = setup({
-      _metadata: {
-        links: { self: { href: 'urn:pypi:pypi:-:backports.ssl_match_hostname:revision:3.2a3:tool:scancode:3.2.2' } }
-      }
-    })
+    const { queue, definitionService, logger } = await setup(
+      'urn:pypi:pypi:-:backports.ssl_match_hostname:revision:3.2a3:tool:scancode:3.2.2'
+    )
     definitionService.getStored.resolves({
       described: {
         tools: ['scancode/3.2.2']
@@ -62,7 +58,7 @@ describe('Harvest queue processing', () => {
     })
     await process(queue, definitionService, logger, true)
 
-    expect(definitionService.computeAndStore.calledOnce).to.be.false
+    expect(definitionService.computeAndStore.called).to.be.false
     expect(logger.info.calledTwice).to.be.true
     expect(logger.info.getCall(0).args[0]).to.eq(
       'Skip definition computation as the tool result has already been processed'
@@ -73,19 +69,106 @@ describe('Harvest queue processing', () => {
     expect(queue.data.length).to.eq(0)
   })
 
+  it('handles two messages for the same coordinates: computes the first and skip the second', async () => {
+    const { queue, definitionService, logger, lock } = await setup(
+      'urn:pypi:pypi:-:dnspython:revision:2.6.0:tool:clearlydefined:1.4.1',
+      'urn:pypi:pypi:-:dnspython:revision:2.6.0:tool:licensee:9.18.1'
+    )
+    definitionService.getStored.resolves({
+      described: {
+        tools: ['clearlydefined/1.4.1', 'licensee/9.18.1']
+      }
+    })
+
+    await process(queue, definitionService, logger, true, lock)
+
+    const coordinates = {
+      type: 'pypi',
+      provider: 'pypi',
+      name: 'dnspython',
+      revision: '2.6.0'
+    }
+    const coordinatesString = 'pypi/pypi/-/dnspython/2.6.0'
+
+    expect(lock.set.calledTwice).to.be.true
+    expect(lock.set.getCall(0).args[0]).to.eq(coordinatesString)
+    expect(lock.set.getCall(1).args[0]).to.eq(coordinatesString)
+
+    expect(definitionService.computeStoreAndCurate.calledOnce).to.be.true
+    expect(definitionService.computeStoreAndCurate.getCall(0).args[0]).to.deep.eq(coordinates)
+
+    expect(definitionService.getStored.calledOnce).to.be.true
+    expect(definitionService.getStored.getCall(0).args[0]).to.deep.eq(coordinates)
+
+    expect(lock.delete.calledTwice).to.be.true
+    expect(lock.delete.getCall(0).args[0]).to.eq(coordinatesString)
+    expect(lock.delete.getCall(1).args[0]).to.eq(coordinatesString)
+    //lock is released before the second message is processed
+    expect(lock.delete.firstCall.calledBefore(definitionService.getStored.firstCall)).to.be.true
+    expect(definitionService.computeAndStore.called).to.be.false
+  })
+
+  it('handles three messages for the same coordinates: computes the first, skip the second and computes the third', async () => {
+    const { queue, definitionService, logger, lock } = await setup(
+      'urn:pypi:pypi:-:dnspython:revision:2.6.0:tool:clearlydefined:1.4.1',
+      'urn:pypi:pypi:-:dnspython:revision:2.6.0:tool:licensee:9.18.1',
+      'urn:pypi:pypi:-:dnspython:revision:2.6.0:tool:reuse:3.2.1'
+    )
+    definitionService.getStored.resolves({
+      described: {
+        tools: ['clearlydefined/1.4.1', 'licensee/9.18.1']
+      }
+    })
+    await process(queue, definitionService, logger, true, lock)
+
+    const coordinates = {
+      type: 'pypi',
+      provider: 'pypi',
+      name: 'dnspython',
+      revision: '2.6.0'
+    }
+    const coordinatesString = 'pypi/pypi/-/dnspython/2.6.0'
+    expect(definitionService.computeStoreAndCurate.calledOnce).to.be.true
+    expect(definitionService.computeStoreAndCurate.getCall(0).args[0]).to.deep.eq(coordinates)
+
+    expect(definitionService.getStored.calledTwice).to.be.true
+    expect(definitionService.getStored.getCall(0).args[0]).to.deep.eq(coordinates)
+    expect(definitionService.getStored.getCall(1).args[0]).to.deep.eq(coordinates)
+
+    expect(definitionService.computeAndStore.calledOnce).to.be.true
+    expect(definitionService.computeAndStore.getCall(0).args[0]).to.deep.eq(coordinates)
+
+    expect(lock.delete.callCount).to.eq(3)
+    expect(lock.delete.getCall(0).args[0]).to.eq(coordinatesString)
+    expect(lock.delete.getCall(1).args[0]).to.eq(coordinatesString)
+    expect(lock.delete.getCall(2).args[0]).to.eq(coordinatesString)
+
+    //lock is released after processing and before the subsequent message is processed
+    expect(definitionService.computeStoreAndCurate.firstCall.calledBefore(lock.delete.firstCall)).to.be.true
+    expect(definitionService.getStored.firstCall.calledAfter(lock.delete.firstCall)).to.be.true
+
+    expect(definitionService.getStored.firstCall.calledBefore(lock.delete.secondCall)).to.be.true
+    expect(definitionService.getStored.secondCall.calledAfter(lock.delete.secondCall)).to.be.true
+
+    expect(definitionService.computeAndStore.firstCall.calledBefore(lock.delete.getCall(2))).to.be.true
+  })
+
   it('handles bogus message', async () => {
-    const { queue, definitionService, logger } = setup({ junk: 'here' })
+    const { queue, definitionService, logger } = await setup({ junk: 'here' })
     await process(queue, definitionService, logger, true)
 
-    expect(definitionService.computeStoreAndCurate.calledOnce).to.be.false
-    expect(logger.info.calledOnce).to.be.false
+    expect(definitionService.computeStoreAndCurate.called).to.be.false
+    expect(logger.info.called).to.be.false
     expect(queue.data.length).to.eq(1)
   })
 })
 
-function setup(data) {
+async function setup(urn, ...additionalUrns) {
   const queue = memoryQueue()
-  queue.queue(JSON.stringify(data))
+  queue.queue(JSON.stringify(createMessage(urn)))
+  if (additionalUrns.length > 0) {
+    await mockDequeueMultiple(queue, urn, additionalUrns)
+  }
   const definitionService = {
     getStored: sinon.stub().resolves(null),
     computeStoreAndCurate: sinon.stub().resolves({}),
@@ -96,5 +179,41 @@ function setup(data) {
     error: sinon.stub()
   }
 
-  return { queue, definitionService, logger }
+  const lock = mockLock()
+
+  return { queue, definitionService, logger, lock }
+}
+
+function mockLock() {
+  const data = {}
+  const lock = {
+    get: key => data[key],
+    set: (key, value) => (data[key] = value),
+    delete: key => delete data[key]
+  }
+  sinon.spy(lock, 'get')
+  sinon.spy(lock, 'set')
+  sinon.spy(lock, 'delete')
+  return lock
+}
+
+function createMessage(href) {
+  return {
+    _metadata: {
+      links: {
+        self: { href }
+      }
+    }
+  }
+}
+
+// memoryQueue only dequeues one message at a time with dequeueMultiple,
+// so we need to mock it to dequeue multiple messages
+// with the same coordinates but different tool versions
+async function mockDequeueMultiple(queue, replaceText, toolVersions) {
+  const message1 = await queue.dequeue()
+  const messages = toolVersions.map(toolVersion =>
+    JSON.parse(JSON.stringify(message1).replaceAll(replaceText, toolVersion))
+  )
+  queue.dequeueMultiple = sinon.stub().resolves([message1, ...messages])
 }

--- a/test/routes/webhookCrawlerTests.js
+++ b/test/routes/webhookCrawlerTests.js
@@ -15,8 +15,8 @@ describe('Webhook Route for Crawler calls', () => {
     const router = webhookRoutes(null, service, logger, 'secret', 'secret', true)
     router._handlePost(request, response)
     expect(response.statusCode).to.be.eq(200)
-    expect(service.computeStoreAndCurate.calledOnce).to.be.true
-    expect(service.computeStoreAndCurate.getCall(0).args[0].name).to.be.eq('test')
+    expect(service.computeAndStoreIfNecessary.calledOnce).to.be.true
+    expect(service.computeAndStoreIfNecessary.getCall(0).args[0].name).to.be.eq('test')
   })
 
   it('handles missing self', () => {
@@ -52,7 +52,8 @@ function createLogger() {
 
 function createDefinitionService() {
   return {
-    computeStoreAndCurate: sinon.stub()
+    computeStoreAndCurate: sinon.stub(),
+    computeAndStoreIfNecessary: sinon.stub()
   }
 }
 


### PR DESCRIPTION
### Background

Upon the availability of harvest tool results, the service currently recomputes the component's definition. As there are four harvest tools involved in the harvest process, this results in the definition being computed up to four times per component. 

Further analysis of harvest result timings from March 24 to April 24 indicated that approximately 80% of components have two or more results available within a 5-minute window.
![image](https://github.com/user-attachments/assets/d922997c-635f-4fc2-8996-b5a1632e2636)


Additionally, based on a 5-day analysis from April 19 to April 24, 50% of components have all four tool results available within the same 5-minute window.
![image](https://github.com/user-attachments/assets/e694d2a4-7a8a-4673-b3b2-0840a6c211ac)

This presents an opportunity to optimize the process by reducing the number of definition calculations, ideally to one per component in 50% of cases.

### Solution

To address this, a delay mechanism is implemented to defer the definition computation for a short period (e.g., 5 minutes). This allows multiple harvest tool results to be aggregated before recomputing the definition, thereby reducing the computation load on the service.

### Benefits:

- **Reduced Computation Load:**
  - By aggregating multiple harvest tool results before computing the definition, the number of computations is significantly reduced.
  
- **Improved Performance:**
  - Reduced load on internal stores leads to improved overall performance of the service.

### Changes:

1. **Visibility Timeout Implementation:**
   - Implemented a delay mechanism where messages related to harvest results are pushed onto the `/harvests` queue store with a visibility timeout. This is handled by the [crawler PR](https://github.com/clearlydefined/crawler/pull/639).

2. **Service-Side Optimization:**
   - Added the ability to check whether harvest results have already been included in the computed definition before triggering a new definition computation. This prevents unnecessary computations and reduces the load on internal stores.  This is the focus of this PR.

### Future work: 
Documentation:
Need to update relevant documentation to explain the environment variable introduced by the delay mechanism 

### Notes:

- The optimization relies on the visibility timeout implementation in the `crawler` repository, as specified in the [crawler PR](https://github.com/clearlydefined/crawler/pull/639).  
- `service` and `crawler` can be deployed independently.  To achieve the best result, both changes need to be deployed to work together.

