### PR TITLE
Trust Proxy

### DIFF
--- a/app.js
+++ b/app.js
@@ -130,7 +130,7 @@ function createApp(config) {
   app.use('/auth', auth.router)
   app.use(config.auth.service.middleware())
 
-  app.set('trust-proxy', true)
+  app.set('trust proxy', true)
   app.use('/', require('./routes/index')(config.buildsha, config.appVersion))
 
   app.use(setupApiRateLimiterAfterCachingInit(config, cachingService))


### PR DESCRIPTION
I suspect this is a fix for https://github.com/clearlydefined/service/issues/1296.

Investigation: I noticed that we were seeing a lot of 429 errors even though our average usage was significantly <250/minute. When I checked out the SwaggerUi I noticed that the `ratelimit-remaining` header was going down by more than 1 per request. I thought there might be a weighting component to the calls (IE a batch api with multiple results counts multiple times) but could find no evidence of that in the code. I then realized that the `ratelimit-remaining` header seems to go down faster the longer I leave between requests. So my hypothesis became that we're somehow sharing a ratelimit "unique identifier" with someone else. Knowing that I learned that the "key" is your IP address by default and the service seems to have stuck with that default. THAT lead me [to this page](https://expressjs.com/en/guide/behind-proxies.html) describing proxy best practices, where I saw `app.set('trust proxy', true)` and realized that's not actually what we wrote, so everyone on the same reverse-proxy instance (Cloudflare based on the headers) is sharing a ratelimit.

Testing: I have no idea how to test this hypothesis given that it involves reverse-proxys which don't seem to be a part of the docker development container, and that I have limited experience in ExpressJS. I am tempted to just say that this change follows the ExpressJS documentation and implements the original intent of this code, and test in the dev instance. But I am open to suggestions on how to test my hypothesis.