### PR TITLE
fix(logging): circular JSON errors in Winston logs by summarizing HTTP/Axios objects

### DIFF
--- a/providers/logging/winstonConfig.js
+++ b/providers/logging/winstonConfig.js
@@ -10,11 +10,67 @@ const SENSITIVE_HEADERS = ['x-api-key', 'authorization', 'proxy-authorization', 
 /** @typedef {import('./winstonConfig.d.ts').WinstonLoggerOptions} WinstonLoggerOptions */
 
 /**
+ * Sanitizes headers by redacting sensitive values.
+ * @param {Record<string, string> | null | undefined} headers
+ * @returns {Record<string, string>}
+ */
+const sanitizeHeaders = headers =>
+  Object.fromEntries(
+    Object.entries(headers || {}).map(([key, value]) =>
+      SENSITIVE_HEADERS.includes(key.toLowerCase()) ? [key, '<REDACTED>'] : [key, value]
+    )
+  )
+
+/**
+ * Winston format that sanitizes metadata to prevent circular JSON errors.
+ * Summarizes HTTP request/response objects and Axios configs.
+ */
+const sanitizeMeta = winston.format(info => {
+  // Summarize HTTP request
+  if (info['req'] && typeof info['req'] === 'object') {
+    const req = /** @type {any} */ (info['req'])
+    info['req'] = {
+      method: req['method'],
+      url: req['originalUrl'] || req['url'],
+      requestId: req['id'],
+      correlationId: req['headers'] && req['headers']['x-correlation-id']
+    }
+  }
+
+  // Summarize HTTP response
+  if (info['res'] && typeof info['res'] === 'object') {
+    const res = /** @type {any} */ (info['res'])
+    info['res'] = {
+      statusCode: res['statusCode']
+    }
+  }
+
+  // Handle generic aliases
+  if (info['request'] && !info['req']) {
+    info['request'] = '[request omitted]'
+  }
+  if (info['response'] && !info['res']) {
+    info['response'] = '[response omitted]'
+  }
+
+  // Summarize Axios config
+  if (info['config'] && typeof info['config'] === 'object') {
+    const cfg = /** @type {any} */ (info['config'])
+    info['config'] = {
+      method: cfg.method,
+      url: cfg.url,
+      headers: sanitizeHeaders(cfg.headers)
+    }
+  }
+
+  return info
+})
+
+/**
  * Factory function to create a Winston logger instance.
  * @param {WinstonLoggerOptions} [options] - Configuration options for the logger.
  * @returns {winston.Logger} A configured Winston logger instance with Application Insights transport.
  */
-
 function factory(options) {
   const realOptions = {
     connectionString: config.get('APPLICATIONINSIGHTS_CONNECTION_STRING'),
@@ -24,54 +80,6 @@ function factory(options) {
   }
 
   mockInsights.setup(realOptions.connectionString || 'mock', realOptions.echo)
-
-  const sanitizeHeaders = (headers = {}) =>
-    Object.fromEntries(
-      Object.entries(headers).map(([key, value]) =>
-        SENSITIVE_HEADERS.includes(key.toLowerCase()) ? [key, '<REDACTED>'] : [key, value]
-      )
-    )
-
-  const sanitizeMeta = winston.format(info => {
-    // Summarize HTTP request
-    if (info['req'] && typeof info['req'] === 'object') {
-      const req = /** @type {any} */ (info['req'])
-      info['req'] = {
-        method: req['method'],
-        url: req['originalUrl'] || req['url'],
-        requestId: req['id'],
-        correlationId: req['headers'] && req['headers']['x-correlation-id']
-      }
-    }
-
-    // Summarize HTTP response
-    if (info['res'] && typeof info['res'] === 'object') {
-      const res = /** @type {any} */ (info['res'])
-      info['res'] = {
-        statusCode: res['statusCode']
-      }
-    }
-
-    // Handle generic aliases
-    if (info['request'] && !info['req']) {
-      info['request'] = '[request omitted]'
-    }
-    if (info['response'] && !info['res']) {
-      info['response'] = '[response omitted]'
-    }
-
-    // Summarize Axios config
-    if (info['config'] && typeof info['config'] === 'object') {
-      const cfg = /** @type {any} */ (info['config'])
-      info['config'] = {
-        method: cfg.method,
-        url: cfg.url,
-        headers: sanitizeHeaders(cfg.headers)
-      }
-    }
-
-    return info
-  })
 
   const logFormat = winston.format.combine(
     sanitizeMeta(),
@@ -146,3 +154,5 @@ function mapLevel(level) {
 }
 
 module.exports = factory
+module.exports.sanitizeHeaders = sanitizeHeaders
+module.exports.sanitizeMeta = sanitizeMeta

--- a/test/providers/logging/winstonConfig.js
+++ b/test/providers/logging/winstonConfig.js
@@ -1,0 +1,326 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+const { expect } = require('chai')
+const { sanitizeHeaders, sanitizeMeta } = require('../../../providers/logging/winstonConfig')
+
+describe('sanitizeHeaders', () => {
+  it('should return empty object for undefined', () => {
+    const result = sanitizeHeaders(undefined)
+    expect(result).to.deep.equal({})
+  })
+
+  it('should return empty object for null', () => {
+    const result = sanitizeHeaders(null)
+    expect(result).to.deep.equal({})
+  })
+
+  it('should return empty object for empty object', () => {
+    const result = sanitizeHeaders({})
+    expect(result).to.deep.equal({})
+  })
+
+  it('should pass through non-sensitive headers unchanged', () => {
+    const headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'X-Request-Id': '12345'
+    }
+    const result = sanitizeHeaders(headers)
+    expect(result).to.deep.equal(headers)
+  })
+
+  it('should redact x-api-key header', () => {
+    const headers = { 'x-api-key': 'secret-key' }
+    const result = sanitizeHeaders(headers)
+    expect(result).to.deep.equal({ 'x-api-key': '<REDACTED>' })
+  })
+
+  it('should redact authorization header', () => {
+    const headers = { authorization: 'Bearer token123' }
+    const result = sanitizeHeaders(headers)
+    expect(result).to.deep.equal({ authorization: '<REDACTED>' })
+  })
+
+  it('should redact proxy-authorization header', () => {
+    const headers = { 'proxy-authorization': 'Basic xyz' }
+    const result = sanitizeHeaders(headers)
+    expect(result).to.deep.equal({ 'proxy-authorization': '<REDACTED>' })
+  })
+
+  it('should redact cookie header', () => {
+    const headers = { cookie: 'session=abc123' }
+    const result = sanitizeHeaders(headers)
+    expect(result).to.deep.equal({ cookie: '<REDACTED>' })
+  })
+
+  it('should handle case-insensitive header names', () => {
+    const headers = {
+      Authorization: 'Bearer token',
+      'X-API-KEY': 'secret',
+      Cookie: 'session=123'
+    }
+    const result = sanitizeHeaders(headers)
+    expect(result).to.deep.equal({
+      Authorization: '<REDACTED>',
+      'X-API-KEY': '<REDACTED>',
+      Cookie: '<REDACTED>'
+    })
+  })
+
+  it('should redact sensitive headers while preserving non-sensitive ones', () => {
+    const headers = {
+      'Content-Type': 'application/json',
+      authorization: 'Bearer secret',
+      'x-api-key': 'api-secret',
+      Accept: 'application/json'
+    }
+    const result = sanitizeHeaders(headers)
+    expect(result).to.deep.equal({
+      'Content-Type': 'application/json',
+      authorization: '<REDACTED>',
+      'x-api-key': '<REDACTED>',
+      Accept: 'application/json'
+    })
+  })
+})
+
+describe('sanitizeMeta', () => {
+  /** @type {ReturnType<typeof sanitizeMeta>} */
+  let format
+
+  beforeEach(() => {
+    format = sanitizeMeta()
+  })
+
+  describe('HTTP request sanitization', () => {
+    it('should summarize req object', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        req: {
+          method: 'GET',
+          originalUrl: '/api/test',
+          id: 'req-123',
+          headers: { 'x-correlation-id': 'corr-456' },
+          socket: { circular: 'reference' }
+        }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.req).to.deep.equal({
+        method: 'GET',
+        url: '/api/test',
+        requestId: 'req-123',
+        correlationId: 'corr-456'
+      })
+    })
+
+    it('should use url if originalUrl is not present', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        req: {
+          method: 'POST',
+          url: '/api/fallback',
+          id: 'req-789'
+        }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.req.url).to.equal('/api/fallback')
+    })
+
+    it('should handle req without headers', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        req: {
+          method: 'GET',
+          url: '/test'
+        }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.req).to.deep.equal({
+        method: 'GET',
+        url: '/test',
+        requestId: undefined,
+        correlationId: undefined
+      })
+    })
+  })
+
+  describe('HTTP response sanitization', () => {
+    it('should summarize res object', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        res: {
+          statusCode: 200,
+          socket: { circular: 'reference' },
+          _header: 'HTTP/1.1 200 OK'
+        }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.res).to.deep.equal({
+        statusCode: 200
+      })
+    })
+  })
+
+  describe('generic request/response aliases', () => {
+    it('should replace request field when req is not present', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        request: { some: 'data', circular: {} }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.request).to.equal('[request omitted]')
+    })
+
+    it('should replace response field when res is not present', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        response: { some: 'data', circular: {} }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.response).to.equal('[response omitted]')
+    })
+
+    it('should not replace request field when req is present', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        req: { method: 'GET', url: '/test' },
+        request: { some: 'data' }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.request).to.deep.equal({ some: 'data' })
+    })
+
+    it('should not replace response field when res is present', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        res: { statusCode: 200 },
+        response: { some: 'data' }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.response).to.deep.equal({ some: 'data' })
+    })
+  })
+
+  describe('Axios config sanitization', () => {
+    it('should summarize config object', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        config: {
+          method: 'post',
+          url: 'https://api.example.com/data',
+          headers: {
+            'Content-Type': 'application/json',
+            authorization: 'Bearer secret'
+          },
+          data: { payload: 'data' },
+          transformRequest: [function () {}]
+        }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.config).to.deep.equal({
+        method: 'post',
+        url: 'https://api.example.com/data',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: '<REDACTED>'
+        }
+      })
+    })
+
+    it('should handle config with null headers', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        config: {
+          method: 'get',
+          url: 'https://api.example.com',
+          headers: null
+        }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.config).to.deep.equal({
+        method: 'get',
+        url: 'https://api.example.com',
+        headers: {}
+      })
+    })
+
+    it('should handle config with undefined headers', () => {
+      const info = {
+        level: 'info',
+        message: 'test',
+        config: {
+          method: 'get',
+          url: 'https://api.example.com'
+        }
+      }
+
+      const result = format.transform(info)
+
+      expect(result.config).to.deep.equal({
+        method: 'get',
+        url: 'https://api.example.com',
+        headers: {}
+      })
+    })
+  })
+
+  describe('passthrough behavior', () => {
+    it('should pass through info without req/res/config unchanged', () => {
+      const info = {
+        level: 'info',
+        message: 'test message',
+        customField: 'value'
+      }
+
+      const result = format.transform(info)
+
+      expect(result).to.deep.equal(info)
+    })
+
+    it('should preserve other metadata fields', () => {
+      const info = {
+        level: 'error',
+        message: 'error occurred',
+        req: { method: 'GET', url: '/test' },
+        error: 'Something went wrong',
+        userId: 'user-123'
+      }
+
+      const result = format.transform(info)
+
+      expect(result.error).to.equal('Something went wrong')
+      expect(result.userId).to.equal('user-123')
+    })
+  })
+})


### PR DESCRIPTION
# Description

After the recent logging changes in [PR #1340](https://github.com/clearlydefined/service/pull/1340), Winston started throwing `Converting circular structure to JSON` errors when logging HTTP requests/responses or Axios errors. This was caused by `req`, `res`, and `config` objects containing circular references that cannot be stringified directly.

# Changes made

1. Introduced a new `sanitizeMeta` Winston format to safely summarize log metadata.
2. Summarizes the following objects instead of logging them directly:
    - `req` → only logs `{ method, url, requestId, correlationId }`
    - `res` → only logs `{ statusCode }`
    - `config` (Axios request config) → only logs `{ method, url, headers['X-Api-Key'] }`
3. Generic `request`/`response` aliases are replaced with `"[request omitted]"` / `"[response omitted]"` when no `req`/`res` exist.
4. Keeps stack traces and main error message intact.

# Log examples

**Before this fix:**

```text
2026-01-02T16:55:40.936Z [error]: SvcRequestFailure: /status/toolsranperday Converting circular structure to JSON
Exception: 
Error: SvcRequestFailure: /status/toolsranperday Converting circular structure to JSON
    --> starting at object with constructor 'ClientRequest'
    |     property 'res' -> object with constructor 'IncomingMessage'
    --- property 'req' closes the circle
GET /status/toolsranperday 500 31.963 ms
```

**After this fix:**

```text
2026-01-02T16:52:49.612Z [error]: Status service failed for toolsranperday Request failed with status code 404
{
  "name": "AxiosError",
  "code": "ERR_BAD_REQUEST",
  "config": {
    "method": "post",
    "url": "https://api.applicationinsights.io/v1/apps/<APP_ID>/query",
    "headers": {
      "Accept": "application/json, text/plain, */*",
      "Content-Type": "application/json; charset=utf-8",
      "User-Agent": "clearlydefined.io crawler",
      "X-Api-Key": "<REDACTED>",
      "Content-Length": "349",
      "Accept-Encoding": "gzip, compress, deflate, br"
    }
  },
  "request": "[request omitted]",
  "response": "[response omitted]",
  "status": 404,
  "statusCode": 404,
  "stack": "AxiosError: Request failed with status code 404\n    at async callFetch (...) \n    at async StatusService._toolsranperday (...) \n    at async StatusService.get (...) \n    at async getRequests (...)"
}
```