### PR TITLE
chore(deps): remove `@types/winston`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,6 @@
         "@types/spdx-expression-parse": "3.0.5",
         "@types/swagger-ui-express": "4.1.8",
         "@types/tmp": "0.2.6",
-        "@types/winston": "2.4.4",
         "@types/xml2js": "0.4.14",
         "chai": "^4.5.0",
         "chai-as-promised": "^7.1.2",
@@ -2124,17 +2123,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
-      }
-    },
-    "node_modules/@types/winston": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
-      "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
-      "deprecated": "This is a stub types definition. winston provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "winston": "*"
       }
     },
     "node_modules/@types/ws": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "@types/spdx-expression-parse": "3.0.5",
     "@types/swagger-ui-express": "4.1.8",
     "@types/tmp": "0.2.6",
-    "@types/winston": "2.4.4",
     "@types/xml2js": "0.4.14",
     "chai": "^4.5.0",
     "chai-as-promised": "^7.1.2",


### PR DESCRIPTION
Remove `@types/winston` from `devDependencies` since `winston` provides its own type definitions (the `@types` package is just a stub)

This is part of a series of PRs to address deprecated packages in the project.

## Stack
- Depends on #1410 
- This PR
- #1412 