### PR TITLE
Fix TypeScript error TS2339

### DIFF
--- a/app.js
+++ b/app.js
@@ -186,6 +186,7 @@ function createApp(config) {
       url: req.url
     })
     const err = new Error('Not Found')
+    // @ts-ignore - Express error convention
     err.status = 404
     next(err)
   }

--- a/middleware/permissions.js
+++ b/middleware/permissions.js
@@ -14,6 +14,7 @@ function permissionsCheck(permission) {
     const intersection = requiredTeams.filter(t => (userTeams || []).includes(t))
     if (requiredTeams.length !== 0 && intersection.length == 0) {
       const error = new Error(`No permission to '${permission}' (needs team membership)`)
+      // @ts-ignore - Express error convention
       error.status = 401
       next(error)
     } else {


### PR DESCRIPTION
This is a fairly common express practice, and one that we want to tell TypeScript to explicitly ignore for now

```
error TS2339: Property 'status' does not exist on type 'Error'.
```