### PR TITLE
fix(test): use fake timers to speed up webhook and curation tests

### DIFF
--- a/test/providers/curation/processTest.js
+++ b/test/providers/curation/processTest.js
@@ -7,10 +7,21 @@ const memoryQueue = require('../../../providers/queueing/memoryQueue')
 const sinon = require('sinon')
 
 describe('Curation queue processing', () => {
+  let clock
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers()
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
   it('handles opened message', async function () {
-    this.timeout(12000)
     const { queue, curationService, logger } = setup({ action: 'opened' })
-    await process(queue, curationService, logger, true)
+    const promise = process(queue, curationService, logger, true)
+    await clock.runAllAsync()
+    await promise
 
     expect(curationService.getContributedCurations.calledOnce).to.be.true
     expect(curationService.validateContributions.calledOnce).to.be.true
@@ -21,9 +32,10 @@ describe('Curation queue processing', () => {
   })
 
   it('handles synchronize message', async function () {
-    this.timeout(12000)
     const { queue, curationService, logger } = setup({ action: 'synchronize' })
-    await process(queue, curationService, logger, true)
+    const promise = process(queue, curationService, logger, true)
+    await clock.runAllAsync()
+    await promise
 
     expect(curationService.getContributedCurations.calledOnce).to.be.true
     expect(curationService.validateContributions.calledOnce).to.be.true
@@ -34,9 +46,10 @@ describe('Curation queue processing', () => {
   })
 
   it('handles closed message', async function () {
-    this.timeout(12000)
     const { queue, curationService, logger } = setup({ action: 'closed' })
-    await process(queue, curationService, logger, true)
+    const promise = process(queue, curationService, logger, true)
+    await clock.runAllAsync()
+    await promise
 
     expect(curationService.getContributedCurations.calledOnce).to.be.false
     expect(curationService.validateContributions.calledOnce).to.be.false

--- a/test/routes/webhookGitHubTests.js
+++ b/test/routes/webhookGitHubTests.js
@@ -7,6 +7,16 @@ const httpMocks = require('node-mocks-http')
 const sinon = require('sinon')
 
 describe('Webhook Route for GitHub calls', () => {
+  let clock
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers()
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
   it('handles invalid action', async () => {
     const request = createRequest('yeah, right')
     const response = httpMocks.createResponse()
@@ -65,13 +75,14 @@ describe('Webhook Route for GitHub calls', () => {
   // })
 
   it('skips closed event that is not merged', async function () {
-    this.timeout(12000)
     const request = createRequest('closed', false)
     const response = httpMocks.createResponse()
     const logger = createLogger()
     const service = createCurationService()
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
-    await router._handlePost(request, response)
+    const promise = router._handlePost(request, response)
+    await clock.runAllAsync()
+    await promise
     expect(response.statusCode).to.be.eq(200)
     expect(service.validateContributions.calledOnce).to.be.false
     expect(service.addByMergedCuration.calledOnce).to.be.true
@@ -82,13 +93,14 @@ describe('Webhook Route for GitHub calls', () => {
   })
 
   it('calls valid for PR changes', async function () {
-    this.timeout(12000)
     const request = createRequest('opened')
     const response = httpMocks.createResponse()
     const logger = createLogger()
     const service = createCurationService()
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
-    await router._handlePost(request, response)
+    const promise = router._handlePost(request, response)
+    await clock.runAllAsync()
+    await promise
     expect(response.statusCode).to.be.eq(200)
     expect(service.validateContributions.calledOnce).to.be.true
     expect(service.updateContribution.calledOnce).to.be.true
@@ -97,13 +109,14 @@ describe('Webhook Route for GitHub calls', () => {
   })
 
   it('calls missing for PR changes', async function () {
-    this.timeout(12000)
     const request = createRequest('opened')
     const response = httpMocks.createResponse()
     const logger = createLogger()
     const service = createCurationService()
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
-    await router._handlePost(request, response)
+    const promise = router._handlePost(request, response)
+    await clock.runAllAsync()
+    await promise
     expect(response.statusCode).to.be.eq(200)
     expect(service.validateContributions.calledOnce).to.be.true
     expect(service.updateContribution.calledOnce).to.be.true
@@ -112,24 +125,26 @@ describe('Webhook Route for GitHub calls', () => {
   })
 
   it('validates the curation when a PR is opened', async function () {
-    this.timeout(12000)
     const request = createRequest('opened')
     const response = httpMocks.createResponse()
     const logger = createLogger()
     const service = createCurationService()
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
-    await router._handlePost(request, response)
+    const promise = router._handlePost(request, response)
+    await clock.runAllAsync()
+    await promise
     expect(service.validateContributions.calledOnce).to.be.true
   })
 
   it('validates the curation when a PR is reopened', async function () {
-    this.timeout(12000)
     const request = createRequest('reopened')
     const response = httpMocks.createResponse()
     const logger = createLogger()
     const service = createCurationService()
     const router = webhookRoutes(service, null, logger, 'secret', 'secret', true)
-    await router._handlePost(request, response)
+    const promise = router._handlePost(request, response)
+    await clock.runAllAsync()
+    await promise
     expect(service.validateContributions.calledOnce).to.be.true
   })
 })


### PR DESCRIPTION
Use Sinon fake timers to eliminate 10-second delays in webhook and curation queue tests, reducing test suite runtime from ~1.5 minutes to ~12 seconds.

The webhook route and curation queue processing code contains hardcoded 10-second delays to handle GitHub's eventual consistency:

```javascript
await new Promise(resolve => setTimeout(resolve, 10 * 1000))
```

These delays were being executed during tests, causing 8 tests to each wait 10 seconds for a total of ~80 seconds of unnecessary wait time.

This PR uses Sinon's `useFakeTimers()` with `clock.runAllAsync()` to instantly advance through all pending timers without waiting for real time.

| Metric | Before | After |
|--------|--------|-------|
| Test suite time | ~1m 32s | ~12s |
| Improvement | - | **87% faster** |