### PR TITLE
Fix redis connection timeout on service startup

### DIFF
--- a/providers/caching/redis.js
+++ b/providers/caching/redis.js
@@ -139,7 +139,7 @@ class RedisCache {
    * @param {RedisCacheOptions} options - Redis connection configuration
    * @returns {RedisClientType} A new Redis client instance
    */
-  static buildRedisClient({ apiKey, service, port = 6380, tls }) {
+  static buildRedisClient({ apiKey, service, port = 6380, tls = true }) {
     /** @type {RedisSocketOptions} Socket configuration options for Redis connection */
     let socketOptions
 

--- a/providers/caching/redisConfig.js
+++ b/providers/caching/redisConfig.js
@@ -23,7 +23,7 @@ function serviceFactory(options) {
   const realOptions = options || {
     service: config.get('CACHING_REDIS_SERVICE'),
     apiKey: config.get('CACHING_REDIS_API_KEY'),
-    port: Number(config.get('CACHING_REDIS_PORT')) || 6379
+    port: Number(config.get('CACHING_REDIS_PORT')) || 6380
   }
   return redis(realOptions)
 }


### PR DESCRIPTION
Recent changes in redis.js and redisConfig.js ([see diff here](https://github.com/clearlydefined/service/pull/1340/files#diff-702ddd33b533c6cf1d13731acaf17e79465c9135cad09a5a7aaf5a99b7fbeb21)) modified the default values for the Redis port and TLS settings. These changes have caused Redis connection timeouts during service startup. Please see the error trace below:

```
2025-12-16T23:22:04.9926796Z Error initializing the Express app: ConnectionTimeoutError: Connection timeout
2025-12-16T23:22:04.9927317Z     at Socket.onTimeout (/opt/service/node_modules/@redis/client/dist/lib/client/socket.js:207:46)
2025-12-16T23:22:04.9927338Z     at Object.onceWrapper (node:events:622:28)
2025-12-16T23:22:04.9927355Z     at Socket.emit (node:events:508:28)
2025-12-16T23:22:04.9927372Z     at Socket._onTimeout (node:net:604:8)
2025-12-16T23:22:04.9927389Z     at listOnTimeout (node:internal/timers:605:17)
2025-12-16T23:22:04.9927406Z     at process.processTimers (node:internal/timers:541:7)
```

Revert the default values for the port and TLS settings to their previous values to resolve this issue.