### PR TITLE
Update Dockerfile entrypoint to use node directly

### DIFF
--- a/DevDockerfile
+++ b/DevDockerfile
@@ -27,5 +27,6 @@ WORKDIR "${APPDIR}"
 COPY . "${APPDIR}"
 
 ENV PORT 4000
+ENV NODE_OPTIONS="--max-old-space-size=8192"
 EXPOSE 4000 2222
-ENTRYPOINT ["npm", "start"]
+ENTRYPOINT ["node", "./bin/www"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,6 @@ WORKDIR "${APPDIR}"
 COPY . "${APPDIR}"
 
 ENV PORT 4000
+ENV NODE_OPTIONS="--max-old-space-size=8192"
 EXPOSE 4000 2222
-ENTRYPOINT ["npm", "start"]
+ENTRYPOINT ["node", "./bin/www"]


### PR DESCRIPTION
Overview
This PR improves Docker container behavior by replacing the npm-based entrypoint with direct Node.js execution, enabling proper signal handling and graceful container shutdown.

Background:
the server fails to start with the following error:
```
2025-12-17T06:31:53.7248178Z npm ERR! path /opt/service
2025-12-17T06:31:53.7249081Z npm ERR! command failed
2025-12-17T06:31:53.7251978Z npm ERR! signal SIGTERM
2025-12-17T06:31:53.7254913Z npm ERR! command sh -c "node --max-old-space-size=8192 ./bin/www"
2025-12-17T06:31:53.7336171Z npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2025-12-17T06_28_02_218Z-debug-0.log
```
The issue is likely caused by the memory allocation setting: the process is requesting 8GB, which exceeds the 7GB provisioned on our dev App Service Plan. This is a known issue tracked at https://github.com/clearlydefined/service/issues/1256.

Key Changes:
- Entrypoint Update
- Memory Configuration: Added ENV NODE_OPTIONS="--max-old-space-size=8192" for configurable memory allocation.  We can potentially set this to a lower value on dev deployment.
