### PR TITLE
Resolve Buffer issues

### DIFF
--- a/test/providers/curation/githubPRs.js
+++ b/test/providers/curation/githubPRs.js
@@ -191,7 +191,7 @@ describe('Curation service pr events', () => {
             expect(ref).to.eq('branch')
             return Promise.resolve()
           },
-          blob: () => Promise.resolve(new Buffer.alloc(0))
+          blob: () => Promise.resolve(Buffer.alloc(0))
         }
       }
     })
@@ -227,7 +227,7 @@ revisions:
           },
           blob: ref => {
             expect(ref).to.eq('thisisasha')
-            return Promise.resolve(new Buffer.from(theYaml))
+            return Promise.resolve(Buffer.from(theYaml))
           }
         }
       }
@@ -257,7 +257,7 @@ revisions:
             expect(ref).to.eq('refs/pull/123/head')
             return Promise.resolve()
           },
-          blob: () => Promise.resolve(new Buffer.alloc(0))
+          blob: () => Promise.resolve(Buffer.alloc(0))
         }
       }
     })
@@ -286,7 +286,7 @@ function createService({ failsCompute = false, geitStubOverride = null }) {
     (() => {
       return {
         tree: () => Promise.resolve(),
-        blob: () => Promise.resolve(new Buffer.alloc(0))
+        blob: () => Promise.resolve(Buffer.alloc(0))
       }
     })
   const service = proxyquire('../../../providers/curation/github', { geit: geitStub })(

--- a/test/providers/summary/fossology.js
+++ b/test/providers/summary/fossology.js
@@ -438,6 +438,6 @@ describe('FOSSologySummarizer fixtures', () => {
 function getHarvestData(version, test) {
   const fileName = path.join(__dirname, `../../fixtures/fossology/${version}/${test}.json`)
   if (fs.existsSync(fileName)) {
-    return JSON.parse(fs.readFileSync(fileName))
+    return JSON.parse(fs.readFileSync(fileName, 'utf8'))
   }
 }

--- a/test/providers/summary/scancode/legacy-summarizer.js
+++ b/test/providers/summary/scancode/legacy-summarizer.js
@@ -287,6 +287,6 @@ describe('ScanCodeLegacySummarizer fixtures', () => {
 function getHarvestData(version, test) {
   const fileName = path.join(__dirname, `../../../fixtures/scancode/${version}/${test}.json`)
   if (fs.existsSync(fileName)) {
-    return JSON.parse(fs.readFileSync(fileName))
+    return JSON.parse(fs.readFileSync(fileName, 'utf8'))
   }
 }

--- a/test/providers/summary/scancode/new-summarizer.js
+++ b/test/providers/summary/scancode/new-summarizer.js
@@ -257,6 +257,6 @@ describe('ScanCodeNewSummarizer fixtures', () => {
 function getHarvestData(version, test) {
   const fileName = path.join(__dirname, `../../../fixtures/scancode/${version}/${test}.json`)
   if (fs.existsSync(fileName)) {
-    return JSON.parse(fs.readFileSync(fileName))
+    return JSON.parse(fs.readFileSync(fileName, 'utf8'))
   }
 }


### PR DESCRIPTION
```
error TS2345: Argument of type 'Buffer' is not assignable to parameter of type 'string'.
```

and [DEP0005][1]

> The Buffer() function and new Buffer() constructor are deprecated due to API usability issues that can lead to accidental security issues.

[1]: https://nodejs.org/api/deprecations.html#DEP0005