### PR TITLE
Fix regex security issues in hostname matching and string replacement

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -753,7 +753,7 @@ const _licenseUrlOverrides = [
     licenseMatchGroup: 1
   },
   {
-    test: /^\w*https?:\/\/(?:www.)?json\.org\/license\.html$/i,
+    test: /^\w*https?:\/\/(?:www\.)?json\.org\/license\.html$/i,
     license: 'JSON'
   },
   {
@@ -773,7 +773,7 @@ const _licenseUrlOverrides = [
     license: 'Apache-2.0'
   },
   {
-    test: /^\w*https?:\/\/raw.githubusercontent.com\/NuGet\/NuGet.Client\/dev\/LICENSE.txt/i,
+    test: /^\w*https?:\/\/raw\.githubusercontent\.com\/NuGet\/NuGet\.Client\/dev\/LICENSE\.txt/i,
     license: 'Apache-2.0'
   },
   {
@@ -785,7 +785,7 @@ const _licenseUrlOverrides = [
     license: 'Apache-2.0'
   },
   {
-    test: /^\w*https?:\/\/www.github.com\/fsharp\/Fake\/blob\/master\/License.txt/i,
+    test: /^\w*https?:\/\/www\.github\.com\/fsharp\/Fake\/blob\/master\/License\.txt/i,
     license: 'Apache-2.0 AND MS-PL'
   },
   {
@@ -811,20 +811,20 @@ const _licenseUrlOverrides = [
   // EULA licenses should be defined as OTHER
   { test: /^https?:\/\/aka\.ms\/(devservicesagreement|pexunj)/i, license: 'OTHER' },
   { test: /^https?:\/\/applitools.com\/eula\/sdk/i, license: 'OTHER' },
-  { test: /^https?:\/\/company.aspose.com\/legal\/eula/i, license: 'OTHER' },
-  { test: /^https?:\/\/www.componentone.com\/SuperPages\/DevToolsEULA/i, license: 'OTHER' },
-  { test: /^https?:\/\/(www|js).devexpress.com(\/.+)?\/eulas/i, license: 'OTHER' },
+  { test: /^https?:\/\/company\.aspose\.com\/legal\/eula/i, license: 'OTHER' },
+  { test: /^https?:\/\/www\.componentone\.com\/SuperPages\/DevToolsEULA/i, license: 'OTHER' },
+  { test: /^https?:\/\/(www|js)\.devexpress\.com(\/.+)?\/eulas/i, license: 'OTHER' },
   { test: /^https?:\/\/dlhsoft.com\/LicenseAgreements\/(.*)?EULA.rtf/i, license: 'OTHER' },
-  { test: /^https?:\/\/www.essentialobjects.com(\/.+)?\/EULA.aspx/i, license: 'OTHER' },
+  { test: /^https?:\/\/www\.essentialobjects\.com(\/.+)?\/EULA\.aspx/i, license: 'OTHER' },
   {
     test: /^https?:\/\/go\.microsoft\.com(\/.*)?\/?\?linkid=(214339|218949|235167|248155|253898|259741|261796|262998|272666|273778|281843|317295|320539|329770|529443|536623|614949|698879|746386|832965|838619|838620|9809688|9862941)/i,
     license: 'OTHER'
   },
-  { test: /^https?:\/\/kusto.blob.core.windows.net\/kusto-nuget\/EULA-agreement.htm/i, license: 'OTHER' },
+  { test: /^https?:\/\/kusto\.blob\.core\.windows\.net\/kusto-nuget\/EULA-agreement\.htm/i, license: 'OTHER' },
   { test: /^https?:\/\/www\.microsoft\.com(\/.+)?\/web\/webpi\/eula\//i, license: 'OTHER' },
-  { test: /^https?:\/\/pdfium.patagames.com\/faq\/eula/i, license: 'OTHER' },
+  { test: /^https?:\/\/pdfium\.patagames\.com\/faq\/eula/i, license: 'OTHER' },
   { test: /^https?:\/\/specflow.org\/plus\/eula\//i, license: 'OTHER' },
-  { test: /^https?:\/\/www.streamcoders.com\/products\/msneteula.html/i, license: 'OTHER' },
+  { test: /^https?:\/\/www\.streamcoders\.com\/products\/msneteula\.html/i, license: 'OTHER' },
   { test: /^https?:\/\/workflowenginenet.com\/EULA/i, license: 'OTHER' },
   { test: /^https?:\/\/aka.ms\/azureml-sdk-license/i, license: 'OTHER' },
   {

--- a/routes/originNpm.js
+++ b/routes/originNpm.js
@@ -13,7 +13,7 @@ router.get(
     const baseUrl = 'https://registry.npmjs.com'
     const { namespace, name } = request.params
     const fullName = namespace ? `${namespace}/${name}` : name
-    const url = `${baseUrl}/${encodeURIComponent(fullName).replace('%40', '@')}` // npmjs doesn't handle the escaped version
+    const url = `${baseUrl}/${encodeURIComponent(fullName).replace(/%40/g, '@')}` // npmjs doesn't handle the escaped version
     const answer = await requestPromise({ url, method: 'GET', json: true })
     const result = Object.getOwnPropertyNames(answer.versions).sort((a, b) => (a < b ? 1 : a > b ? -1 : 0))
     return response.status(200).send(uniq(result))


### PR DESCRIPTION
## Summary

This PR fixes 11 CodeQL security alerts by addressing two types of issues:

**Incomplete string replacement** (`routes/originNpm.js:16`)
- Changed `replace('%40', '@')` to `replace(/%40/g, '@')` so all encoded @ symbols get replaced, not just the first one

**Unescaped dots in hostname regexes** (`lib/utils.js`, 10 instances)
- Dots in regex patterns like `/json.org/` match any character, not literal dots
- This could allow `jsonXorg` to match where only `json.org` should
- Fixed by escaping: `/json\.org/`

Affected domains: json.org, raw.githubusercontent.com, www.github.com, company.aspose.com, www.componentone.com, devexpress.com, www.essentialobjects.com, kusto.blob.core.windows.net, pdfium.patagames.com, www.streamcoders.com