### PR TITLE
chore: upgrade mongodb from 6.16.0 to 6.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "memory-cache": "0.2.0",
         "minimatch": "10.2.4",
         "mkdirp": "3.0.1",
-        "mongodb": "6.16.0",
+        "mongodb": "6.21.0",
         "morgan": "1.10.1",
         "painless-config": "0.1.2",
         "pako": "2.1.0",
@@ -9036,14 +9036,14 @@
       "license": "MIT"
     },
     "node_modules/mongodb": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
-      "integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.3",
-        "mongodb-connection-string-url": "^3.0.0"
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
       },
       "engines": {
         "node": ">=16.20.1"
@@ -9054,7 +9054,7 @@
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
+        "snappy": "^7.3.2",
         "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "memory-cache": "0.2.0",
     "minimatch": "10.2.4",
     "mkdirp": "3.0.1",
-    "mongodb": "6.16.0",
+    "mongodb": "6.21.0",
     "morgan": "1.10.1",
     "painless-config": "0.1.2",
     "pako": "2.1.0",


### PR DESCRIPTION
We don't want to do the major version upgrade yet, but we can at least be on the latest patch version.

Related: https://github.com/clearlydefined/service/pull/1505