### PR TITLE
Fix App Insights 3.x connection string configuration

### DIFF
--- a/lib/mockInsights.d.ts
+++ b/lib/mockInsights.d.ts
@@ -25,10 +25,10 @@ declare class MockInsights {
   /**
    * Sets up the Application Insights abstraction layer
    *
-   * @param key - Application Insights instrumentation key. If null, undefined, or 'mock', uses console-based logging
+   * @param connectionString - Application Insights connection string. If null, undefined, or 'mock', uses console-based logging
    * @param echo - Whether to echo telemetry to both console and Application Insights client when both are available
    */
-  static setup(key?: string | null, echo?: boolean): void
+  static setup(connectionString?: string | null, echo?: boolean): void
 
   /**
    * Tracks an exception

--- a/lib/mockInsights.js
+++ b/lib/mockInsights.js
@@ -64,21 +64,21 @@ class MockInsights {
 
   /**
    * Sets up the Application Insights abstraction layer. This method configures the telemetry client
-   * based on the provided key, creating either a full Application Insights client or a console-based fallback wrapper.
+   * based on the provided connection string, creating either a full Application Insights client or a console-based fallback wrapper.
    *
-   * @param {string | null} [key=null] - Application Insights instrumentation key. If null, undefined, or 'mock', uses
-   *   console-based logging. Default is `null`
+   * @param {string | null} [connectionString=null] - Application Insights connection string. If null, undefined, or
+   *   'mock', uses console-based logging. Default is `null`
    * @param {boolean} [echo=false] - Whether to echo telemetry to both console and Application Insights client when both
    *   are available. Default is `false`
    * @returns {void}
    */
-  static setup(key = null, echo = false) {
+  static setup(connectionString = null, echo = false) {
     // exit if we are already setup
     if (_client instanceof MockInsights) return
-    if (!key || key === 'mock') {
+    if (!connectionString || connectionString === 'mock') {
       _client = new MockInsights()
     } else {
-      appInsights.setup(key).setAutoCollectPerformance(false).setAutoCollectDependencies(true).start()
+      appInsights.setup(connectionString).setAutoCollectPerformance(false).setAutoCollectDependencies(true).start()
       if (echo) {
         _client = new MockInsights(appInsights.defaultClient)
       } else {

--- a/providers/logging/winstonConfig.d.ts
+++ b/providers/logging/winstonConfig.d.ts
@@ -6,10 +6,10 @@ import * as winston from 'winston'
 /** Configuration options for creating a Winston logger instance. */
 export interface WinstonLoggerOptions {
   /**
-   * Application Insights instrumentation key for logging. If not provided, uses APPINSIGHTS_INSTRUMENTATIONKEY from
-   * config.
+   * Application Insights connection string for logging. If not provided, uses APPLICATIONINSIGHTS_CONNECTION_STRING
+   * from config.
    */
-  key?: string
+  connectionString?: string
 
   /**
    * Whether to echo log messages to the console.

--- a/providers/logging/winstonConfig.js
+++ b/providers/logging/winstonConfig.js
@@ -16,13 +16,13 @@ const mockInsights = require('../../lib/mockInsights')
 
 function factory(options) {
   const realOptions = {
-    key: config.get('APPINSIGHTS_INSTRUMENTATIONKEY'),
+    connectionString: config.get('APPLICATIONINSIGHTS_CONNECTION_STRING'),
     echo: config.get('LOGGER_LOG_TO_CONSOLE') === 'true',
     level: config.get('APPINSIGHTS_EXPORT_LOG_LEVEL') || 'info',
     ...options
   }
 
-  mockInsights.setup(realOptions.key || 'mock', realOptions.echo)
+  mockInsights.setup(realOptions.connectionString || 'mock', realOptions.echo)
 
   const logFormat = winston.format.combine(
     winston.format.timestamp(),


### PR DESCRIPTION
## Summary

The applicationinsights 3.x SDK (upgraded in #1425) requires a connection string, not an instrumentation key. The code was still reading `APPINSIGHTS_INSTRUMENTATIONKEY`, which the new SDK tried to parse as a connection string and failed.

## Changes

- Read `APPLICATIONINSIGHTS_CONNECTION_STRING` env var instead of `APPINSIGHTS_INSTRUMENTATIONKEY`
- Rename the `key` parameter to `connectionString` in `MockInsights.setup()` and `WinstonLoggerOptions`
- Update JSDoc and TypeScript type definitions

## Deployment note

Set the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable. The connection string is available in the Azure Portal under Application Insights > Overview > Connection String.