### PR TITLE
Use a fully-qualified reference to the base container image

### DIFF
--- a/DevDockerfile
+++ b/DevDockerfile
@@ -1,11 +1,8 @@
 # Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-# FROM node:8-alpine
-FROM node:18
+FROM docker.io/library/node:18
 ENV APPDIR=/opt/service
-# RUN apk update && apk upgrade && \
-#    apk add --no-cache bash git openssh
 
 ## get SSH server running
 # RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 # Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-# FROM node:8-alpine
-FROM node:18
+FROM docker.io/library/node:18
 ENV APPDIR=/opt/service
-# RUN apk update && apk upgrade && \
-#    apk add --no-cache bash git openssh
 
 ## get SSH server running
 # RUN apt-get update \


### PR DESCRIPTION
The implicit reference, `node`, makes assumptions that only work on Docker itself, and not on some other container image tooling. The fully-qualified equivalent is `docker.io/library/node`.