### PR TITLE
Bump maxItem to address need for NOTICE file with 10,005 packages.

### DIFF
--- a/schemas/notice-request.json
+++ b/schemas/notice-request.json
@@ -8,7 +8,7 @@
   "properties": {
     "coordinates": {
       "type": "array",
-      "maxItems": 5000,
+      "maxItems": 15000,
       "items": { "type": "string" },
       "errorMessage": {
         "type": "coordinates type must be an array"


### PR DESCRIPTION
A user has 10,005 components in their NOTICE file and their notice API request is producing an error on every try. This PR increases the maxItems limit for the json sent to the NOTICE API from 5000 to 15000. 

THIS IS A DRAFT WHILE I CONFIRM AND TEST RELATED ISSUES.