### PR TITLE
chore(deps): remove unused `vso-node-api` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "throat": "^6.0.2",
         "tiny-attribution-generator": "0.1.3",
         "tmp": "0.2.5",
-        "vso-node-api": "6.5.0",
         "winston": "^3.17.0",
         "xml2js": "0.6.2"
       },
@@ -10829,15 +10828,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha512-o9QYRJN5WgS8oCtqvwzzcfnzaTnDPr7HpUsQdSXscTyzXbjvl4wSHPTUKOKzEaDeQvOuyRtt3ui+ujM7x7TReQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -10927,22 +10917,6 @@
         "node": ">=6.0.0",
         "npm": ">=3.0.0"
       }
-    },
-    "node_modules/typed-rest-client": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-      "integrity": "sha512-OsqQHQPP3x1ci8vNPtTQws98b+B/NZAXByZo3vw0y8SFf2nVp/Gh1084t+6LW/g+0mhf0rayqLNAiQ+ItHEIPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "0.0.4",
-        "underscore": "1.8.3"
-      }
-    },
-    "node_modules/typed-rest-client/node_modules/underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
-      "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -11156,24 +11130,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
-    },
-    "node_modules/vso-node-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
-      "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
-      "deprecated": "use azure-devops-node-api. vso-node-api has been renamed to azure-devops-node-api",
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "0.0.4",
-        "typed-rest-client": "^0.12.0",
-        "underscore": "1.8.3"
-      }
-    },
-    "node_modules/vso-node-api/node_modules/underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
       "license": "MIT"
     },
     "node_modules/walk-back": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "throat": "^6.0.2",
     "tiny-attribution-generator": "0.1.3",
     "tmp": "0.2.5",
-    "vso-node-api": "6.5.0",
     "winston": "^3.17.0",
     "xml2js": "0.6.2"
   },


### PR DESCRIPTION
## Summary

- Remove the deprecated `vso-node-api` package entirely since it is not used anywhere in the codebase

This is part of a series of PRs to address deprecated packages in the project.

### Stack
- Depends on #1410 
- Depends on #1411
- This PR