### PR TITLE
enable Biome `useBlockStatements` rule

### DIFF
--- a/app.js
+++ b/app.js
@@ -243,7 +243,9 @@ function createApp(config) {
     } else {
       // Don't log Azure robot liveness checks
       // https://feedback.azure.com/forums/169385-web-apps/suggestions/32120617-document-healthcheck-url-requirement-for-custom-co
-      if (!request?.url?.includes('robots933456.txt')) logger.error(`SvcRequestFailure: ${request.url}`, error)
+      if (!request?.url?.includes('robots933456.txt')) {
+        logger.error(`SvcRequestFailure: ${request.url}`, error)
+      }
 
       // set locals, only providing error in development
       response.locals.message = error.message

--- a/bin/config.js
+++ b/bin/config.js
@@ -37,7 +37,9 @@ function loadOne(spec, namespace) {
   const getPath = (namespace ? `${namespace}.` : '') + requirePath
   let target = get(providers, getPath)
   try {
-    if (!target) target = require(requirePath)
+    if (!target) {
+      target = require(requirePath)
+    }
     return objectPath ? get(target, objectPath) : target
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e)

--- a/biome.json
+++ b/biome.json
@@ -43,6 +43,7 @@
       },
       "style": {
         "noParameterAssign": "off",
+        "useBlockStatements": "error",
         "useDefaultParameterLast": "off"
       },
       "complexity": {

--- a/business/aggregator.js
+++ b/business/aggregator.js
@@ -80,7 +80,9 @@ class AggregationService {
         mergeDefinitions(result, data.summary)
       }
     }
-    if (!tools.length) return null
+    if (!tools.length) {
+      return null
+    }
     set(result, 'described.tools', tools.reverse())
     const cdSummarized = this._findData('clearlydefined', summarized)
     this._overrideDeclaredLicense(result, cdSummarized, coordinates)
@@ -113,8 +115,12 @@ class AggregationService {
    */
   _findData(toolSpec, summarized) {
     const [tool, toolVersion] = toolSpec.split('/')
-    if (!summarized[tool]) return null
-    if (toolVersion) return { toolSpec, summary: summarized[tool][toolVersion] }
+    if (!summarized[tool]) {
+      return null
+    }
+    if (toolVersion) {
+      return { toolSpec, summary: summarized[tool][toolVersion] }
+    }
 
     const versions = Object.getOwnPropertyNames(summarized[tool])
     const latest = getLatestVersion(versions)
@@ -131,9 +137,13 @@ class AggregationService {
    */
   _normalizeFiles(result, cdSummarized, coordinates) {
     const cdFiles = get(cdSummarized, 'summary.files')
-    if (!cdFiles || !cdFiles.length) return
+    if (!cdFiles || !cdFiles.length) {
+      return
+    }
     const difference = (result.files?.length || 0) - cdFiles.length
-    if (!difference) return
+    if (!difference) {
+      return
+    }
     this.logger.info('difference between summary file count and cd file count', {
       count: difference,
       coordinates: coordinates.toString()

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -92,7 +92,9 @@ class DefinitionService {
     this.search = search
     this.cache = cache
     this.upgradeHandler = upgradeHandler
-    if (this.upgradeHandler) this.upgradeHandler.currentSchema = currentSchema
+    if (this.upgradeHandler) {
+      this.upgradeHandler.currentSchema = currentSchema
+    }
     this.logger = logger()
   }
 
@@ -111,7 +113,9 @@ class DefinitionService {
    * @returns {Promise<Definition | undefined>} The fully rendered definition
    */
   async get(coordinates, pr = null, force = false, expand = null) {
-    if (!validator.validate('coordinates-1.0', coordinates)) return undefined
+    if (!validator.validate('coordinates-1.0', coordinates)) {
+      return undefined
+    }
     if (pr) {
       const curation = this.curationService.get(coordinates, pr)
       return this.compute(coordinates, curation)
@@ -121,7 +125,9 @@ class DefinitionService {
     let result = await this.upgradeHandler.validate(existing)
     if (result) {
       this._logDefinitionStatus(result, coordinates)
-    } else result = force ? await this.computeAndStore(coordinates) : await this.computeStoreAndCurate(coordinates)
+    } else {
+      result = force ? await this.computeAndStore(coordinates) : await this.computeStoreAndCurate(coordinates)
+    }
     return this._trimDefinition(this._cast(result), expand)
   }
 
@@ -134,10 +140,14 @@ class DefinitionService {
     const cacheKey = this._getCacheKey(coordinates)
     this.logger.debug('1:Redis:start', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
     const cached = await this.cache.get(cacheKey)
-    if (cached) return cached
+    if (cached) {
+      return cached
+    }
     this.logger.debug('2:blob+mongoDB:start', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
     const stored = await this.definitionStore.get(coordinates)
-    if (stored) this._setDefinitionInCache(cacheKey, stored)
+    if (stored) {
+      this._setDefinitionInCache(cacheKey, stored)
+    }
     return stored
   }
 
@@ -164,7 +174,9 @@ class DefinitionService {
    * @private
    */
   async _cacheExistingAside(coordinates, force) {
-    if (force) return null
+    if (force) {
+      return null
+    }
     return await this.getStored(coordinates)
   }
 
@@ -195,7 +207,9 @@ class DefinitionService {
    * @private
    */
   _trimDefinition(definition, expand) {
-    if (expand === '-files') return omit(definition, 'files')
+    if (expand === '-files') {
+      return omit(definition, 'files')
+    }
     return definition
   }
 
@@ -227,7 +241,9 @@ class DefinitionService {
         this.logger.debug(`1:1:notice_generate:get_single_start:${coordinates}`, { ts: new Date().toISOString() })
         const definition = await this.get(coordinates, null, force, expand)
         this.logger.debug(`1:1:notice_generate:get_single_end:${coordinates}`, { ts: new Date().toISOString() })
-        if (!definition) return
+        if (!definition) {
+          return
+        }
         const key = definition.coordinates.toString()
         result[key] = definition
       })
@@ -243,7 +259,9 @@ class DefinitionService {
    * @returns {Promise<string[]>} the list of all coordinates for all discovered definitions
    */
   async list(coordinates, recompute = false) {
-    if (!recompute) return this.definitionStore.list(coordinates)
+    if (!recompute) {
+      return this.definitionStore.list(coordinates)
+    }
     const curated = (await this.curationService.list(coordinates)).map(c => c.toString())
     const tools = await this.harvestStore.list(coordinates)
     const harvest = tools.map(tool => EntityCoordinates.fromString(tool).toString())
@@ -318,7 +336,9 @@ class DefinitionService {
    * @private
    */
   _validate(definition) {
-    if (!validator.validate('definition', definition)) throw new Error(validator.errorsText())
+    if (!validator.validate('definition', definition)) {
+      throw new Error(validator.errorsText())
+    }
   }
 
   /**
@@ -329,7 +349,9 @@ class DefinitionService {
   async computeStoreAndCurate(coordinates) {
     // one coordinate a time through this method so no duplicate auto curation will be created.
     this.logger.debug('3:memory_lock:start', { ts: new Date().toISOString(), coordinates: coordinates.toString() })
-    while (computeLock.get(coordinates.toString())) await new Promise(resolve => setTimeout(resolve, 500))
+    while (computeLock.get(coordinates.toString())) {
+      await new Promise(resolve => setTimeout(resolve, 500))
+    }
     try {
       computeLock.set(coordinates.toString(), true)
       const definition = await this._computeAndStore(coordinates)
@@ -346,7 +368,9 @@ class DefinitionService {
    * @returns {Promise<Definition>} The computed definition
    */
   async computeAndStore(coordinates) {
-    while (computeLock.get(coordinates.toString())) await new Promise(resolve => setTimeout(resolve, 500)) // one coordinate a time through this method so we always get latest
+    while (computeLock.get(coordinates.toString())) {
+      await new Promise(resolve => setTimeout(resolve, 500)) // one coordinate a time through this method so we always get latest
+    }
     try {
       computeLock.set(coordinates.toString(), true)
       return await this._computeAndStore(coordinates)
@@ -363,7 +387,9 @@ class DefinitionService {
    * @returns {Promise<Definition | undefined>} The computed definition or undefined if skipped
    */
   async computeAndStoreIfNecessary(coordinates, tool, toolRevision) {
-    while (computeLock.get(coordinates.toString())) await new Promise(resolve => setTimeout(resolve, 500)) // one coordinate a time through this method so we always get latest
+    while (computeLock.get(coordinates.toString())) {
+      await new Promise(resolve => setTimeout(resolve, 500)) // one coordinate a time through this method so we always get latest
+    }
     try {
       computeLock.set(coordinates.toString(), true)
       if (!(await this._isToolResultNew(coordinates, tool, toolRevision))) {
@@ -511,11 +537,15 @@ class DefinitionService {
    * @private
    */
   _getCasedCoordinates(raw, coordinates) {
-    if (!raw || !Object.keys(raw).length) return coordinates
+    if (!raw || !Object.keys(raw).length) {
+      return coordinates
+    }
     for (const tool in raw) {
       for (const version in raw[tool]) {
         const cased = get(raw[tool][version], '_metadata.links.self.href')
-        if (cased) return EntityCoordinates.fromUrn(cased)
+        if (cased) {
+          return EntityCoordinates.fromUrn(cased)
+        }
       }
     }
     throw new Error('unable to find self link')
@@ -529,8 +559,11 @@ class DefinitionService {
    */
   _ensureNoNulls(object) {
     for (const key of Object.keys(object)) {
-      if (object[key] && typeof object[key] === 'object') this._ensureNoNulls(object[key])
-      else if (object[key] == null) delete object[key]
+      if (object[key] && typeof object[key] === 'object') {
+        this._ensureNoNulls(object[key])
+      } else if (object[key] == null) {
+        delete object[key]
+      }
     }
   }
 
@@ -644,10 +677,14 @@ class DefinitionService {
    * @private
    */
   _computeDiscoveredScore(definition) {
-    if (!definition.files) return 0
+    if (!definition.files) {
+      return 0
+    }
     const coreFiles = definition.files.filter(DefinitionService._isInCoreFacet)
-    if (!coreFiles.length) return 0
-    const completeFiles = coreFiles.filter(file => file.license && file.attributions && file.attributions.length)
+    if (!coreFiles.length) {
+      return 0
+    }
+    const completeFiles = coreFiles.filter(file => file.license && file.attributions?.length)
     return Math.round((completeFiles.length / coreFiles.length) * weights.discovered)
   }
 
@@ -662,7 +699,9 @@ class DefinitionService {
     // Note here that we are saying that every discovered license is satisfied by the declared
     // license. If there are no discovered licenses then all is good.
     const discovered = get(definition, 'licensed.facets.core.discovered.expressions') || []
-    if (!declared || !discovered) return 0
+    if (!declared || !discovered) {
+      return 0
+    }
     return discovered.every(expression => SPDX.satisfies(expression, declared)) ? weights.consistency : 0
   }
   /**
@@ -690,11 +729,17 @@ class DefinitionService {
    * @private
    */
   _computeTextsScore(definition) {
-    if (!definition.files || !definition.files.length) return 0
+    if (!definition.files || !definition.files.length) {
+      return 0
+    }
     const includedTexts = this._collectLicenseTexts(definition)
-    if (!includedTexts.length) return 0
+    if (!includedTexts.length) {
+      return 0
+    }
     const referencedLicenses = this._collectReferencedLicenses(definition)
-    if (!referencedLicenses.length) return 0
+    if (!referencedLicenses.length) {
+      return 0
+    }
 
     // check that all the referenced licenses have texts
     const found = intersection(referencedLicenses, includedTexts)
@@ -710,10 +755,14 @@ class DefinitionService {
   _collectReferencedLicenses(definition) {
     const referencedExpressions = new Set(get(definition, 'licensed.facets.core.discovered.expressions') || [])
     const declared = get(definition, 'licensed.declared')
-    if (declared) referencedExpressions.add(declared)
+    if (declared) {
+      referencedExpressions.add(declared)
+    }
     /** @type {Set<string>} */
     const result = new Set()
-    for (const expression of referencedExpressions) this._extractLicensesFromExpression(expression, result)
+    for (const expression of referencedExpressions) {
+      this._extractLicensesFromExpression(expression, result)
+    }
     return Array.from(result)
   }
 
@@ -740,7 +789,9 @@ class DefinitionService {
    * @private
    */
   _extractLicensesFromExpression(expression, seen) {
-    if (!expression) return
+    if (!expression) {
+      return
+    }
     /** @type {SpdxExpression} */
     const parsed = typeof expression === 'string' ? SPDX.parse(expression) : expression
     if (parsed.license) {
@@ -796,8 +847,12 @@ class DefinitionService {
         throat(10, async (/** @type {EntityCoordinates} */ coordinates) => {
           try {
             const definition = await this.get(coordinates, null, recompute)
-            if (recompute) return Promise.resolve(null)
-            if (this.search.store) return this.search.store(definition)
+            if (recompute) {
+              return Promise.resolve(null)
+            }
+            if (this.search.store) {
+              return this.search.store(definition)
+            }
           } catch (error) {
             this.logger.info('failed to reload in definition service', {
               error,
@@ -815,10 +870,13 @@ class DefinitionService {
    * @private
    */
   _ensureFacets(definition) {
-    if (!definition.files) return
+    if (!definition.files) {
+      return
+    }
     const facetFiles = this._computeFacetFiles([...definition.files], get(definition, 'described.facets'))
-    for (const facet in facetFiles)
+    for (const facet in facetFiles) {
       setIfValue(definition, `licensed.facets.${facet}`, this._summarizeFacetInfo(facet, facetFiles[facet]))
+    }
   }
 
   /**
@@ -831,13 +889,17 @@ class DefinitionService {
   _computeFacetFiles(files, facets = {}) {
     const facetList = Object.getOwnPropertyNames(facets)
     remove(facetList, 'core')
-    if (facetList.length === 0) return { core: files }
+    if (facetList.length === 0) {
+      return { core: files }
+    }
     /** @type {Record<string, DefinitionFile[]>} */
     const result = { core: [...files] }
     for (const facet in facetList) {
       const facetKey = facetList[facet]
       const filters = facets[facetKey]
-      if (!filters || filters.length === 0) break
+      if (!filters || filters.length === 0) {
+        break
+      }
       result[facetKey] = files.filter(file => filters.some(filter => minimatch(file.path, filter)))
       pullAllWith(result['core'], result[facetKey], isEqual)
     }
@@ -853,7 +915,9 @@ class DefinitionService {
    * @private
    */
   _summarizeFacetInfo(facet, facetFiles) {
-    if (!facetFiles || facetFiles.length === 0) return null
+    if (!facetFiles || facetFiles.length === 0) {
+      return null
+    }
     /** @type {Set<string>} */
     const attributions = new Set()
     /** @type {Set<string>} */
@@ -903,7 +967,9 @@ class DefinitionService {
    * @private
    */
   _ensureSourceLocation(coordinates, definition) {
-    if (get(definition, 'described.sourceLocation')) return updateSourceLocation(definition.described.sourceLocation)
+    if (get(definition, 'described.sourceLocation')) {
+      return updateSourceLocation(definition.described.sourceLocation)
+    }
     // For source components there may not be an explicit harvested source location (it is self-evident)
     // Make it explicit in the definition
     switch (coordinates.type) {
@@ -912,7 +978,9 @@ class DefinitionService {
       case 'sourcearchive':
       case 'pypi': {
         const url = buildSourceUrl(coordinates)
-        if (!url) return
+        if (!url) {
+          return
+        }
         this._ensureDescribed(definition)
         definition.described.sourceLocation = { ...coordinates, url }
         break

--- a/business/noticeService.js
+++ b/business/noticeService.js
@@ -105,8 +105,12 @@ class NoticeService {
               noDefinition.push(id)
               return undefined
             }
-            if (!isDeclaredLicense(get(definition, 'licensed.declared'))) noLicense.push(id)
-            if (!get(definition, 'licensed.facets.core.attribution.parties[0]')) noCopyright.push(id)
+            if (!isDeclaredLicense(get(definition, 'licensed.declared'))) {
+              noLicense.push(id)
+            }
+            if (!get(definition, 'licensed.facets.core.attribution.parties[0]')) {
+              noCopyright.push(id)
+            }
             return {
               name: [definition.coordinates.namespace, definition.coordinates.name].filter(x => x).join('/'),
               version: get(definition, 'coordinates.revision'),
@@ -133,14 +137,18 @@ class NoticeService {
    * @private
    */
   _getRenderer(name, options) {
-    if (!name) return new TextRenderer()
+    if (!name) {
+      return new TextRenderer()
+    }
     switch (name) {
       case 'text':
         return new TextRenderer()
       case 'html':
         return new HtmlRenderer(options.template)
       case 'template':
-        if (!options.template) throw new Error('options.template is required for template renderer')
+        if (!options.template) {
+          throw new Error('options.template is required for template renderer')
+        }
         return new TemplateRenderer(options.template)
       case 'json':
         return new JsonRenderer()
@@ -157,7 +165,9 @@ class NoticeService {
    * @private
    */
   async _getPackageText(definition) {
-    if (!definition.files) return ''
+    if (!definition.files) {
+      return ''
+    }
     this.logger.info('2:1:notice_generate:get_single_package_files:start', {
       ts: new Date().toISOString(),
       coordinates: definition.coordinates.toString()
@@ -167,8 +177,7 @@ class NoticeService {
         .filter(
           file =>
             file.token &&
-            file.natures &&
-            file.natures.includes('license') &&
+            file.natures?.includes('license') &&
             file.path &&
             (file.path.indexOf('/') === -1 ||
               (definition.coordinates.type === 'npm' && file.path.startsWith('package/')))

--- a/business/statsService.js
+++ b/business/statsService.js
@@ -44,13 +44,19 @@ class StatsService {
    */
   async get(stat) {
     const statKey = /** @type {StatKey} */ (stat.toLowerCase())
-    if (!this.statLookup[statKey]) throw new Error('Not found')
+    if (!this.statLookup[statKey]) {
+      throw new Error('Not found')
+    }
     try {
       const cacheKey = this._getCacheKey(statKey)
       const cached = await this.cache.get(cacheKey)
-      if (cached) return cached
+      if (cached) {
+        return cached
+      }
       const result = await this.statLookup[statKey].bind(this)()
-      if (result) await this.cache.set(cacheKey, result, 60 * 60 /* 1h */)
+      if (result) {
+        await this.cache.set(cacheKey, result, 60 * 60 /* 1h */)
+      }
       return result
     } catch (error) {
       this.logger.error(`Stat service failed for ${statKey}`, error)
@@ -122,7 +128,9 @@ class StatsService {
    * @private
    */
   _getMedian(frequencyTable, totalCount) {
-    if (totalCount === 0) return 0
+    if (totalCount === 0) {
+      return 0
+    }
     const cutoff = Math.ceil(totalCount / 2)
     let marker = 0
     let median = 0

--- a/business/statusService.js
+++ b/business/statusService.js
@@ -44,13 +44,19 @@ class StatusService {
    */
   async get(key) {
     key = key.toLowerCase()
-    if (!this.statusLookup[key]) throw new Error('Not found')
+    if (!this.statusLookup[key]) {
+      throw new Error('Not found')
+    }
     try {
       const cacheKey = this._getCacheKey(key)
       const cached = await this.cache.get(cacheKey)
-      if (cached) return cached
+      if (cached) {
+        return cached
+      }
       const result = await this.statusLookup[key].bind(this)()
-      if (result) await this.cache.set(cacheKey, result, 60 * 60 /* 1h */)
+      if (result) {
+        await this.cache.set(cacheKey, result, 60 * 60 /* 1h */)
+      }
       return result
     } catch (error) {
       this.logger.error(`Status service failed for ${key}`, error)

--- a/business/suggestionService.js
+++ b/business/suggestionService.js
@@ -35,7 +35,9 @@ class SuggestionService {
    */
   async get(coordinates) {
     const definitions = await this._getRelatedDefinitions(coordinates)
-    if (!definitions) return null
+    if (!definitions) {
+      return null
+    }
     let hasSuggested = false
     /** @type {Suggestion} */
     const suggestion = { coordinates }
@@ -86,10 +88,14 @@ class SuggestionService {
       compareDates(get(a, 'described.releaseDate'), get(b, 'described.releaseDate'))
     )
     // If the related array only has one entry then return early
-    if (definitions.length < 1) return null
+    if (definitions.length < 1) {
+      return null
+    }
     // Split the definitions into before supplied coords and those after
     const index = definitions.findIndex(entry => entry.coordinates.revision === coordinates.revision)
-    if (index === -1) return null
+    if (index === -1) {
+      return null
+    }
     const before = definitions.slice(Math.max(index - 3, 0), index).reverse()
     const after = definitions.slice(index + 1, index + 3)
     return { original: definitions[index], related: before.concat(after) }
@@ -106,7 +112,9 @@ class SuggestionService {
    * @private
    */
   _collectSuggestionsForField(definitions, suggestion, field, isValid = get) {
-    if (isValid(definitions.original, field)) return false
+    if (isValid(definitions.original, field)) {
+      return false
+    }
     return setIfValue(
       suggestion,
       field,

--- a/business/summarizer.js
+++ b/business/summarizer.js
@@ -33,7 +33,9 @@ class SummaryService {
    * @private
    */
   _summarizeTool(coordinates, tool, data) {
-    if (!summarizers[tool]) return data
+    if (!summarizers[tool]) {
+      return data
+    }
     const summarizer = summarizers[tool](this.options[tool] || {})
     return Object.getOwnPropertyNames(data).reduce(
       (result, version) => {

--- a/lib/coordinatesMapper.js
+++ b/lib/coordinatesMapper.js
@@ -71,7 +71,9 @@ class CoordinatesMapper {
     let mapped = this.cache.get(coordinates?.toString())
     if (mapper && !mapped) {
       mapped = await mapper.map(coordinates)
-      if (mapped) this.cache.set(coordinates.toString(), mapped)
+      if (mapped) {
+        this.cache.set(coordinates.toString(), mapped)
+      }
     }
     return mapped || coordinates
   }

--- a/lib/curation.js
+++ b/lib/curation.js
@@ -33,7 +33,9 @@ class Curation {
     this.data = typeof content === 'string' ? this.load(content) : content
     /** @type {boolean} */
     this.shouldValidate = validate
-    if (validate) this.validate()
+    if (validate) {
+      this.validate()
+    }
   }
 
   /**
@@ -145,7 +147,9 @@ class Curation {
    */
   getCoordinates() {
     const c = this.data.coordinates
-    if (!c) return []
+    if (!c) {
+      return []
+    }
     return Object.getOwnPropertyNames(this.data.revisions).map(
       key => new EntityCoordinates(c.type, c.provider, c.namespace, c.name, key)
     )

--- a/lib/entityCoordinates.js
+++ b/lib/entityCoordinates.js
@@ -29,7 +29,9 @@ const toLowerCaseMap = {
  * @returns {string | undefined} The normalized value or the original value if no normalization is needed
  */
 function normalize(value, provider, property) {
-  if (!value) return value
+  if (!value) {
+    return value
+  }
   const mask = toLowerCaseMap[provider] || 0
   return mask & property ? value.toLowerCase() : value
 }
@@ -44,8 +46,12 @@ class EntityCoordinates {
    * @returns {EntityCoordinates | null} New EntityCoordinates instance or null if spec is falsy
    */
   static fromObject(spec) {
-    if (!spec) return null
-    if (spec.constructor === EntityCoordinates) return spec
+    if (!spec) {
+      return null
+    }
+    if (spec.constructor === EntityCoordinates) {
+      return spec
+    }
     return new EntityCoordinates(spec.type, spec.provider, spec.namespace, spec.name, spec.revision)
   }
 
@@ -56,7 +62,9 @@ class EntityCoordinates {
    * @returns {EntityCoordinates | null} New EntityCoordinates instance or null if path is invalid
    */
   static fromString(path) {
-    if (!path || typeof path !== 'string') return null
+    if (!path || typeof path !== 'string') {
+      return null
+    }
 
     path = path.startsWith('/') ? path.slice(1) : path
     const [type, provider, namespace, name, revision] = path.split('/')
@@ -70,7 +78,9 @@ class EntityCoordinates {
    * @returns {EntityCoordinates | null} New EntityCoordinates instance or null if urn is invalid
    */
   static fromUrn(urn) {
-    if (!urn) return null
+    if (!urn) {
+      return null
+    }
     const [, type, provider, namespace, name, , revision] = urn.split(':')
     return new EntityCoordinates(type, provider, namespace, name, revision)
   }
@@ -90,12 +100,16 @@ class EntityCoordinates {
     /** @type {string | undefined} The Provider of the entity */
     this.provider = provider?.toLowerCase()
     /** @type {string | undefined} The Namespace of the entity */
-    if (namespace && namespace !== '-') this.namespace = normalize(namespace, this.provider, NAMESPACE)
+    if (namespace && namespace !== '-') {
+      this.namespace = normalize(namespace, this.provider, NAMESPACE)
+    }
     /** @type {string | undefined} The Name of the entity */
     this.name = normalize(name, this.provider, NAME)
     const normalizedRevision = normalize(revision, this.provider, REVISION)
     /** @type {string | undefined} The Revision/version of the entity */
-    if (normalizedRevision) this.revision = normalizedRevision
+    if (normalizedRevision) {
+      this.revision = normalizedRevision
+    }
   }
 
   /**

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -80,7 +80,9 @@ async function callFetch(request, axiosInstance = axios) {
   try {
     const options = buildRequestOptions(request)
     const response = await axiosInstance(options)
-    if (!request.resolveWithFullResponse) return response.data
+    if (!request.resolveWithFullResponse) {
+      return response.data
+    }
     // @ts-expect-error - Adding custom properties to response object
     response.statusCode = response.status
     // @ts-expect-error - Adding custom properties to response object

--- a/lib/gradleCoordinatesMapper.js
+++ b/lib/gradleCoordinatesMapper.js
@@ -56,7 +56,9 @@ class GradleCoordinatesMapper {
    * @throws {Error} When repository requests fail with non-404 errors
    */
   async map(coordinates) {
-    if (!this._shouldResolve(coordinates)) return null
+    if (!this._shouldResolve(coordinates)) {
+      return null
+    }
     const resolved = await this._resolve(coordinates)
     return resolved && EntityCoordinates.fromObject({ ...coordinates, ...resolved })
   }
@@ -88,7 +90,9 @@ class GradleCoordinatesMapper {
     const markerCoordinates = coordinates.revision
       ? coordinates
       : { ...coordinates, revision: await this._getLatestVersion(coordinates) }
-    if (!markerCoordinates.revision) return null
+    if (!markerCoordinates.revision) {
+      return null
+    }
 
     const mappedGav = await this._getImplementation(markerCoordinates)
     return (
@@ -145,7 +149,9 @@ class GradleCoordinatesMapper {
     return this._handleRequest(url).catch(
       /** @returns {string | FetchResponse | null} */
       error => {
-        if (error.statusCode === 404) return null
+        if (error.statusCode === 404) {
+          return null
+        }
         throw error
       }
     )

--- a/lib/licenseMatcher.js
+++ b/lib/licenseMatcher.js
@@ -95,7 +95,9 @@ class DefinitionLicenseMatchPolicy {
   _addFileToMap(fileMap, files, propName) {
     if (files) {
       for (const f of /** @type {{path?: string}[]} */ (files)) {
-        if (!f.path) continue
+        if (!f.path) {
+          continue
+        }
         const current = fileMap.get(f.path) || /** @type {{sourceFile?: object, targetFile?: object}} */ ({})
         current[propName] = f
         fileMap.set(f.path, current)

--- a/lib/mockInsights.js
+++ b/lib/mockInsights.js
@@ -74,7 +74,9 @@ class MockInsights {
    */
   static setup(connectionString = null, echo = false) {
     // exit if we are already setup
-    if (_client instanceof MockInsights) return
+    if (_client instanceof MockInsights) {
+      return
+    }
     if (!connectionString || connectionString === 'mock') {
       _client = new MockInsights()
     } else {
@@ -97,7 +99,9 @@ class MockInsights {
   trackException(exceptionTelemetry) {
     console.log('Exception: ')
     console.dir(exceptionTelemetry.exception)
-    if (this.client) this.client.trackException(exceptionTelemetry)
+    if (this.client) {
+      this.client.trackException(exceptionTelemetry)
+    }
   }
 
   /**
@@ -114,7 +118,9 @@ class MockInsights {
     const severity = /** @type {keyof typeof severityMap} */ (traceTelemetry.severity)
     const severityChar = severityMap[severity] || '?'
     console.log(`[${severityChar}] ${traceTelemetry.message}${propertyString}`)
-    if (this.client) this.client.trackTrace(traceTelemetry)
+    if (this.client) {
+      this.client.trackTrace(traceTelemetry)
+    }
   }
 }
 module.exports = MockInsights

--- a/lib/pypiCoordinatesMapper.js
+++ b/lib/pypiCoordinatesMapper.js
@@ -61,7 +61,9 @@ class PypiCoordinatesMapper {
    * @throws {Error} When PyPI API request fails with non-404 error
    */
   async map(coordinates) {
-    if (!this._shouldResolve(coordinates)) return null
+    if (!this._shouldResolve(coordinates)) {
+      return null
+    }
     const resolved = await this._resolve(coordinates)
     return resolved && EntityCoordinates.fromObject({ ...coordinates, ...resolved })
   }
@@ -77,7 +79,9 @@ class PypiCoordinatesMapper {
    * @returns {boolean} True if the coordinates should be resolved, false otherwise
    */
   _shouldResolve(coordinates) {
-    if (typeof coordinates.name !== 'string' || coordinates.name.includes('/')) return false
+    if (typeof coordinates.name !== 'string' || coordinates.name.includes('/')) {
+      return false
+    }
     return coordinates.name.includes('.') || coordinates.name.includes('_') || coordinates.name.includes('-')
   }
 
@@ -91,14 +95,18 @@ class PypiCoordinatesMapper {
    * @throws {Error} When PyPI API request fails with non-404 error
    */
   async _resolve(coordinates) {
-    if (coordinates.name === '..') return null
+    if (coordinates.name === '..') {
+      return null
+    }
     const encodedName = encodeURIComponent(coordinates.name)
     const url = new URL(`/pypi/${encodedName}/json`, this.baseUrl).toString()
     try {
       const answer = await this._fetch({ url, method: 'GET', json: true })
       return answer?.info?.name && { name: answer.info.name }
     } catch (error) {
-      if (/** @type {FetchError} */ (error).statusCode === 404) return null
+      if (/** @type {FetchError} */ (error).statusCode === 404) {
+        return null
+      }
       throw error
     }
   }

--- a/lib/rateLimit.js
+++ b/lib/rateLimit.js
@@ -112,7 +112,9 @@ class RateLimiter {
       opts.limit = max //limit is preferred over max
       opts.windowMs = windowMs
     }
-    if (store) opts.store = store
+    if (store) {
+      opts.store = store
+    }
     return opts
   }
 }
@@ -152,7 +154,9 @@ class RedisBasedRateLimiter extends RateLimiter {
    * @override
    */
   initialize() {
-    if (!this._client) throw new Error('Redis client is missing')
+    if (!this._client) {
+      throw new Error('Redis client is missing')
+    }
     const store = RedisBasedRateLimiter.buildRedisStore(this._client, this.options.redis)
     super.initialize(store)
     return this

--- a/lib/resultCoordinates.js
+++ b/lib/resultCoordinates.js
@@ -15,8 +15,12 @@ class ResultCoordinates {
    * @returns {ResultCoordinates | null} New ResultCoordinates instance or null if spec is falsy
    */
   static fromObject(spec) {
-    if (!spec) return null
-    if (spec.constructor === ResultCoordinates) return spec
+    if (!spec) {
+      return null
+    }
+    if (spec.constructor === ResultCoordinates) {
+      return spec
+    }
     return new ResultCoordinates(
       spec.type,
       spec.provider,
@@ -36,7 +40,9 @@ class ResultCoordinates {
    * @returns {ResultCoordinates | null} New ResultCoordinates instance or null if path is invalid
    */
   static fromString(path) {
-    if (!path) return null
+    if (!path) {
+      return null
+    }
     path = path.startsWith('/') ? path.slice(1) : path
     const [type, provider, namespaceSpec, name, revision, tool, toolVersion] = path.split('/')
     const namespace = namespaceSpec === '-' ? null : namespaceSpec
@@ -51,7 +57,9 @@ class ResultCoordinates {
    * @returns {ResultCoordinates | null} New ResultCoordinates instance or null if urn is invalid
    */
   static fromUrn(urn) {
-    if (!urn) return null
+    if (!urn) {
+      return null
+    }
     const [, type, provider, namespace, name, , revision, , tool, toolVersion] = urn.split(':')
     return new ResultCoordinates(type, provider, namespace, name, revision, tool, toolVersion)
   }
@@ -74,7 +82,9 @@ class ResultCoordinates {
     /** @type {string | undefined} The Provider of the entity */
     this.provider = entity.provider
     /** @type {string | undefined} The Namespace of the entity */
-    if (entity.namespace) this.namespace = entity.namespace
+    if (entity.namespace) {
+      this.namespace = entity.namespace
+    }
     /** @type {string | undefined} The Name of the entity */
     this.name = entity.name
     /** @type {string | undefined} The Revision/version of the entity */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -124,9 +124,15 @@ function parseNamespaceNameRevision(request) {
  * @returns {string | null} The latest non-prerelease version, or null if none found
  */
 function getLatestVersion(versions) {
-  if (!Array.isArray(versions)) return versions
-  if (versions.length === 0) return null
-  if (versions.length === 1) return versions[0]
+  if (!Array.isArray(versions)) {
+    return versions
+  }
+  if (versions.length === 0) {
+    return null
+  }
+  if (versions.length === 1) {
+    return versions[0]
+  }
   return versions.reduce(
     /**
      * @param {string} max
@@ -134,9 +140,13 @@ function getLatestVersion(versions) {
      */
     (max, current) => {
       const normalizedCurrent = _normalizeVersion(current)
-      if (!normalizedCurrent || semver.prerelease(normalizedCurrent) !== null) return max
+      if (!normalizedCurrent || semver.prerelease(normalizedCurrent) !== null) {
+        return max
+      }
       const normalizedMax = _normalizeVersion(max)
-      if (!normalizedMax) return normalizedCurrent
+      if (!normalizedMax) {
+        return normalizedCurrent
+      }
       return semver.gt(normalizedCurrent, normalizedMax) ? current : max
     },
     versions[0]
@@ -149,7 +159,9 @@ function getLatestVersion(versions) {
  * @returns {string[] | null} Simplified array or null if empty
  */
 function simplifyAttributions(entries) {
-  if (!entries || !entries.length) return null
+  if (!entries || !entries.length) {
+    return null
+  }
   // first decode any HTML and reduce whitespace
   // trim off all non-pair punctuation and sort longest first (favor longer entries).
   // unique the collection ignoring common, legit trailing punctuation.
@@ -177,9 +189,15 @@ const dateTimeFormats = ['MM-dd-yyyy']
 function utcDateTime(dateAndTime) {
   const utcOpt = { zone: 'utc' }
   let result = DateTime.fromISO(dateAndTime, utcOpt)
-  if (!result.isValid) result = DateTime.fromRFC2822(dateAndTime, utcOpt)
-  if (!result.isValid) result = DateTime.fromHTTP(dateAndTime, utcOpt)
-  if (!result.isValid) result = DateTime.fromSQL(dateAndTime, utcOpt)
+  if (!result.isValid) {
+    result = DateTime.fromRFC2822(dateAndTime, utcOpt)
+  }
+  if (!result.isValid) {
+    result = DateTime.fromHTTP(dateAndTime, utcOpt)
+  }
+  if (!result.isValid) {
+    result = DateTime.fromSQL(dateAndTime, utcOpt)
+  }
 
   for (let index = 0; !result.isValid && index < dateTimeFormats.length; index++) {
     result = DateTime.fromFormat(dateAndTime, dateTimeFormats[index], utcOpt)
@@ -193,12 +211,18 @@ function utcDateTime(dateAndTime) {
  * @returns {string | null} ISO date string (yyyy-MM-dd) or null if invalid
  */
 function extractDate(dateAndTime) {
-  if (!dateAndTime) return null
+  if (!dateAndTime) {
+    return null
+  }
   const result = utcDateTime(dateAndTime)
-  if (!result) return null
+  if (!result) {
+    return null
+  }
   const validStart = utcDateTime('1950-01-01')
   const validEnd = DateTime.utc().plus({ days: 30 })
-  if (result < validStart || result > validEnd) return null
+  if (result < validStart || result > validEnd) {
+    return null
+  }
   return result.toISODate() //'yyyy-MM-dd' format
 }
 
@@ -209,7 +233,9 @@ function extractDate(dateAndTime) {
  * @returns {number} Negative if dateA < dateB, positive if dateA > dateB, 0 if equal
  */
 function compareDates(dateA, dateB) {
-  if (!dateA || !dateB) return dateA ? 1 : dateB ? -1 : 0
+  if (!dateA || !dateB) {
+    return dateA ? 1 : dateB ? -1 : 0
+  }
   // @ts-expect-error - Date subtraction works in JavaScript
   return DateTime.fromISO(dateA).toJSDate() - DateTime.fromISO(dateB).toJSDate()
 }
@@ -222,8 +248,12 @@ function compareDates(dateA, dateB) {
  * @returns {boolean} true if value was set, false otherwise
  */
 function setIfValue(target, path, value) {
-  if (!value) return false
-  if (Array.isArray(value) && value.length === 0) return false
+  if (!value) {
+    return false
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return false
+  }
   set(target, path, value)
   return true
 }
@@ -250,10 +280,14 @@ function setToArray(values) {
  * @returns {Set<V>} The modified Set
  */
 function addArrayToSet(array, set, valueExtractor) {
-  if (!array || !array.length) return set
+  if (!array || !array.length) {
+    return set
+  }
   valueExtractor =
     valueExtractor || /** @param {T} value */ (value => /** @type {V} */ (/** @type {unknown} */ (value)))
-  for (const entry of array) set.add(valueExtractor(entry))
+  for (const entry of array) {
+    set.add(valueExtractor(entry))
+  }
   return set
 }
 
@@ -263,11 +297,15 @@ function addArrayToSet(array, set, valueExtractor) {
  * @returns {string | null} SPDX license identifier or null
  */
 function extractLicenseFromLicenseUrl(licenseUrl) {
-  if (!licenseUrl) return null
+  if (!licenseUrl) {
+    return null
+  }
   for (const licenseUrlOverride of _licenseUrlOverrides) {
     const licenseUrlMatch = licenseUrlOverride.test.exec(licenseUrl)
     if (licenseUrlMatch) {
-      if (licenseUrlOverride.license) return licenseUrlOverride.license
+      if (licenseUrlOverride.license) {
+        return licenseUrlOverride.license
+      }
       if (licenseUrlOverride.licenseMatchGroup) {
         const parsed = SPDX.normalize(licenseUrlMatch[licenseUrlOverride.licenseMatchGroup])
         return parsed === 'NOASSERTION' ? null : parsed
@@ -285,8 +323,12 @@ function extractLicenseFromLicenseUrl(licenseUrl) {
  * @returns {void}
  */
 function mergeDefinitions(base, proposed, override) {
-  if (!proposed) return
-  if (!base) return
+  if (!proposed) {
+    return
+  }
+  if (!base) {
+    return
+  }
   setIfValue(base, 'described', _mergeDescribed(base.described, proposed.described))
   setIfValue(base, 'licensed', _mergeLicensed(base.licensed, proposed.licensed, override))
   setIfValue(base, 'files', _mergeFiles(base.files, proposed.files, override))
@@ -299,8 +341,12 @@ function mergeDefinitions(base, proposed, override) {
  * @returns {FileEntry[] | undefined}
  */
 function _mergeFiles(base, proposed, override) {
-  if (!proposed) return base
-  if (!base) return proposed
+  if (!proposed) {
+    return base
+  }
+  if (!base) {
+    return proposed
+  }
   /** @type {Record<string, FileEntry>} */
   const baseLookup = base.reduce(
     /**
@@ -315,8 +361,11 @@ function _mergeFiles(base, proposed, override) {
   )
   for (const /** @type {FileEntry} */ file of proposed) {
     const entry = baseLookup[file.path]
-    if (entry) _mergeFile(entry, file, override)
-    else base.push(file)
+    if (entry) {
+      _mergeFile(entry, file, override)
+    } else {
+      base.push(file)
+    }
   }
   return base
 }
@@ -328,8 +377,12 @@ function _mergeFiles(base, proposed, override) {
  * @returns {FileEntry | undefined}
  */
 function _mergeFile(base, proposed, override) {
-  if (!proposed) return base
-  if (!base) return proposed
+  if (!proposed) {
+    return base
+  }
+  if (!base) {
+    return proposed
+  }
   const result = /** @type {FileEntry} */ (
     _mergeExcept(base, proposed, ['license', 'attributions', 'facets', 'hashes', 'natures'])
   )
@@ -379,8 +432,12 @@ function _mergeFile(base, proposed, override) {
  * @returns {{facets?: object, hashes?: object, files?: number} | undefined}
  */
 function _mergeDescribed(base, proposed) {
-  if (!proposed) return base
-  if (!base) return proposed
+  if (!proposed) {
+    return base
+  }
+  if (!base) {
+    return proposed
+  }
   const result = _mergeExcept(base, proposed, ['facets', 'hashes', 'files'])
   setIfValue(result, 'facets', _mergeObject(base.facets, proposed.facets))
   setIfValue(result, 'hashes', _mergeObject(base.hashes, proposed.hashes))
@@ -396,8 +453,12 @@ function _mergeDescribed(base, proposed) {
  * @returns {{declared?: string} | undefined}
  */
 function _mergeLicensed(base, proposed, override) {
-  if (!proposed) return base
-  if (!base) return proposed
+  if (!proposed) {
+    return base
+  }
+  if (!base) {
+    return proposed
+  }
   const result = _mergeExcept(base, proposed, ['declared'])
   setIfValue(result, 'declared', override ? proposed.declared : SPDX.merge(proposed.declared, base.declared, 'AND'))
   return result
@@ -410,8 +471,12 @@ function _mergeLicensed(base, proposed, override) {
  * @returns {T | undefined}
  */
 function _mergeObject(base, proposed) {
-  if (!proposed) return base
-  if (!base) return proposed
+  if (!proposed) {
+    return base
+  }
+  if (!base) {
+    return proposed
+  }
   return extend(base, proposed)
 }
 
@@ -422,8 +487,12 @@ function _mergeObject(base, proposed) {
  * @returns {T[] | undefined}
  */
 function _mergeArray(base, proposed) {
-  if (!proposed) return base
-  if (!base) return proposed
+  if (!proposed) {
+    return base
+  }
+  if (!base) {
+    return proposed
+  }
   return union(base, proposed)
 }
 
@@ -436,7 +505,9 @@ function _mergeArray(base, proposed) {
 function _mergeExcept(base, proposed, paths = []) {
   const overlay = {}
   extend(true, overlay, proposed)
-  for (const path of paths) unset(overlay, path)
+  for (const path of paths) {
+    unset(overlay, path)
+  }
   extend(true, base, overlay)
   return base
 }
@@ -489,7 +560,9 @@ function deCodeSlashes(namespace) {
  */
 function updateSourceLocation(spec) {
   // if there is a name then this is the new style source location so just use it
-  if (spec.name) return
+  if (spec.name) {
+    return
+  }
 
   if (spec.provider === 'github' || spec.provider === 'gitlab') {
     const segments = spec.url.split('/')
@@ -515,14 +588,22 @@ function updateSourceLocation(spec) {
  * @returns {boolean}
  */
 function isLicenseFile(filePath, coordinates, packages) {
-  if (!filePath) return false
+  if (!filePath) {
+    return false
+  }
   filePath = filePath.toLowerCase()
   const basePath = filePath.split('/')[0]
-  if (_licenseFileNames.includes(basePath)) return true
-  if (!coordinates) return false
+  if (_licenseFileNames.includes(basePath)) {
+    return true
+  }
+  if (!coordinates) {
+    return false
+  }
   for (const prefix of getLicenseLocations(coordinates, packages) || []) {
     const prefixLowered = prefix.toLowerCase()
-    if (_licenseFileNames.includes(filePath.replace(prefixLowered, ''))) return true
+    if (_licenseFileNames.includes(filePath.replace(prefixLowered, ''))) {
+      return true
+    }
   }
   return false
 }
@@ -615,9 +696,13 @@ function debsrcLicenseLocations(packages) {
  * @returns {string | null} Normalized combined expression or null
  */
 function joinExpressions(expressions) {
-  if (!expressions) return null
+  if (!expressions) {
+    return null
+  }
   const list = setToArray(expressions)
-  if (!list) return null
+  if (!list) {
+    return null
+  }
   const joinedExpressionString = `(${list.join(') AND (')})`
   return SPDX.normalize(joinedExpressionString)
 }
@@ -634,14 +719,18 @@ function normalizeLicenseExpression(
   logger,
   licenseRefLookup = /** @param {string} token */ token => token && scancodeMap.get(token)
 ) {
-  if (!rawLicenseExpression) return null
+  if (!rawLicenseExpression) {
+    return null
+  }
 
   /** @param {string} licenseExpression */
   const licenseVisitor = licenseExpression =>
     scancodeMap.get(licenseExpression) || SPDX.normalizeSingle(licenseExpression)
   const parsed = SPDX.parse(rawLicenseExpression, licenseVisitor, licenseRefLookup)
   const result = SPDX.stringify(parsed)
-  if (result === 'NOASSERTION') logger.info(`ScanCode NOASSERTION from ${rawLicenseExpression}`)
+  if (result === 'NOASSERTION') {
+    logger.info(`ScanCode NOASSERTION from ${rawLicenseExpression}`)
+  }
 
   return result
 }
@@ -652,7 +741,9 @@ function normalizeLicenseExpression(
  * @returns {string | null}
  */
 function _normalizeVersion(version) {
-  if (version === '1') return '1.0.0' // version '1' is not semver valid see https://github.com/clearlydefined/crawler/issues/124
+  if (version === '1') {
+    return '1.0.0' // version '1' is not semver valid see https://github.com/clearlydefined/crawler/issues/124
+  }
   return semver.valid(version) ? version : null
 }
 
@@ -662,7 +753,9 @@ function _normalizeVersion(version) {
  * @returns {ParsedUrn} Object with parsed URN components
  */
 function parseUrn(urn) {
-  if (!urn) return {}
+  if (!urn) {
+    return {}
+  }
   const [scheme, type, provider, namespace, name, revToken, revision, toolToken, tool, toolRevision] = urn.split(':')
   return {
     scheme,

--- a/middleware/github.js
+++ b/middleware/github.js
@@ -72,7 +72,9 @@ const middleware = asyncMiddleware(async (req, res, next) => {
  */
 async function setupServiceClient(req, token) {
   const client = Github.getClient({ token })
-  if (!client) throw new Error('GitHub client could not be created. Please check your configuration.')
+  if (!client) {
+    throw new Error('GitHub client could not be created. Please check your configuration.')
+  }
   req.app.locals.service = { github: { client } }
   return client
 }
@@ -123,7 +125,9 @@ async function setupInfo(req, cacheKey, client) {
  */
 async function setupTeams(req, cacheKey, client) {
   // anonymous users are not members of any team
-  if (!cacheKey || !client) return null
+  if (!cacheKey || !client) {
+    return null
+  }
   // check cache for team data; hash the token so we're not storing them raw
   let teams = await cache.get(cacheKey)
   if (!teams) {

--- a/providers/caching/redis.js
+++ b/providers/caching/redis.js
@@ -43,7 +43,9 @@ class RedisCache {
    * @throws {Error} Will throw an error if the Redis connection fails
    */
   async initialize() {
-    if (this._client) return Promise.resolve()
+    if (this._client) {
+      return Promise.resolve()
+    }
     if (!this._clientReady) {
       this._clientReady = RedisCache.initializeClient(this.options, this.logger)
         .then(client => {
@@ -86,7 +88,9 @@ class RedisCache {
    */
   async get(item) {
     const cacheItem = await this._client.get(item)
-    if (!cacheItem) return null
+    if (!cacheItem) {
+      return null
+    }
 
     let result
     try {
@@ -114,7 +118,9 @@ class RedisCache {
       return null
     }
 
-    if (!result.startsWith(objectPrefix)) return result
+    if (!result.startsWith(objectPrefix)) {
+      return result
+    }
     try {
       return JSON.parse(result.substring(4))
     } catch (error) {
@@ -132,11 +138,16 @@ class RedisCache {
    * @returns {Promise<void>} Promise that resolves when the item is stored
    */
   async set(item, value, ttlSeconds) {
-    if (typeof value !== 'string') value = objectPrefix + JSON.stringify(value)
+    if (typeof value !== 'string') {
+      value = objectPrefix + JSON.stringify(value)
+    }
     const deflated = pako.deflate(value)
     const data = Buffer.from(deflated).toString('base64')
-    if (ttlSeconds) await this._client.set(item, data, { EX: ttlSeconds })
-    else await this._client.set(item, data)
+    if (ttlSeconds) {
+      await this._client.set(item, data, { EX: ttlSeconds })
+    } else {
+      await this._client.set(item, data)
+    }
   }
 
   /**

--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -108,7 +108,9 @@ class GitHubCurationService {
         state
       }
       //See https://docs.github.com/en/rest/reference/pulls#list-pull-requests
-      if (state === 'closed') prOptions = { ...prOptions, sort: 'updated', direction: 'asc' }
+      if (state === 'closed') {
+        prOptions = { ...prOptions, sort: 'updated', direction: 'asc' }
+      }
       let response = await client.pullRequests.getAll(prOptions)
       this._processContributions(response.data)
       while (/** @type {*} */ (this.github).hasNextPage(response)) {
@@ -163,7 +165,9 @@ class GitHubCurationService {
     await Promise.all(
       toBeCleaned.map(throat(10, async coordinates => this.cache.delete(this._getCacheKey(coordinates))))
     )
-    if (data.merged_at) await this._prMerged(curations)
+    if (data.merged_at) {
+      await this._prMerged(curations)
+    }
   }
 
   /**
@@ -373,12 +377,15 @@ class GitHubCurationService {
 
     if (userGithub) {
       const { name, email } = await this._getUserInfo(userGithub)
-      if (name && email) fileBody.committer = { name, email }
+      if (name && email) {
+        fileBody.committer = { name, email }
+      }
     }
 
     // Github requires name/email to set committer
-    if ((info.name || info.login) && info.email)
+    if ((info.name || info.login) && info.email) {
       fileBody.committer = { name: info.name || info.login, email: info.email }
+    }
     if (get(currentContent, '_origin.sha')) {
       fileBody.sha = /** @type {*} */ (currentContent)._origin.sha
       return serviceGithub.rest.repos.createOrUpdateFileContents(fileBody)
@@ -405,8 +412,9 @@ class GitHubCurationService {
   /** @param {CurationPatchEntry[]} patches */
   async _validateDefinitionsExist(patches) {
     const targetCoordinates = patches.reduce((result, patch) => {
-      for (const key in patch.revisions)
+      for (const key in patch.revisions) {
         result.push(EntityCoordinates.fromObject({ ...patch.coordinates, revision: key }))
+      }
       return result
     }, [])
     const validDefinitions = await this.definitionService.listAll(targetCoordinates)
@@ -541,8 +549,9 @@ class GitHubCurationService {
    */
   async addOrUpdate(userGithub, serviceGithub, info, patch) {
     const { missing } = await this._validateDefinitionsExist(patch.patches)
-    if (missing.length > 0)
+    if (missing.length > 0) {
       throw new Error('The contribution has failed because some of the supplied component definitions do not exist')
+    }
     return this._addOrUpdate(userGithub, serviceGithub, info, patch)
   }
 
@@ -752,15 +761,22 @@ ${this._formatDefinitions(patch.patches)}`
    * @returns {Promise<CurationRevision | null>} The requested curation revision data, or null
    */
   async get(coordinates, curation = null) {
-    if (!coordinates.revision)
+    if (!coordinates.revision) {
       throw new Error(
         `Coordinates ${coordinates.toString()} appear to be malformed. Are they missing a namespace or revision?`
       )
-    if (curation && typeof curation !== 'number' && typeof curation !== 'string') return curation
+    }
+    if (curation && typeof curation !== 'number' && typeof curation !== 'string') {
+      return curation
+    }
     const all = await this._getCurations(coordinates, /** @type {number | string | null} */ (curation))
-    if (!all || !all.revisions) return null
+    if (!all || !all.revisions) {
+      return null
+    }
     const result = all.revisions[coordinates.revision]
-    if (!result) return null
+    if (!result) {
+      return null
+    }
     // Stash the sha of the content as a NON-enumerable prop so it does not get merged into the patch
     Object.defineProperty(result, '_origin', { value: all._origin, enumerable: false })
     return result
@@ -788,7 +804,9 @@ ${this._formatDefinitions(patch.patches)}`
       original.length - 1 !== i ? [current, 'children'] : current
     )
     const blob = get(tree, treePath)
-    if (!blob) return null
+    if (!blob) {
+      return null
+    }
     this.logger.debug('8:compute:curation_blob:start', {
       ts: new Date().toISOString(),
       coordinates: coordinates.toString()
@@ -821,7 +839,9 @@ ${this._formatDefinitions(patch.patches)}`
       curationFilenames.map(
         throat(10, async path => {
           const content = await this._getContent(sha, path)
-          if (!content) return undefined
+          if (!content) {
+            return undefined
+          }
           return new Curation(content, path)
         })
       )
@@ -846,8 +866,12 @@ ${this._formatDefinitions(patch.patches)}`
    * @param {CurationRevision} curation
    */
   _ensureCurationInfo(definition, curation) {
-    if (!curation) return
-    if (Object.getOwnPropertyNames(curation).length === 0) return
+    if (!curation) {
+      return
+    }
+    if (Object.getOwnPropertyNames(curation).length === 0) {
+      return
+    }
     const origin = get(curation, '_origin.sha')
     definition.described = definition.described || {}
     definition.described.tools = definition.described.tools || []
@@ -937,9 +961,13 @@ ${this._formatDefinitions(patch.patches)}`
   async list(coordinates) {
     const cacheKey = this._getCacheKey(coordinates)
     const existing = await this.cache.get(cacheKey)
-    if (existing) return existing
+    if (existing) {
+      return existing
+    }
     const data = await this.store.list(coordinates)
-    if (data) await this.cache.set(cacheKey, data, 60 * 60 * 24)
+    if (data) {
+      await this.cache.set(cacheKey, data, 60 * 60 * 24)
+    }
     return data
   }
 
@@ -955,7 +983,9 @@ ${this._formatDefinitions(patch.patches)}`
     const promises = coordinatesList.map(
       throat(10, async coordinates => {
         const data = await this.list(coordinates)
-        if (!data) return
+        if (!data) {
+          return
+        }
         const key = coordinates.toString()
         result[key] = /** @type {CurationListResult} */ (data)
       })
@@ -977,7 +1007,9 @@ ${this._formatDefinitions(patch.patches)}`
       const response = await this.github.rest.pulls.listFiles({ owner, repo, pull_number: number })
       return response.data
     } catch (/** @type {*} */ error) {
-      if (error.code === 404) throw error
+      if (error.code === 404) {
+        throw error
+      }
       throw new Error(`Error calling GitHub to get pr#${number}. Code ${error.code}`, { cause: error })
     }
   }
@@ -1004,7 +1036,9 @@ ${this._formatDefinitions(patch.patches)}`
       const changedRevisions = allRevisions.filter(
         revision => !isEqual(prDefinitions.revisions[revision], masterDefinitions.revisions[revision])
       )
-      for (const revision of changedRevisions) changedCoordinates.push(`${fileName}/${revision}`)
+      for (const revision of changedRevisions) {
+        changedCoordinates.push(`${fileName}/${revision}`)
+      }
     }
     return changedCoordinates
   }
@@ -1108,7 +1142,9 @@ ${this._formatDefinitions(patch.patches)}`
     const contributions = []
     coordinates = coordinates.asRevisionless()
     const { curations } = /** @type {CurationListResult} */ (await this.list(coordinates))
-    if (!curations || Object.keys(curations).length === 0) return undefined
+    if (!curations || Object.keys(curations).length === 0) {
+      return undefined
+    }
     const processedRevisions = new Set()
     for (const [curatedCoordinatesStr, curation] of Object.entries(curations)) {
       const curatedCoordinates = EntityCoordinates.fromString(curatedCoordinatesStr)
@@ -1139,7 +1175,9 @@ ${this._formatDefinitions(patch.patches)}`
         info,
         matchingRevisionAndReason
       )
-      for (const r of matchingRevisionAndReason) processedRevisions.add(r.version)
+      for (const r of matchingRevisionAndReason) {
+        processedRevisions.add(r.version)
+      }
       contributions.push({
         coordinates: curatedCoordinates.toString(),
         contribution: get(contribution, 'data.html_url')
@@ -1157,7 +1195,9 @@ ${this._formatDefinitions(patch.patches)}`
   async _getCurationTree(pr) {
     const key = this._generateCurationTreeKey(pr)
     const cached = this.treeCache.get(key)
-    if (cached) return cached
+    if (cached) {
+      return cached
+    }
     const tree = await this.smartGit.tree(pr ? `refs/pull/${encodeURIComponent(pr)}/head` : this.options.branch)
     // Since these trees are used very often and not changed frequently, it should be cached but not be kept in Redis.
     // In case webhook event failed to trigger cache clean, set ttl to a day

--- a/providers/curation/memoryStore.js
+++ b/providers/curation/memoryStore.js
@@ -43,7 +43,9 @@ class MemoryStore {
     if (curations) {
       /** @type {Record<string, CurationData>} */
       const files = {}
-      for (const curation of curations) files[curation.path] = curation.data
+      for (const curation of curations) {
+        files[curation.path] = curation.data
+      }
       this.contributions[pr.number] = { pr, files }
       return
     }
@@ -54,7 +56,9 @@ class MemoryStore {
 
   /** @param {EntityCoordinates} coordinates */
   list(coordinates) {
-    if (!coordinates) throw new Error('must specify coordinates to list')
+    if (!coordinates) {
+      throw new Error('must specify coordinates to list')
+    }
     const pattern = this._getCurationId(coordinates)
     return Object.keys(this.curations)
       .filter(key => key.startsWith(pattern))
@@ -67,7 +71,9 @@ class MemoryStore {
     const result = {}
     for (const coordinates of coordinatesList) {
       const data = this.list(coordinates)
-      if (!data) continue
+      if (!data) {
+        continue
+      }
       const key = coordinates.toString()
       result[key] = data
     }
@@ -76,7 +82,9 @@ class MemoryStore {
 
   /** @param {EntityCoordinates} coordinates */
   _getCurationId(coordinates) {
-    if (!coordinates) return ''
+    if (!coordinates) {
+      return ''
+    }
     return EntityCoordinates.fromObject(coordinates).toString().toLowerCase()
   }
 }

--- a/providers/curation/mongoCurationStore.js
+++ b/providers/curation/mongoCurationStore.js
@@ -59,7 +59,9 @@ class MongoCurationStore {
       curations.map(
         throat(10, async curation => {
           const _id = this._getCurationId(curation.data.coordinates)
-          if (_id) await this.collection.replaceOne({ _id }, { _id, ...curation.data }, { upsert: true })
+          if (_id) {
+            await this.collection.replaceOne({ _id }, { _id, ...curation.data }, { upsert: true })
+          }
         })
       )
     )
@@ -83,8 +85,12 @@ class MongoCurationStore {
    * @param {Curation[] | null} [curations] - The set of actual proposed changes.
    */
   updateContribution(pr, curations = null) {
-    if (!curations || !curations.some(curation => get(curation, 'data.coordinates') && get(curation, 'data.revisions')))
+    if (
+      !curations ||
+      !curations.some(curation => get(curation, 'data.coordinates') && get(curation, 'data.revisions'))
+    ) {
       return this.collection.updateOne({ _id: pr.number }, { $set: { pr: pr } }, { upsert: true })
+    }
     const files = curations
       .filter(curation => get(curation, 'data.coordinates') && get(curation, 'data.revisions'))
       .map(curation => {
@@ -110,9 +116,13 @@ class MongoCurationStore {
    */
   // TODO need to do something about paging
   async list(coordinates) {
-    if (!coordinates) throw new Error('must specify coordinates to list')
+    if (!coordinates) {
+      throw new Error('must specify coordinates to list')
+    }
     const pattern = this._getCurationId(coordinates.asRevisionless())
-    if (!pattern) return null
+    if (!pattern) {
+      return null
+    }
     const safePattern = this._escapeRegex(pattern)
     // Limit the length of the pattern to prevent ReDoS and ensure it's a string
     const maxPatternLength = 256
@@ -136,7 +146,9 @@ class MongoCurationStore {
 
   /** @param {EntityCoordinatesSpec} coordinates */
   _getCurationId(coordinates) {
-    if (!coordinates) return ''
+    if (!coordinates) {
+      return ''
+    }
     return EntityCoordinates.fromObject(coordinates).toString().toLowerCase()
   }
 
@@ -144,11 +156,21 @@ class MongoCurationStore {
   _buildContributionQuery(coordinates) {
     /** @type {Record<string, string>} */
     const result = {}
-    if (coordinates.type) result['files.coordinates.type'] = coordinates.type.toLowerCase()
-    if (coordinates.provider) result['files.coordinates.provider'] = coordinates.provider.toLowerCase()
-    if (coordinates.namespace) result['files.coordinates.namespace'] = coordinates.namespace.toLowerCase()
-    if (coordinates.name) result['files.coordinates.name'] = coordinates.name.toLowerCase()
-    if (coordinates.revision) result['files.revisions.revision'] = coordinates.revision.toLowerCase()
+    if (coordinates.type) {
+      result['files.coordinates.type'] = coordinates.type.toLowerCase()
+    }
+    if (coordinates.provider) {
+      result['files.coordinates.provider'] = coordinates.provider.toLowerCase()
+    }
+    if (coordinates.namespace) {
+      result['files.coordinates.namespace'] = coordinates.namespace.toLowerCase()
+    }
+    if (coordinates.name) {
+      result['files.coordinates.name'] = coordinates.name.toLowerCase()
+    }
+    if (coordinates.revision) {
+      result['files.revisions.revision'] = coordinates.revision.toLowerCase()
+    }
     return result
   }
 

--- a/providers/curation/process.js
+++ b/providers/curation/process.js
@@ -12,7 +12,9 @@ const { get } = require('lodash')
 async function work(once) {
   try {
     const message = await queue.dequeue()
-    if (!get(message, 'data.pull_request') || !get(message, 'data.action')) return
+    if (!get(message, 'data.pull_request') || !get(message, 'data.action')) {
+      return
+    }
     const pr = message.data.pull_request
     const action = message.data.action
     switch (action) {
@@ -38,7 +40,9 @@ async function work(once) {
   } catch (/** @type {*} */ error) {
     logger.error(error)
   } finally {
-    if (!once) setTimeout(work, 30000, once)
+    if (!once) {
+      setTimeout(work, 30000, once)
+    }
   }
 }
 

--- a/providers/harvest/cacheBasedCrawler.js
+++ b/providers/harvest/cacheBasedCrawler.js
@@ -104,7 +104,9 @@ class CacheBasedHarvester {
     const newHarvest = this._getHarvest(entry)
     const { harvests: trackedHarvests } = await this._getTrackedForCoordinates(entry.coordinates)
     const isTracked = trackedHarvests.some(harvest => isEqual(harvest, newHarvest))
-    if (isTracked) this.logger.debug(`Entry with coordinates ${entry.coordinates.toString()} is already tracked.`)
+    if (isTracked) {
+      this.logger.debug(`Entry with coordinates ${entry.coordinates.toString()} is already tracked.`)
+    }
     return isTracked
   }
 
@@ -147,7 +149,9 @@ class CacheBasedHarvester {
       )
     )
     for (const result of results) {
-      if (result.status === 'rejected') this.logger.error(result.reason)
+      if (result.status === 'rejected') {
+        this.logger.error(result.reason)
+      }
     }
   }
 
@@ -159,7 +163,9 @@ class CacheBasedHarvester {
    * @returns {Promise<HarvestCallItem[]>} Promise resolving to array of tracked harvest items
    */
   async _getCached(key) {
-    if (!key) return []
+    if (!key) {
+      return []
+    }
     try {
       const harvests = await this._cache.get(key)
       return harvests || []
@@ -197,7 +203,9 @@ class CacheBasedHarvester {
    */
   async done(coordinates) {
     const cacheKey = this._getCacheKey(coordinates)
-    if (!cacheKey) return
+    if (!cacheKey) {
+      return
+    }
     try {
       await this._cache.delete(cacheKey)
       this.logger.debug(`Removed cache for ${cacheKey}.`)

--- a/providers/harvest/crawlerQueue.js
+++ b/providers/harvest/crawlerQueue.js
@@ -25,8 +25,11 @@ class CrawlingQueueHarvester {
     const entries = Array.isArray(spec) ? spec : [spec]
     for (const entry of entries) {
       const message = JSON.stringify(this.toHarvestItem(entry))
-      if (turbo) this.normalQueue.queue(message)
-      else this.laterQueue.queue(message)
+      if (turbo) {
+        this.normalQueue.queue(message)
+      } else {
+        this.laterQueue.queue(message)
+      }
     }
   }
 

--- a/providers/harvest/process.js
+++ b/providers/harvest/process.js
@@ -19,7 +19,9 @@ async function work(once) {
   let isQueueEmpty = true
   try {
     const messages = await queue.dequeueMultiple()
-    if (messages && messages.length > 0) isQueueEmpty = false
+    if (messages && messages.length > 0) {
+      isQueueEmpty = false
+    }
     await Promise.all(messages.map(message => processMessage(message)))
   } catch (error) {
     logger.error(error instanceof Error ? error.message : String(error))
@@ -35,7 +37,9 @@ async function work(once) {
  */
 async function processMessage(message) {
   const urn = get(message, 'data._metadata.links.self.href')
-  if (!urn) return
+  if (!urn) {
+    return
+  }
   const coordinates = EntityCoordinates.fromUrn(urn)
   const { tool, toolRevision } = parseUrn(urn)
   if (tool === 'clearlydefined') {

--- a/providers/harvest/throttling/listBasedFilter.js
+++ b/providers/harvest/throttling/listBasedFilter.js
@@ -39,8 +39,12 @@ class ListBasedFilter {
    * @returns {boolean} true if blocked
    */
   isBlocked(coord) {
-    if (!coord || this._blacklist.size === 0) return false
-    if (!this._targetTypes.has(coord.type)) return false
+    if (!coord || this._blacklist.size === 0) {
+      return false
+    }
+    if (!this._targetTypes.has(coord.type)) {
+      return false
+    }
     const versionless = coord.asRevisionless().toString()
     return this._blacklist.has(versionless)
   }

--- a/providers/harvest/throttling/listBasedFilterConfig.js
+++ b/providers/harvest/throttling/listBasedFilterConfig.js
@@ -16,10 +16,14 @@ const loggerFactory = require('../../logging/logger')
  * @returns {string[]} Parsed array or empty array if parsing fails
  */
 function parseListEnv(value, logger) {
-  if (!value || value.trim() === '') return []
+  if (!value || value.trim() === '') {
+    return []
+  }
   try {
     const parsed = JSON.parse(value)
-    if (!Array.isArray(parsed)) throw new Error('Not an array')
+    if (!Array.isArray(parsed)) {
+      throw new Error('Not an array')
+    }
     return parsed
   } catch (e) {
     logger.warn(`Blacklist configuration invalid, using empty list: ${e instanceof Error ? e.message : String(e)}`)

--- a/providers/logging/logger.js
+++ b/providers/logging/logger.js
@@ -33,7 +33,9 @@ let logger
  * @throws {Error} If no logger has been initialized and none is provided
  */
 module.exports = loggerValue => {
-  if (loggerValue && !logger) logger = loggerValue
+  if (loggerValue && !logger) {
+    logger = loggerValue
+  }
   if (!logger) {
     throw new Error('Logger not initialized. Please provide a logger instance on first call.')
   }

--- a/providers/queueing/azureStorageQueue.js
+++ b/providers/queueing/azureStorageQueue.js
@@ -43,10 +43,13 @@ class AzureStorageQueue {
    */
   async dequeue() {
     const message = await promisify(this.queueService.getMessage).bind(this.queueService)(this.options.queueName)
-    if (!message) return null
-    if (message.dequeueCount <= 5)
+    if (!message) {
+      return null
+    }
+    if (message.dequeueCount <= 5) {
       // @ts-expect-error - azure-storage QueueMessageResult is structurally compatible at runtime
       return { original: message, data: JSON.parse(Buffer.from(message.messageText, 'base64').toString('utf8')) }
+    }
     // @ts-expect-error - azure-storage QueueMessageResult used as QueueMessage
     await this.delete({ original: message })
     return this.dequeue()
@@ -63,7 +66,9 @@ class AzureStorageQueue {
       // @ts-expect-error - azure-storage getMessages accepts options as second arg
       this.options.dequeueOptions
     )
-    if (!messages || messages.length === 0) return []
+    if (!messages || messages.length === 0) {
+      return []
+    }
     for (const i in messages) {
       if (messages[i].dequeueCount <= 5) {
         messages[i] = {

--- a/providers/queueing/memoryQueue.js
+++ b/providers/queueing/memoryQueue.js
@@ -39,9 +39,13 @@ class MemoryQueue {
    */
   async dequeue() {
     const message = this.data[0]
-    if (!message) return null
+    if (!message) {
+      return null
+    }
     this.data[0].dequeueCount++
-    if (message.dequeueCount <= 5) return Promise.resolve({ original: message, data: this._parseData(message) })
+    if (message.dequeueCount <= 5) {
+      return Promise.resolve({ original: message, data: this._parseData(message) })
+    }
     await this.delete({ original: message })
     return this.dequeue()
   }
@@ -68,7 +72,9 @@ class MemoryQueue {
   async delete(message) {
     const newData = []
     for (let i = 0; i < this.data.length; i++) {
-      if (this.data[i].messageId !== message.original.messageId) newData.push(this.data[i])
+      if (this.data[i].messageId !== message.original.messageId) {
+        newData.push(this.data[i])
+      }
     }
     this.data = newData
   }

--- a/providers/search/abstractSearch.js
+++ b/providers/search/abstractSearch.js
@@ -39,7 +39,9 @@ class AbstractSearch {
    */
   _getLicenses(definition) {
     const facets = get(definition, 'licensed.facets')
-    if (!facets) return []
+    if (!facets) {
+      return []
+    }
     // TODO probably need to use a better comparison here that compares actual expressions rather than just the strings
     return uniq(
       values(facets).reduce((result, facet) => result.concat(get(facet, 'discovered.expressions')), [])
@@ -51,7 +53,9 @@ class AbstractSearch {
    */
   _getAttributions(definition) {
     const facets = get(definition, 'licensed.facets')
-    if (!facets) return []
+    if (!facets) {
+      return []
+    }
     return uniq(values(facets).reduce((result, facet) => result.concat(get(facet, 'attribution.parties')), [])).filter(
       e => e
     )

--- a/providers/search/azureSearch.js
+++ b/providers/search/azureSearch.js
@@ -14,9 +14,15 @@ class AzureSearch extends AbstractSearch {
   /** @override */
   async initialize() {
     super.initialize()
-    if (!(await this._hasIndex(definitionsIndexName))) await this._createIndex(this._buildDefinitionsIndex())
-    if (!(await this._hasDataSource(definitionsDataSourceName))) await this._createDataSource(this._buildDataSource())
-    if (!(await this._hasIndexer(definitionsIndexerName))) await this._createIndexer(this._buildIndexer())
+    if (!(await this._hasIndex(definitionsIndexName))) {
+      await this._createIndex(this._buildDefinitionsIndex())
+    }
+    if (!(await this._hasDataSource(definitionsDataSourceName))) {
+      await this._createDataSource(this._buildDataSource())
+    }
+    if (!(await this._hasIndexer(definitionsIndexerName))) {
+      await this._createIndexer(this._buildIndexer())
+    }
   }
 
   /**

--- a/providers/search/memory.js
+++ b/providers/search/memory.js
@@ -43,7 +43,9 @@ class MemorySearch extends AbstractSearch {
    */
   store(definitions) {
     const entries = this._getEntries(Array.isArray(definitions) ? definitions : [definitions])
-    for (const /** @type {any} */ entry of entries) this.index[entry.coordinates] = entry
+    for (const /** @type {any} */ entry of entries) {
+      this.index[entry.coordinates] = entry
+    }
   }
 
   /**
@@ -51,7 +53,9 @@ class MemorySearch extends AbstractSearch {
    * @override
    */
   async query(body) {
-    if (!body.count) throw new Error('unsupported query')
+    if (!body.count) {
+      throw new Error('unsupported query')
+    }
     return { count: Object.keys(this.index).length }
   }
 

--- a/providers/stores/abstractAzblobStore.js
+++ b/providers/stores/abstractAzblobStore.js
@@ -72,7 +72,9 @@ class AbstractAzBlobStore {
       continuation = result.continuationToken
       for (const /** @type {BlobEntry} */ entry of result.entries) {
         const visitResult = visitor(entry)
-        if (visitResult !== null) list.push(visitResult)
+        if (visitResult !== null) {
+          list.push(visitResult)
+        }
       }
     } while (continuation)
     return list
@@ -86,13 +88,17 @@ class AbstractAzBlobStore {
    */
   async get(coordinates) {
     let name = AbstractFileStore.toStoragePathFromCoordinates(coordinates)
-    if (!name.endsWith('.json')) name += '.json'
+    if (!name.endsWith('.json')) {
+      name += '.json'
+    }
     try {
       const result = await promisify(this.blobService.getBlobToText).bind(this.blobService)(this.containerName, name)
       return JSON.parse(result)
     } catch (error) {
       const azureError = /** @type {{statusCode?: number}} */ (error)
-      if (azureError.statusCode === 404) return null
+      if (azureError.statusCode === 404) {
+        return null
+      }
       throw error
     }
   }

--- a/providers/stores/abstractFileStore.js
+++ b/providers/stores/abstractFileStore.js
@@ -51,7 +51,9 @@ class AbstractFileStore {
       return (
         await Promise.all(
           paths.map(async path => {
-            if (!this._isValidPath(path)) return null
+            if (!this._isValidPath(path)) {
+              return null
+            }
             const data = await promisify(fs.readFile)(path)
             return data ? visitor(JSON.parse(data.toString())) : null
           })
@@ -60,7 +62,9 @@ class AbstractFileStore {
     } catch (error) {
       // If there is just no entry, that's fine, there is no content.
       const nodeError = /** @type {NodeJS.ErrnoException} */ (error)
-      if (nodeError.code === 'ENOENT') return []
+      if (nodeError.code === 'ENOENT') {
+        return []
+      }
       throw error
     }
   }
@@ -79,7 +83,9 @@ class AbstractFileStore {
     } catch (error) {
       const nodeError = /** @type {NodeJS.ErrnoException} */ (error)
       this.logger.debug(`Error reading file at ${filePath}: ${nodeError.message}`)
-      if (nodeError.code === 'ENOENT') return null
+      if (nodeError.code === 'ENOENT') {
+        return null
+      }
       throw error
     }
   }
@@ -96,33 +102,63 @@ class AbstractFileStore {
       await Promise.all(
         paths.map(async path => {
           try {
-            if (!this._isValidPath(path)) return null
+            if (!this._isValidPath(path)) {
+              return null
+            }
             const data = await promisify(fs.readFile)(path)
-            if (!data) return null
+            if (!data) {
+              return null
+            }
             const definition = JSON.parse(data.toString())
             return definition
           } catch (error) {
             // If there is just no entry, that's fine, there is no content.
             const nodeError = /** @type {NodeJS.ErrnoException} */ (error)
-            if (nodeError.code === 'ENOENT') return null
+            if (nodeError.code === 'ENOENT') {
+              return null
+            }
             throw error
           }
         })
       )
     ).filter(definition => {
-      if (!definition) return false
-      if (query.type && definition.coordinates?.type !== query.type) return false
-      if (query.provider && definition.coordinates?.provider !== query.provider) return false
-      if (query.name && definition.coordinates?.name !== query.name) return false
-      if (query.namespace && definition.coordinates?.namespace !== query.namespace) return false
-      if (query.license && definition.licensed?.declared !== query.license) return false
-      if (query.releasedAfter && definition.described?.releaseDate < query.releasedAfter) return false
-      if (query.releasedBefore && definition.described?.releaseDate > query.releasedBefore) return false
-      if (query.minLicensedScore && definition.licensed?.score?.total < query.minLicensedScore) return false
-      if (query.maxLicensedScore && definition.licensed?.score?.total > query.maxLicensedScore) return false
+      if (!definition) {
+        return false
+      }
+      if (query.type && definition.coordinates?.type !== query.type) {
+        return false
+      }
+      if (query.provider && definition.coordinates?.provider !== query.provider) {
+        return false
+      }
+      if (query.name && definition.coordinates?.name !== query.name) {
+        return false
+      }
+      if (query.namespace && definition.coordinates?.namespace !== query.namespace) {
+        return false
+      }
+      if (query.license && definition.licensed?.declared !== query.license) {
+        return false
+      }
+      if (query.releasedAfter && definition.described?.releaseDate < query.releasedAfter) {
+        return false
+      }
+      if (query.releasedBefore && definition.described?.releaseDate > query.releasedBefore) {
+        return false
+      }
+      if (query.minLicensedScore && definition.licensed?.score?.total < query.minLicensedScore) {
+        return false
+      }
+      if (query.maxLicensedScore && definition.licensed?.score?.total > query.maxLicensedScore) {
+        return false
+      }
 
-      if (query.minDescribedScore && definition.described?.score?.total < query.minDescribedScore) return false
-      if (query.maxDescribedScore && definition.described?.score?.total > query.maxDescribedScore) return false
+      if (query.minDescribedScore && definition.described?.score?.total < query.minDescribedScore) {
+        return false
+      }
+      if (query.maxDescribedScore && definition.described?.score?.total > query.maxDescribedScore) {
+        return false
+      }
       return true
     })
   }
@@ -240,7 +276,9 @@ class AbstractFileStore {
       })
       .reduce(
         (latest, { tool, toolVersion, path }) => {
-          if (!tool || !toolVersion) return latest
+          if (!tool || !toolVersion) {
+            return latest
+          }
           latest[tool] = latest[tool] || { toolVersion: '', path: '' }
           //if the version is greater than the current version, replace it
           if (!latest[tool].toolVersion || getLatestVersion([toolVersion, latest[tool].toolVersion]) === toolVersion) {

--- a/providers/stores/abstractMongoDefinitionStore.js
+++ b/providers/stores/abstractMongoDefinitionStore.js
@@ -214,7 +214,9 @@ class AbstractMongoDefinitionStore {
    * @returns {string} The ID string (lowercased coordinate string)
    */
   getId(coordinates) {
-    if (!coordinates) return ''
+    if (!coordinates) {
+      return ''
+    }
     return EntityCoordinates.fromObject(coordinates).toString().toLowerCase()
   }
 
@@ -227,31 +229,63 @@ class AbstractMongoDefinitionStore {
   buildQuery(parameters) {
     /** @type {Record<string, any>} */
     const filter = {}
-    if (parameters.type) filter['coordinates.type'] = parameters.type
-    if (parameters.provider) filter['coordinates.provider'] = parameters.provider
-    if (parameters.namespace) filter['coordinates.namespace'] = parameters.namespace
-    if (parameters.name) filter['coordinates.name'] = parameters.name
-    if (parameters.type === null) filter['coordinates.type'] = null
-    if (parameters.provider === null) filter['coordinates.provider'] = null
-    if (parameters.name === null) filter['coordinates.name'] = null
-    if (parameters.namespace === null) filter['coordinates.namespace'] = null
-    if (parameters.license) filter['licensed.declared'] = parameters.license
-    if (parameters.releasedAfter) filter['described.releaseDate'] = { $gt: parameters.releasedAfter }
-    if (parameters.releasedBefore) filter['described.releaseDate'] = { $lt: parameters.releasedBefore }
-    if (parameters.minEffectiveScore)
+    if (parameters.type) {
+      filter['coordinates.type'] = parameters.type
+    }
+    if (parameters.provider) {
+      filter['coordinates.provider'] = parameters.provider
+    }
+    if (parameters.namespace) {
+      filter['coordinates.namespace'] = parameters.namespace
+    }
+    if (parameters.name) {
+      filter['coordinates.name'] = parameters.name
+    }
+    if (parameters.type === null) {
+      filter['coordinates.type'] = null
+    }
+    if (parameters.provider === null) {
+      filter['coordinates.provider'] = null
+    }
+    if (parameters.name === null) {
+      filter['coordinates.name'] = null
+    }
+    if (parameters.namespace === null) {
+      filter['coordinates.namespace'] = null
+    }
+    if (parameters.license) {
+      filter['licensed.declared'] = parameters.license
+    }
+    if (parameters.releasedAfter) {
+      filter['described.releaseDate'] = { $gt: parameters.releasedAfter }
+    }
+    if (parameters.releasedBefore) {
+      filter['described.releaseDate'] = { $lt: parameters.releasedBefore }
+    }
+    if (parameters.minEffectiveScore) {
       filter['scores.effective'] = { $gt: Number.parseInt(String(parameters.minEffectiveScore), 10) }
-    if (parameters.maxEffectiveScore)
+    }
+    if (parameters.maxEffectiveScore) {
       filter['scores.effective'] = { $lt: Number.parseInt(String(parameters.maxEffectiveScore), 10) }
-    if (parameters.minToolScore) filter['scores.tool'] = { $gt: Number.parseInt(String(parameters.minToolScore), 10) }
-    if (parameters.maxToolScore) filter['scores.tool'] = { $lt: Number.parseInt(String(parameters.maxToolScore), 10) }
-    if (parameters.minLicensedScore)
+    }
+    if (parameters.minToolScore) {
+      filter['scores.tool'] = { $gt: Number.parseInt(String(parameters.minToolScore), 10) }
+    }
+    if (parameters.maxToolScore) {
+      filter['scores.tool'] = { $lt: Number.parseInt(String(parameters.maxToolScore), 10) }
+    }
+    if (parameters.minLicensedScore) {
       filter['licensed.score.total'] = { $gt: Number.parseInt(String(parameters.minLicensedScore), 10) }
-    if (parameters.maxLicensedScore)
+    }
+    if (parameters.maxLicensedScore) {
       filter['licensed.score.total'] = { $lt: Number.parseInt(String(parameters.maxLicensedScore), 10) }
-    if (parameters.minDescribedScore)
+    }
+    if (parameters.minDescribedScore) {
       filter['described.score.total'] = { $gt: Number.parseInt(String(parameters.minDescribedScore), 10) }
-    if (parameters.maxDescribedScore)
+    }
+    if (parameters.maxDescribedScore) {
       filter['described.score.total'] = { $lt: Number.parseInt(String(parameters.maxDescribedScore), 10) }
+    }
     return filter
   }
 
@@ -276,7 +310,9 @@ class AbstractMongoDefinitionStore {
     /** @type {Record<string, number>} */
     const clause = {}
     const sortDirection = parameters.sortDesc ? -1 : 1
-    for (const item of sort) clause[item] = sortDirection
+    for (const item of sort) {
+      clause[item] = sortDirection
+    }
     //Always sort on coordinatesKey(_id or partitionKey) for continuation token
     const coordinateKey = this.getCoordinatesKey()
     clause[coordinateKey] = sortDirection
@@ -307,7 +343,9 @@ class AbstractMongoDefinitionStore {
    * @returns {Record<string, any> | undefined} The pagination filter or undefined
    */
   _buildPaginationQuery(continuationToken, sort) {
-    if (!continuationToken.length) return undefined
+    if (!continuationToken.length) {
+      return undefined
+    }
     const queryExpressions = this._buildQueryExpressions(continuationToken, sort)
     return queryExpressions.length <= 1 ? queryExpressions[0] : { $or: [...queryExpressions] }
   }
@@ -397,7 +435,9 @@ class AbstractMongoDefinitionStore {
    * @returns {string} The continuation token or empty string if no more pages
    */
   _getContinuationToken(pageSize, data, sortClause) {
-    if (data.length !== pageSize) return ''
+    if (data.length !== pageSize) {
+      return ''
+    }
     const lastItem = data[data.length - 1]
     const lastValues = Object.keys(sortClause)
       .map(key => get(lastItem, key))

--- a/providers/stores/azblobAttachmentStore.js
+++ b/providers/stores/azblobAttachmentStore.js
@@ -58,7 +58,9 @@ class AzBlobAttachmentStore {
         this.logger.info('2:1:1:notice_generate:get_single_file:end', { ts: new Date().toISOString(), file: key })
         return JSON.parse(result).attachment
       } catch (/** @type {any} */ error) {
-        if (error.statusCode === 404) return null
+        if (error.statusCode === 404) {
+          return null
+        }
         throw error
       }
     })()

--- a/providers/stores/azblobDefinitionStore.js
+++ b/providers/stores/azblobDefinitionStore.js
@@ -32,7 +32,9 @@ class AzBlobDefinitionStore extends AbstractAzBlobStore {
       coordinates,
       /** @param {BlobEntry} entry */ entry => {
         const path = entry.metadata['id']
-        if (!path) return null
+        if (!path) {
+          return null
+        }
         const entryCoordinates = EntityCoordinates.fromString(path)
         return AbstractFileStore.isInterestingCoordinates(entryCoordinates) ? path : null
       }
@@ -71,7 +73,9 @@ class AzBlobDefinitionStore extends AbstractAzBlobStore {
     try {
       await promisify(this.blobService.deleteBlob).bind(this.blobService)(this.containerName, blobName)
     } catch (/** @type {any} */ error) {
-      if (error.code !== 'BlobNotFound') throw error
+      if (error.code !== 'BlobNotFound') {
+        throw error
+      }
     }
   }
 }

--- a/providers/stores/azblobHarvestStore.js
+++ b/providers/stores/azblobHarvestStore.js
@@ -48,7 +48,9 @@ class AzHarvestBlobStore extends AbstractAzBlobStore {
       coordinates,
       /** @param {any} entry */ entry => {
         const urn = entry.metadata.urn
-        if (!urn) return null
+        if (!urn) {
+          return null
+        }
         const entryCoordinates = ResultCoordinates.fromUrn(urn)
         return AbstractFileStore.isInterestingCoordinates(entryCoordinates) ? entryCoordinates.toString() : null
       }
@@ -65,7 +67,9 @@ class AzHarvestBlobStore extends AbstractAzBlobStore {
    */
   stream(coordinates, stream) {
     let name = this._toStoragePathFromCoordinates(coordinates)
-    if (!name.endsWith('.json')) name += '.json'
+    if (!name.endsWith('.json')) {
+      name += '.json'
+    }
     return new Promise((resolve, reject) =>
       this.blobService.getBlobToStream(this.containerName, name, stream, responseOrError(resolve, reject))
     )
@@ -134,7 +138,9 @@ class AzHarvestBlobStore extends AbstractAzBlobStore {
       return entries.reduce((result, entry) => {
         const { tool, toolVersion } = this._toResultCoordinatesFromStoragePath(entry.name)
         // TODO: LOG HERE THERE IF THERE ARE SOME BOGUS FILES HANGING AROUND
-        if (!tool || !toolVersion) return result
+        if (!tool || !toolVersion) {
+          return result
+        }
         const current = (result[tool] = result[tool] || {})
         current[toolVersion] = entry.content
         return result

--- a/providers/stores/dispatchConfig.js
+++ b/providers/stores/dispatchConfig.js
@@ -14,7 +14,9 @@
  * @throws {Error} Error if no factories are configured
  */
 function definition(options) {
-  if (!options.factories) throw new Error('no factories configured')
+  if (!options.factories) {
+    throw new Error('no factories configured')
+  }
   const stores = options.factories.map(x => x())
   return require('./dispatchDefinitionStore')({ stores })
 }

--- a/providers/stores/dispatchDefinitionStore.js
+++ b/providers/stores/dispatchDefinitionStore.js
@@ -107,7 +107,9 @@ class DispatchDefinitionStore {
       try {
         const opResult = await operation(store)
         result = result || opResult
-        if (result && first) return result
+        if (result && first) {
+          return result
+        }
       } catch (error) {
         this.logger.error('DispatchDefinitionStore failure', error)
       }

--- a/providers/stores/fileAttachmentStore.js
+++ b/providers/stores/fileAttachmentStore.js
@@ -46,7 +46,9 @@ class FileAttachmentStore {
       const result = await promisify(fs.readFile)(filePath)
       return JSON.parse(result.toString()).attachment
     } catch (/** @type {any} */ error) {
-      if (error.code === 'ENOENT') return null
+      if (error.code === 'ENOENT') {
+        return null
+      }
       throw error
     }
   }

--- a/providers/stores/fileDefinitionStore.js
+++ b/providers/stores/fileDefinitionStore.js
@@ -64,7 +64,9 @@ class FileDefinitionStore extends AbstractFileStore {
     try {
       await promisify(fs.unlink)(filePath)
     } catch (/** @type {any} */ error) {
-      if (error.code !== 'ENOENT') throw error
+      if (error.code !== 'ENOENT') {
+        throw error
+      }
     }
   }
 }

--- a/providers/stores/fileHarvestStore.js
+++ b/providers/stores/fileHarvestStore.js
@@ -33,7 +33,9 @@ class FileHarvestStore extends AbstractFileStore {
       coordinates,
       /** @param {any} entry */ entry => {
         const link = get(entry, '_metadata.links.self.href')
-        if (!link) return null
+        if (!link) {
+          return null
+        }
         return ResultCoordinates.fromUrn(link).toString()
       }
     )
@@ -85,7 +87,9 @@ class FileHarvestStore extends AbstractFileStore {
     try {
       return await recursive(root, ['.DS_Store'])
     } catch (/** @type {any} */ error) {
-      if (error.code === 'ENOENT') return []
+      if (error.code === 'ENOENT') {
+        return []
+      }
       throw error
     }
   }

--- a/providers/stores/mongo.js
+++ b/providers/stores/mongo.js
@@ -55,8 +55,11 @@ class MongoStore extends AbstractMongoDefinitionStore {
     /** @type {Definition | undefined} */
     let definition
     for await (const page of /** @type {AsyncIterable<any>} */ (cursor)) {
-      if (!definition) definition = page
-      else definition.files = definition.files.concat(page['files'])
+      if (!definition) {
+        definition = page
+      } else {
+        definition.files = definition.files.concat(page['files'])
+      }
     }
     return definition
   }
@@ -100,7 +103,9 @@ class MongoStore extends AbstractMongoDefinitionStore {
         index => {
           if (index === 0) {
             const definitionPage = clone(definition)
-            if (definition.files) definitionPage.files = definition.files.slice(0, pageSize)
+            if (definition.files) {
+              definitionPage.files = definition.files.slice(0, pageSize)
+            }
             return { ...definitionPage, _mongo: { partitionKey: definition._id, page: 1, totalPages: pages } }
           }
           return {

--- a/providers/summary/clearlydefined.js
+++ b/providers/summary/clearlydefined.js
@@ -146,7 +146,9 @@ class ClearlyDescribedSummarizer {
    * @param {ClearlyDefinedHarvestedData} data - The harvested data
    */
   addSourceLocation(result, data) {
-    if (!data.sourceInfo) return
+    if (!data.sourceInfo) {
+      return
+    }
     const spec = data.sourceInfo
     updateSourceLocation(spec)
     spec.url = buildSourceUrl(spec)
@@ -159,7 +161,9 @@ class ClearlyDescribedSummarizer {
    * @param {ClearlyDefinedHarvestedData} data - The harvested data
    */
   addFiles(result, data) {
-    if (!data.files) return
+    if (!data.files) {
+      return
+    }
     result.files = data.files.map(file => {
       return { path: file.path, hashes: file.hashes }
     })
@@ -172,12 +176,18 @@ class ClearlyDescribedSummarizer {
    * @param {EntityCoordinates} coordinates - The entity coordinates
    */
   addAttachedFiles(result, data, coordinates) {
-    if (!data.attachments || !result.files) return
+    if (!data.attachments || !result.files) {
+      return
+    }
     for (const file of data.attachments) {
       const existing = result.files.find(entry => entry.path === file.path)
-      if (!existing) continue
+      if (!existing) {
+        continue
+      }
       existing.token = file.token
-      if (isLicenseFile(file.path, coordinates)) existing.natures = uniq((existing.natures || []).concat(['license']))
+      if (isLicenseFile(file.path, coordinates)) {
+        existing.natures = uniq((existing.natures || []).concat(['license']))
+      }
     }
   }
 
@@ -189,13 +199,18 @@ class ClearlyDescribedSummarizer {
    * @param {EntityCoordinates} coordinates - The entity coordinates
    */
   addInterestingFiles(result, data, coordinates) {
-    if (!data.interestingFiles) return
+    if (!data.interestingFiles) {
+      return
+    }
     const newDefinition = cloneDeep(result)
     const newFiles = cloneDeep(data.interestingFiles)
     for (const /** @type {{ license?: string; path: string; natures?: string[] }} */ file of newFiles) {
       file.license = SPDX.normalize(file.license)
-      if (!file.license) delete file.license
-      else if (isLicenseFile(file.path, coordinates)) file.natures = uniq((file.natures || []).concat(['license']))
+      if (!file.license) {
+        delete file.license
+      } else if (isLicenseFile(file.path, coordinates)) {
+        file.natures = uniq((file.natures || []).concat(['license']))
+      }
     }
     set(newDefinition, 'files', newFiles)
     mergeDefinitions(result, newDefinition)
@@ -209,7 +224,9 @@ class ClearlyDescribedSummarizer {
    * @param {EntityCoordinates} coordinates - The entity coordinates
    */
   addLicenseFromFiles(result, data, coordinates) {
-    if (!data.interestingFiles) return
+    if (!data.interestingFiles) {
+      return
+    }
     const licenses = data.interestingFiles
       .map(
         /** @param {{ license?: string; path: string }} file */
@@ -253,7 +270,9 @@ class ClearlyDescribedSummarizer {
     const projectSummaryLicenses = /** @type {MavenLicenseInfo[] | undefined} */ (
       get(data, 'manifest.summary.licenses') || get(data, 'manifest.summary.project.licenses')
     ) // the project layer was removed in 1.2.0
-    if (!projectSummaryLicenses) return undefined
+    if (!projectSummaryLicenses) {
+      return undefined
+    }
     const licenseSummaries = /** @type {MavenLicenseInfo[]} */ (
       flatten(projectSummaryLicenses.map(/** @param {MavenLicenseInfo} x */ x => x.license)).filter(
         /** @param {unknown} x */ x => x
@@ -269,10 +288,11 @@ class ClearlyDescribedSummarizer {
     let licenses = licenseUrls
       .map(/** @param {string} url */ url => extractLicenseFromLicenseUrl(url))
       .filter(/** @param {unknown} x */ x => x)
-    if (!licenses.length)
+    if (!licenses.length) {
       licenses = licenseNames
         .map(/** @param {string} x */ x => SPDX.lookupByName(x) || x)
         .filter(/** @param {unknown} x */ x => x)
+    }
     return licenses
   }
 
@@ -290,7 +310,9 @@ class ClearlyDescribedSummarizer {
     setIfValue(result, 'described.urls.version', `${get(result, 'described.urls.registry')}/${coordinates.revision}`)
     setIfValue(result, 'described.urls.download', urls.download)
     const licenses = this.getDeclaredLicenseMaven(data)
-    if (licenses?.length) setIfValue(result, 'licensed.declared', SPDX.normalize(licenses.join(' OR ')))
+    if (licenses?.length) {
+      setIfValue(result, 'licensed.declared', SPDX.normalize(licenses.join(' OR ')))
+    }
   }
 
   /**
@@ -341,7 +363,9 @@ class ClearlyDescribedSummarizer {
     )
     setIfValue(result, 'described.projectWebsite', get(data, 'manifest.homepage'))
     const license = /** @type {string | undefined} */ (get(data, 'registryData.license'))
-    if (license) setIfValue(result, 'licensed.declared', SPDX.normalize(license.split('/').join(' OR ')))
+    if (license) {
+      setIfValue(result, 'licensed.declared', SPDX.normalize(license.split('/').join(' OR ')))
+    }
     setIfValue(result, 'described.urls.registry', `https://crates.io/crates/${coordinates.name}`)
     setIfValue(result, 'described.urls.version', `${get(result, 'described.urls.registry')}/${coordinates.revision}`)
     setIfValue(
@@ -372,7 +396,9 @@ class ClearlyDescribedSummarizer {
       `https://repo1.maven.org/maven2/${namespaceAsFolders}/${coordinates.name}/${coordinates.revision}/${coordinates.name}-${coordinates.revision}.jar`
     )
     const licenses = this.getDeclaredLicenseMaven(data)
-    if (licenses?.length) setIfValue(result, 'licensed.declared', SPDX.normalize(licenses.join(' OR ')))
+    if (licenses?.length) {
+      setIfValue(result, 'licensed.declared', SPDX.normalize(licenses.join(' OR ')))
+    }
   }
 
   /**
@@ -387,9 +413,11 @@ class ClearlyDescribedSummarizer {
       /** @type {string | undefined} */ (get(data, 'manifest.licenseExpression'))
     )
     const licenseUrl = /** @type {string | undefined} */ (get(data, 'manifest.licenseUrl'))
-    if (licenseExpression) set(result, 'licensed.declared', licenseExpression)
-    else if (licenseUrl?.trim())
+    if (licenseExpression) {
+      set(result, 'licensed.declared', licenseExpression)
+    } else if (licenseUrl?.trim()) {
       set(result, 'licensed.declared', extractLicenseFromLicenseUrl(licenseUrl) || 'NOASSERTION')
+    }
     setIfValue(result, 'described.urls.registry', `https://nuget.org/packages/${coordinates.name}`)
     setIfValue(result, 'described.urls.version', `${get(result, 'described.urls.registry')}/${coordinates.revision}`)
     setIfValue(
@@ -398,7 +426,9 @@ class ClearlyDescribedSummarizer {
       `https://nuget.org/api/v2/package/${coordinates.name}/${coordinates.revision}`
     )
     const packageEntries = /** @type {{ fullName: string }[] | undefined} */ (get(data, 'manifest.packageEntries'))
-    if (!packageEntries) return
+    if (!packageEntries) {
+      return
+    }
     const newDefinition = cloneDeep(result)
     newDefinition.files = packageEntries.map(
       /** @param {{ fullName: string }} file */ file => {
@@ -461,7 +491,9 @@ class ClearlyDescribedSummarizer {
    * @param {EntityCoordinates} coordinates - The entity coordinates
    */
   addNpmData(result, data, coordinates) {
-    if (!data.registryData) return
+    if (!data.registryData) {
+      return
+    }
     const registryData = /** @type {import('./clearlydefined').NpmRegistryData} */ (data.registryData)
     setIfValue(result, 'described.releaseDate', extractDate(registryData.releaseDate))
     setIfValue(
@@ -480,18 +512,28 @@ class ClearlyDescribedSummarizer {
       }/-/${coordinates.name}-${coordinates.revision}.tgz`
     )
     const manifest = registryData.manifest
-    if (!manifest) return
+    if (!manifest) {
+      return
+    }
     let homepage = manifest.homepage
-    if (homepage && isArray(homepage)) homepage = homepage[0]
+    if (homepage && isArray(homepage)) {
+      homepage = homepage[0]
+    }
     setIfValue(result, 'described.projectWebsite', homepage)
     const bugs = manifest.bugs
     if (bugs) {
       if (typeof bugs === 'string') {
-        if (bugs.startsWith('http')) setIfValue(result, 'described.issueTracker', bugs)
-      } else setIfValue(result, 'described.issueTracker', bugs.url || bugs.email)
+        if (bugs.startsWith('http')) {
+          setIfValue(result, 'described.issueTracker', bugs)
+        }
+      } else {
+        setIfValue(result, 'described.issueTracker', bugs.url || bugs.email)
+      }
     }
     const expression = this.parseLicenseExpression(manifest, 'npm')
-    if (!expression) return
+    if (!expression) {
+      return
+    }
     setIfValue(result, 'licensed.declared', SPDX.normalize(expression))
   }
 
@@ -502,7 +544,9 @@ class ClearlyDescribedSummarizer {
    * @param {EntityCoordinates} coordinates - The entity coordinates
    */
   addComposerData(result, data, coordinates) {
-    if (!data.registryData) return
+    if (!data.registryData) {
+      return
+    }
     const registryData = /** @type {import('./clearlydefined').ComposerRegistryData} */ (data.registryData)
     setIfValue(result, 'described.releaseDate', extractDate(registryData.releaseDate))
     setIfValue(
@@ -511,14 +555,18 @@ class ClearlyDescribedSummarizer {
       `https://packagist.org/packages/${`${coordinates.namespace}/${coordinates.name}`}`
     )
     const manifest = registryData.manifest
-    if (!manifest) return
+    if (!manifest) {
+      return
+    }
     setIfValue(result, 'described.urls.version', `${get(result, 'described.urls.registry')}#${manifest.version}`)
     setIfValue(result, 'described.projectWebsite', manifest.homepage)
     if (manifest.dist?.url) {
       setIfValue(result, 'described.urls.download', manifest.dist.url)
     }
     const expression = this.parseLicenseExpression(manifest, 'composer')
-    if (!expression) return
+    if (!expression) {
+      return
+    }
     setIfValue(result, 'licensed.declared', SPDX.normalize(expression))
   }
 
@@ -560,8 +608,9 @@ class ClearlyDescribedSummarizer {
   addGemData(result, data, coordinates) {
     setIfValue(result, 'described.releaseDate', extractDate(data.releaseDate))
     const license = SPDX.normalize(/** @type {string | undefined} */ (get(data, 'registryData.license')))
-    if (license) set(result, 'licensed.declared', license)
-    else {
+    if (license) {
+      set(result, 'licensed.declared', license)
+    } else {
       const gemLicenses = /** @type {string[] | undefined} */ (get(data, 'registryData.licenses')) || []
       const licenses = SPDX.normalize(gemLicenses.join(' OR '))
       setIfValue(result, 'licensed.declared', licenses)
@@ -599,7 +648,9 @@ class ClearlyDescribedSummarizer {
       const revision = find(releases[coordinates.revision], revision =>
         revision.filename ? revision.filename.includes('tar.gz') || revision.filename.includes('zip') : false
       )
-      if (revision) setIfValue(result, 'described.urls.download', revision.url)
+      if (revision) {
+        setIfValue(result, 'described.urls.download', revision.url)
+      }
     }
   }
 
@@ -652,7 +703,9 @@ class ClearlyDescribedSummarizer {
    */
   addDebData(result, data, coordinates) {
     setIfValue(result, 'described.releaseDate', extractDate(data.releaseDate))
-    if (!data.registryData) return
+    if (!data.registryData) {
+      return
+    }
     const registryData = /** @type {DebianRegistryEntry[]} */ (data.registryData)
     const registryUrl = this.getDebianRegistryUrl(registryData)
     if (registryUrl) {
@@ -679,7 +732,9 @@ class ClearlyDescribedSummarizer {
    */
   addDebSrcData(result, data, coordinates) {
     setIfValue(result, 'described.releaseDate', extractDate(data.releaseDate))
-    if (!data.registryData) return
+    if (!data.registryData) {
+      return
+    }
     const registryData = /** @type {DebianRegistryEntry[]} */ (data.registryData)
     const registryUrl = this.getDebianRegistryUrl(registryData)
     if (registryUrl) {

--- a/providers/summary/fossology.js
+++ b/providers/summary/fossology.js
@@ -56,18 +56,26 @@ class FOSSologySummarizer {
    */
   _summarizeNomos(result, output) {
     const content = /** @type {string | undefined} */ (get(output, 'nomos.output.content'))
-    if (!content) return
+    if (!content) {
+      return
+    }
     const files = content
       .split('\n')
       .map(
         /** @param {string} file */ file => {
           // File package/dist/ajv.min.js contains license(s) No_license_found
           const match = /^File (.*?) contains license\(s\) (.*?)$/.exec(file)
-          if (!match) return null
+          if (!match) {
+            return null
+          }
           const [, path, rawLicense] = match
           const license = noOpLicenseIds.has(rawLicense) ? null : SPDX.normalize(rawLicense)
-          if (path && license) return { path, license }
-          if (path) return { path }
+          if (path && license) {
+            return { path, license }
+          }
+          if (path) {
+            return { path }
+          }
           return null
         }
       )
@@ -83,17 +91,25 @@ class FOSSologySummarizer {
    */
   _summarizeMonk(result, output) {
     const content = /** @type {string | undefined} */ (get(output, 'monk.output.content'))
-    if (!content) return
+    if (!content) {
+      return
+    }
     const files = content
       .split('\n')
       .map(
         /** @param {string} file */ file => {
           const fullMatch = /^found full match between \\"(.*?)\\" and \\"(.*?)\\"/.exec(file)
-          if (!fullMatch) return null
+          if (!fullMatch) {
+            return null
+          }
           const [, path, rawLicense] = fullMatch
           const license = SPDX.normalize(rawLicense)
-          if (path && license) return { path, license }
-          if (path) return { path }
+          if (path && license) {
+            return { path, license }
+          }
+          if (path) {
+            return { path }
+          }
           return null
         }
       )
@@ -139,7 +155,9 @@ class FOSSologySummarizer {
    * @private
    */
   _declareLicense(coordinates, result) {
-    if (!result.files) return
+    if (!result.files) {
+      return
+    }
     // if we know this is a license file by the name of it and it has a license detected in it
     // then let's declare the license for the component
     const licenses = uniq(

--- a/providers/summary/licensee.js
+++ b/providers/summary/licensee.js
@@ -36,7 +36,9 @@ class LicenseeSummarizer {
    * @throws {Error} If Licensee data is invalid
    */
   summarize(coordinates, harvested) {
-    if (!harvested || !harvested.licensee || !harvested.licensee.version) throw new Error('Invalid Licensee data')
+    if (!harvested || !harvested.licensee || !harvested.licensee.version) {
+      throw new Error('Invalid Licensee data')
+    }
     const result = {}
     setIfValue(result, 'files', this._summarizeFiles(harvested))
     this._addLicenseFromFiles(result, coordinates)
@@ -54,11 +56,17 @@ class LicenseeSummarizer {
       get(harvested, 'licensee.output.content.matched_files')
     )
     const attachments = harvested.attachments || []
-    if (!files) return null
+    if (!files) {
+      return null
+    }
     return files
       .map(file => {
-        if (get(file, 'matcher.name') !== 'exact') return null
-        if (80 > +get(file, 'matcher.confidence')) return null
+        if (get(file, 'matcher.name') !== 'exact') {
+          return null
+        }
+        if (80 > +get(file, 'matcher.confidence')) {
+          return null
+        }
         const path = file.filename
         const attachment = attachments.find(x => x.path === path)
         const license = SPDX.normalize(file.matched_license)
@@ -80,7 +88,9 @@ class LicenseeSummarizer {
    * @private
    */
   _addLicenseFromFiles(result, coordinates) {
-    if (!result.files) return
+    if (!result.files) {
+      return
+    }
     const licenses = result.files
       .map(file => (isDeclaredLicense(file.license) && isLicenseFile(file.path, coordinates) ? file.license : null))
       .filter(x => x)

--- a/providers/summary/reuse.js
+++ b/providers/summary/reuse.js
@@ -37,7 +37,9 @@ class FsfeReuseSummarizer {
    * @throws {Error} If REUSE data is invalid
    */
   summarize(_coordinates, harvested) {
-    if (!harvested || !harvested.reuse || !harvested.reuse.metadata.CreatorTool) throw new Error('Invalid REUSE data')
+    if (!harvested || !harvested.reuse || !harvested.reuse.metadata.CreatorTool) {
+      throw new Error('Invalid REUSE data')
+    }
     const result = {}
 
     setIfValue(result, 'files', this._summarizeFiles(harvested))
@@ -53,7 +55,9 @@ class FsfeReuseSummarizer {
    */
   _summarizeFiles(harvested) {
     const files = /** @type {ReuseFile[] | undefined} */ (get(harvested, 'reuse.files'))
-    if (!files) return null
+    if (!files) {
+      return null
+    }
     /** @type {FileEntry[]} */
     const licenseFiles = []
     const attachments = harvested.attachments || []
@@ -99,7 +103,9 @@ class FsfeReuseSummarizer {
    * @private
    */
   _addLicenseDeclaration(harvested, result) {
-    if (!harvested.reuse.licenses) return
+    if (!harvested.reuse.licenses) {
+      return
+    }
     const declaredLicenses = harvested.reuse.licenses
       .map(license => (isDeclaredLicense(SPDX.normalize(license.spdxId)) ? license.spdxId : null))
       .filter(x => x)

--- a/providers/summary/scancode.js
+++ b/providers/summary/scancode.js
@@ -44,7 +44,9 @@ class ScanCodeDelegator {
     const scancodeVersion = /** @type {string | undefined} */ (
       get(harvested, 'content.headers[0].tool_version') || get(harvested, 'content.scancode_version')
     )
-    if (!scancodeVersion) throw new Error('Not valid ScanCode data')
+    if (!scancodeVersion) {
+      throw new Error('Not valid ScanCode data')
+    }
 
     if (gte(scancodeVersion, '32.1.0')) {
       return ScanCodeNewSummarizer(this.options, this.logger).summarize(scancodeVersion, coordinates, harvested)

--- a/providers/summary/scancode/legacy-summarizer.js
+++ b/providers/summary/scancode/legacy-summarizer.js
@@ -68,7 +68,9 @@ class ScanCodeLegacySummarizer {
    */
   addDescribedInfo(result, harvested) {
     const releaseDate = harvested._metadata.releaseDate
-    if (releaseDate) result.described = { releaseDate: extractDate(releaseDate.trim()) }
+    if (releaseDate) {
+      result.described = { releaseDate: extractDate(releaseDate.trim()) }
+    }
   }
 
   /**
@@ -171,8 +173,11 @@ class ScanCodeLegacySummarizer {
    */
   _findRootFiles(files, roots) {
     return files.filter(file => {
-      for (const root of roots)
-        if (file.path.startsWith(root) && file.path.slice(root.length).indexOf('/') === -1) return true
+      for (const root of roots) {
+        if (file.path.startsWith(root) && file.path.slice(root.length).indexOf('/') === -1) {
+          return true
+        }
+      }
       return false
     })
   }
@@ -240,7 +245,9 @@ class ScanCodeLegacySummarizer {
         (licenses, file) => {
           if (file.licenses) {
             for (const license of file.licenses) {
-              if (license.score && license.score >= 90) licenses.add(this._createExpressionFromLicense(license))
+              if (license.score && license.score >= 90) {
+                licenses.add(this._createExpressionFromLicense(license))
+              }
             }
           }
           return licenses
@@ -286,7 +293,9 @@ class ScanCodeLegacySummarizer {
   _summarizeFileInfo(files, coordinates) {
     return files
       .map(file => {
-        if (file.type !== 'file') return null
+        if (file.type !== 'file') {
+          return null
+        }
         /** @type {FileEntry} */
         const result = { path: file.path }
         const asserted = /** @type {ScanCodeLicense[] | undefined} */ (get(file, 'packages[0].asserted_licenses'))
@@ -294,17 +303,20 @@ class ScanCodeLegacySummarizer {
         let licenses = new Set(
           fileLicense.map(/** @param {ScanCodeLicense} x */ x => x.license).filter(/** @param {unknown} x */ x => x)
         )
-        if (!licenses.size)
+        if (!licenses.size) {
           licenses = new Set(
             fileLicense
               .filter(/** @param {ScanCodeLicense} x */ x => x.score !== undefined && x.score >= 80)
               .map(/** @param {ScanCodeLicense} x */ x => this._createExpressionFromLicense(x))
           )
+        }
         const licenseExpression = joinExpressions(licenses)
         setIfValue(result, 'license', licenseExpression)
         if (this._getLicenseByIsLicenseText([file]) || this._getLicenseByFileName([file], coordinates)) {
           result.natures = result.natures || []
-          if (!result.natures.includes('license')) result.natures.push('license')
+          if (!result.natures.includes('license')) {
+            result.natures.push('license')
+          }
         }
         setIfValue(
           result,
@@ -333,7 +345,9 @@ class ScanCodeLegacySummarizer {
    */
   _createExpressionFromLicense(license) {
     const rule = license.matched_rule
-    if (!rule || !rule.license_expression) return SPDX.normalize(license.spdx_license_key)
+    if (!rule || !rule.license_expression) {
+      return SPDX.normalize(license.spdx_license_key)
+    }
     return normalizeLicenseExpression(rule.license_expression, this.logger, null)
   }
 }

--- a/providers/summary/scancode/new-summarizer.js
+++ b/providers/summary/scancode/new-summarizer.js
@@ -51,7 +51,9 @@ class ScanCodeNewSummarizer {
    * @throws {Error} If ScanCode version is not provided
    */
   summarize(scancodeVersion, coordinates, harvestedData) {
-    if (!scancodeVersion) throw new Error('Not valid ScanCode data')
+    if (!scancodeVersion) {
+      throw new Error('Not valid ScanCode data')
+    }
 
     const result = {}
     this.addDescribedInfo(result, harvestedData)
@@ -74,7 +76,9 @@ class ScanCodeNewSummarizer {
    */
   addDescribedInfo(result, harvestedData) {
     const releaseDate = harvestedData._metadata.releaseDate
-    if (releaseDate) result.described = { releaseDate: extractDate(releaseDate.trim()) }
+    if (releaseDate) {
+      result.described = { releaseDate: extractDate(releaseDate.trim()) }
+    }
   }
 
   /**
@@ -123,9 +127,13 @@ class ScanCodeNewSummarizer {
    */
   _readDeclaredLicenseExpressionFromPackage({ content }) {
     const { packages } = content
-    if (!packages) return null
+    if (!packages) {
+      return null
+    }
     const [firstPackage] = packages
-    if (!firstPackage) return null
+    if (!firstPackage) {
+      return null
+    }
 
     const licenseExpression = firstPackage.declared_license_expression_spdx
 
@@ -175,7 +183,9 @@ class ScanCodeNewSummarizer {
     return files.filter(
       /** @param {ScanCodeFile} file */ file => {
         for (const root of roots) {
-          if (file.path.startsWith(root) && file.path.slice(root.length).indexOf('/') === -1) return true
+          if (file.path.startsWith(root) && file.path.slice(root.length).indexOf('/') === -1) {
+            return true
+          }
         }
         return false
       }
@@ -260,7 +270,9 @@ class ScanCodeNewSummarizer {
    * @private
    */
   _getLicenseExpressionFromFileLicenseDetections(file) {
-    if (!file.license_detections) return null
+    if (!file.license_detections) {
+      return null
+    }
     const licenseExpressions = file.license_detections.reduce(
       /**
        * @param {Set<string>} licenseExpressions
@@ -295,7 +307,9 @@ class ScanCodeNewSummarizer {
     return files
       .map(
         /** @param {ScanCodeFile} file */ file => {
-          if (file.type !== 'file') return null
+          if (file.type !== 'file') {
+            return null
+          }
 
           /** @type {FileEntry} */
           const result = { path: file.path }
@@ -309,7 +323,9 @@ class ScanCodeNewSummarizer {
             this._getClosestLicenseMatchByFileName([file], coordinates)
           ) {
             result.natures = result.natures || []
-            if (!result.natures.includes('license')) result.natures.push('license')
+            if (!result.natures.includes('license')) {
+              result.natures.push('license')
+            }
           }
 
           setIfValue(

--- a/providers/upgrade/defUpgradeQueue.js
+++ b/providers/upgrade/defUpgradeQueue.js
@@ -17,9 +17,13 @@ class DefinitionQueueUpgrader extends DefinitionVersionChecker {
    * @returns {Promise<Definition | undefined>}
    */
   async validate(definition) {
-    if (!definition) return undefined
+    if (!definition) {
+      return undefined
+    }
     const result = await super.validate(definition)
-    if (result) return result
+    if (result) {
+      return result
+    }
 
     await this._queueUpgrade(definition)
     return definition
@@ -27,7 +31,9 @@ class DefinitionQueueUpgrader extends DefinitionVersionChecker {
 
   /** @param {Definition} definition */
   async _queueUpgrade(definition) {
-    if (!this._upgrade) throw new Error('Upgrade queue is not set')
+    if (!this._upgrade) {
+      throw new Error('Upgrade queue is not set')
+    }
     try {
       const message = this._constructMessage(definition)
       await this._upgrade.queue(message)

--- a/providers/upgrade/defVersionCheck.js
+++ b/providers/upgrade/defVersionCheck.js
@@ -33,12 +33,16 @@ class DefinitionVersionChecker {
    * @returns {Promise<Definition | undefined>}
    */
   async validate(definition) {
-    if (!this._currentSchema) throw new Error('Current schema version is not set')
+    if (!this._currentSchema) {
+      throw new Error('Current schema version is not set')
+    }
     const defSchemaVersion = get(definition, '_meta.schemaVersion')
     this.logger.debug(
       `Definition version: ${defSchemaVersion}, Current schema version: ${this._currentSchema}, Coordinates: ${DefinitionVersionChecker.getCoordinates(definition)}`
     )
-    if (defSchemaVersion && gte(defSchemaVersion, this._currentSchema)) return definition
+    if (defSchemaVersion && gte(defSchemaVersion, this._currentSchema)) {
+      return definition
+    }
     return undefined
   }
 

--- a/providers/upgrade/process.js
+++ b/providers/upgrade/process.js
@@ -32,18 +32,24 @@ class QueueHandler {
     let isQueueEmpty = true
     try {
       const messages = await this._queue.dequeueMultiple()
-      if (messages && messages.length > 0) isQueueEmpty = false
+      if (messages && messages.length > 0) {
+        isQueueEmpty = false
+      }
       const results = await Promise.allSettled(
         messages.map(async message => {
           await this._messageHandler.processMessage(message)
           await this._queue.delete(message)
         })
       )
-      for (const result of results.filter(result => result.status === 'rejected')) this.logger.error(result.reason)
+      for (const result of results.filter(result => result.status === 'rejected')) {
+        this.logger.error(result.reason)
+      }
     } catch (error) {
       this.logger.error(error instanceof Error ? error.message : String(error))
     } finally {
-      if (!once) setTimeout(this.work.bind(this), isQueueEmpty ? 10000 : 0)
+      if (!once) {
+        setTimeout(this.work.bind(this), isQueueEmpty ? 10000 : 0)
+      }
     }
   }
 }
@@ -74,7 +80,9 @@ class DefinitionUpgrader {
   /** @param {DequeuedMessage} message */
   async processMessage(message) {
     let coordinates = get(message, 'data.coordinates')
-    if (!coordinates) return
+    if (!coordinates) {
+      return
+    }
     coordinates = EntityCoordinates.fromObject(coordinates)
 
     while (this._upgradeLock.get(coordinates.toString())) {

--- a/routes/attachments.js
+++ b/routes/attachments.js
@@ -17,7 +17,9 @@ router.get('/:id', asyncMiddleware(getAttachment))
  */
 async function getAttachment(request, response) {
   const result = await attachmentStore.get(/** @type {string} */ (request.params.id))
-  if (!result) return response.sendStatus(404)
+  if (!result) {
+    return response.sendStatus(404)
+  }
   return response.status(200).send(result)
 }
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -64,7 +64,9 @@ router.get('/github', (req, res) => {
   if (referrer) {
     try {
       const url = new URL(referrer)
-      if (url.hostname === 'localhost') res.cookie('localhostOrigin', url.origin)
+      if (url.hostname === 'localhost') {
+        res.cookie('localhostOrigin', url.origin)
+      }
     } catch (err) {
       console.warn('Referrer parsing error, ignoring', err)
     }
@@ -76,7 +78,9 @@ router.get('/github', (req, res) => {
 router.get('/github/start', passportOrPat(), (_req, res) => {
   // this only runs if passport didn't kick in above, but double
   // check for sanity in case upstream changes
-  if (!options.clientId) res.redirect('finalize')
+  if (!options.clientId) {
+    res.redirect('finalize')
+  }
 })
 
 router.get('/github/finalize', passportOrPat(), async (req, res) => {
@@ -88,7 +92,9 @@ router.get('/github/finalize', passportOrPat(), async (req, res) => {
   // allow for sending auth responses to localhost on dev site; see /github
   // route above. real origin is stored in cookie.
   let origin = endpoints.website
-  if (endpoints.service.includes('dev-api') && req.cookies.localhostOrigin) origin = req.cookies.localhostOrigin
+  if (endpoints.service.includes('dev-api') && req.cookies.localhostOrigin) {
+    origin = req.cookies.localhostOrigin
+  }
 
   // passing in the 'website' endpoint below is very important;
   // using '*' instead means this page will gladly send out a
@@ -153,7 +159,9 @@ async function getUserDetails(token, org) {
 function findPermissions(team) {
   const permissions = options.permissions
   for (const permission in permissions) {
-    if (permissions[permission].includes(team)) return permission
+    if (permissions[permission].includes(team)) {
+      return permission
+    }
   }
   return null
 }

--- a/routes/curations.js
+++ b/routes/curations.js
@@ -22,7 +22,9 @@ router.get('/:type/:provider/:namespace/:name/:revision/pr/:pr', asyncMiddleware
 async function getChangesForCoordinatesInPr(request, response) {
   const coordinates = await utils.toEntityCoordinatesFromRequest(request)
   const result = await curationService.get(coordinates, request.params.pr)
-  if (result) return response.status(200).send(result)
+  if (result) {
+    return response.status(200).send(result)
+  }
   return response.sendStatus(404)
 }
 
@@ -40,7 +42,9 @@ async function getPr(request, response) {
     return response.status(200).send({ url, changes })
   } catch (exception) {
     const error = /** @type {Error & {code?: number}} */ (exception)
-    if (error.code === 404) return response.sendStatus(404)
+    if (error.code === 404) {
+      return response.sendStatus(404)
+    }
     throw error
   }
 }
@@ -53,10 +57,14 @@ router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(getCur
  * @param {Response} response
  */
 async function getCurationForCoordinates(request, response) {
-  if (request.query.expand === 'prs') return listCurations(request, response)
+  if (request.query.expand === 'prs') {
+    return listCurations(request, response)
+  }
   const coordinates = await utils.toEntityCoordinatesFromRequest(request)
   const result = await curationService.get(coordinates)
-  if (!result) return response.sendStatus(404)
+  if (!result) {
+    return response.sendStatus(404)
+  }
   return response.status(200).send(result)
 }
 
@@ -70,7 +78,9 @@ router.get('{/:type}{/:provider}{/:namespace}{/:name}', asyncMiddleware(listCura
 async function listCurations(request, response) {
   const coordinates = await utils.toEntityCoordinatesFromRequest(request)
   const result = await curationService.list(coordinates)
-  if (!result || !result.contributions.length) return response.sendStatus(404)
+  if (!result || !result.contributions.length) {
+    return response.sendStatus(404)
+  }
   return response.status(200).send(result)
 }
 
@@ -84,8 +94,9 @@ async function listAllCurations(request, response) {
   const coordinatesList = request.body.map((/** @type {string | null | undefined} */ entry) =>
     EntityCoordinates.fromString(entry)
   )
-  if (coordinatesList.length > 1000)
+  if (coordinatesList.length > 1000) {
     return response.status(400).send(`Body contains too many coordinates: ${coordinatesList.length}`)
+  }
   const normalizedCoordinatesList = await Promise.all(coordinatesList.map(utils.toNormalizedEntityCoordinates))
 
   const result = await curationService.listAll(normalizedCoordinatesList)
@@ -108,7 +119,9 @@ async function updateCurations(request, response) {
   const patchesInError = []
   for (const /** @type {string | import('../lib/curation').CurationData} */ entry of request.body.patches) {
     const curation = new Curation(entry)
-    if (curation.errors.length > 0) curationErrors = [...curationErrors, curation.errors]
+    if (curation.errors.length > 0) {
+      curationErrors = [...curationErrors, curation.errors]
+    }
     patchesInError.push(entry)
   }
   if (curationErrors.length > 0) {

--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -82,8 +82,12 @@ router.get('/', asyncMiddleware(getDefinitions))
  */
 async function getDefinitions(request, response) {
   const pattern = request.query.pattern
-  if (pattern) return response.send(await definitionService.suggestCoordinates(pattern))
-  if (!validator.validate('definitions-find', request.query)) return response.status(400).send(validator.errorsText())
+  if (pattern) {
+    return response.send(await definitionService.suggestCoordinates(pattern))
+  }
+  if (!validator.validate('definitions-find', request.query)) {
+    return response.status(400).send(validator.errorsText())
+  }
   const normalizedCoordinates = await utils.toNormalizedEntityCoordinates(request.query)
   const result = await definitionService.find({ ...request.query, ...normalizedCoordinates })
   return response.send(result)
@@ -94,9 +98,12 @@ async function getDefinitions(request, response) {
 router.post(
   '/:type/:provider/:namespace/:name/:revision',
   asyncMiddleware(async (/** @type {Request} */ request, /** @type {Response} */ response) => {
-    if (!request.query.preview)
+    if (!request.query.preview) {
       return response.status(400).send('Only valid for previews. Use the "preview" query parameter')
-    if (!validator.validate('curation', request.body)) return response.status(400).send(validator.errorsText())
+    }
+    if (!validator.validate('curation', request.body)) {
+      return response.status(400).send(validator.errorsText())
+    }
     const coordinates = await utils.toEntityCoordinatesFromRequest(request)
     const result = await definitionService.compute(coordinates, request.body)
     return response.status(200).send(result)
@@ -115,8 +122,9 @@ async function listDefinitions(request, response) {
   const coordinatesList = request.body.map((/** @type {string | null | undefined} */ entry) =>
     EntityCoordinates.fromString(entry)
   )
-  if (coordinatesList.length > 500)
+  if (coordinatesList.length > 500) {
     return response.status(400).send(`Body contains too many coordinates: ${coordinatesList.length}`)
+  }
   const normalizedCoordinates = await Promise.all(coordinatesList.map(utils.toNormalizedEntityCoordinates))
   const coordinatesLookup = mapCoordinates(request, normalizedCoordinates)
 
@@ -161,8 +169,9 @@ function mapCoordinates(request, normalizedCoordinates) {
   for (let i = 0; i < request.body.length; i++) {
     const requestedKey = request.body[i]
     const normalizedKey = normalizedCoordinates[i]?.toString()
-    if (requestedKey && normalizedKey && requestedKey.toLowerCase() !== normalizedKey.toLowerCase())
+    if (requestedKey && normalizedKey && requestedKey.toLowerCase() !== normalizedKey.toLowerCase()) {
       coordinatesLookup.set(requestedKey, normalizedKey)
+    }
   }
   return coordinatesLookup
 }
@@ -175,15 +184,21 @@ function mapCoordinates(request, normalizedCoordinates) {
  */
 function adaptResultKeys(result, requestedKeys, coordinatesLookup, matchCase) {
   const shouldAdaptKeys = coordinatesLookup.size > 0 || matchCase
-  if (!shouldAdaptKeys) return result
+  if (!shouldAdaptKeys) {
+    return result
+  }
   const resultKeyLookup = new Map(Object.keys(result).map(key => [key.toLowerCase(), key]))
   return requestedKeys.reduce(
     (total, requested) => {
       let mapped = coordinatesLookup.get(requested)
-      if (matchCase) mapped = mapped || resultKeyLookup.get(requested.toLowerCase())
+      if (matchCase) {
+        mapped = mapped || resultKeyLookup.get(requested.toLowerCase())
+      }
       const resultKey = mapped || resultKeyLookup.get(requested.toLowerCase())
       const value = result[resultKey]
-      if (value) total[mapped ? requested : resultKey] = value
+      if (value) {
+        total[mapped ? requested : resultKey] = value
+      }
       return total
     },
     /** @type {Record<string, any>} */ ({})

--- a/routes/harvest.js
+++ b/routes/harvest.js
@@ -126,9 +126,13 @@ async function normalizeFilterCoordinates(requests) {
   const normalizedBody = await Promise.all(
     requests.map(async entry => {
       const coordinates = EntityCoordinates.fromString(entry?.coordinates)
-      if (!coordinates) return null
+      if (!coordinates) {
+        return null
+      }
       const normalized = await utils.toNormalizedEntityCoordinates(coordinates)
-      if (harvestThrottler.isBlocked(normalized)) throw new Error(`Harvest throttled for ${normalized.toString()}`)
+      if (harvestThrottler.isBlocked(normalized)) {
+        throw new Error(`Harvest throttled for ${normalized.toString()}`)
+      }
       return { ...entry, coordinates: normalized.toString() }
     })
   )

--- a/routes/originGitHub.js
+++ b/routes/originGitHub.js
@@ -62,7 +62,9 @@ router.get(
     } catch (e) {
       const error = /** @type {any} */ (e)
       logger.error('Error in /:login/:repo/revisions route', { error })
-      if (error.code === 404) return response.status(200).send([])
+      if (error.code === 404) {
+        return response.status(200).send([])
+      }
       // TODO what to do on non-404 errors? Log for sure but what do we give back to the caller?
       return response.status(200).send([])
     }

--- a/routes/originGitLab.js
+++ b/routes/originGitLab.js
@@ -20,7 +20,9 @@ router.get(
 
       const project_info = await gitlab.Projects.search(project)
       const project_match = getExactProjectMatch(namespace, project, project_info)
-      if (!project_match) throw new Error(`No project found for ${namespace}/${project}`)
+      if (!project_match) {
+        throw new Error(`No project found for ${namespace}/${project}`)
+      }
 
       const tags = await gitlab.Tags.all(project_match.id)
 
@@ -38,7 +40,9 @@ router.get(
     } catch (e) {
       const err = /** @type {any} */ (e)
       logger.info(err)
-      if (err.code === 404) return response.status(200).send([])
+      if (err.code === 404) {
+        return response.status(200).send([])
+      }
       // TODO what to do on non-404 errors? Log for sure but what do we give back to the caller?
       return response.status(200).send([])
     }

--- a/routes/originMaven.js
+++ b/routes/originMaven.js
@@ -20,7 +20,9 @@ router.get(
       return response.status(200).send(uniq(result))
     } catch (e) {
       const error = /** @type {any} */ (e)
-      if (error.code === 404) return response.status(200).send([])
+      if (error.code === 404) {
+        return response.status(200).send([])
+      }
       // TODO what to do on non-404 errors? Log for sure but what do we give back to the caller?
       return response.status(200).send([])
     }
@@ -52,10 +54,11 @@ router.get(
  */
 function getSuggestions(answer, group) {
   const docs = answer.response.docs
-  if (docs.length)
+  if (docs.length) {
     return docs.map((/** @type {any} */ item) => {
       return { id: escapeHTML(item.id) }
     })
+  }
   const suggestions = answer.spellcheck?.suggestions?.[1]
   const result = suggestions ? suggestions.suggestion : []
   return group

--- a/routes/originPyPi.js
+++ b/routes/originPyPi.js
@@ -34,7 +34,9 @@ async function getPypiData(name) {
     return await requestPromise({ url, method: 'GET', json: true })
   } catch (e) {
     const error = /** @type {any} */ (e)
-    if (error.statusCode === 404) return {}
+    if (error.statusCode === 404) {
+      return {}
+    }
     throw error
   }
 }

--- a/routes/suggestions.js
+++ b/routes/suggestions.js
@@ -19,7 +19,9 @@ router.get('/:type/:provider/:namespace/:name/:revision', asyncMiddleware(getSug
 async function getSuggestions(request, response) {
   const coordinates = await utils.toEntityCoordinatesFromRequest(request)
   const result = await suggestionService.get(coordinates)
-  if (result) return response.status(200).send(result)
+  if (result) {
+    return response.status(200).send(result)
+  }
   return response.sendStatus(404)
 }
 

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -31,7 +31,9 @@ router.post('/', asyncMiddleware(handlePost))
  * @param {Response} response
  */
 function handlePost(request, response) {
-  if (request.headers['x-crawler']) return handleCrawlerCall(request, response)
+  if (request.headers['x-crawler']) {
+    return handleCrawlerCall(request, response)
+  }
   return handleGitHubCall(request, response)
 }
 
@@ -41,7 +43,9 @@ function handlePost(request, response) {
  */
 async function handleGitHubCall(request, response) {
   const body = validateGitHubCall(request, response)
-  if (!body) return
+  if (!body) {
+    return
+  }
   const pr = body.pull_request
   try {
     switch (body.action) {
@@ -113,15 +117,19 @@ async function handleCrawlerCall(request, response) {
  * @returns {boolean}
  */
 function validateGitHubSignature(request, response) {
-  if (request.hostname?.includes('localhost')) return true
+  if (request.hostname?.includes('localhost')) {
+    return true
+  }
   const isGithubEvent = request.headers['x-github-event']
   const signature = /** @type {string | undefined} */ (request.headers['x-hub-signature'])
-  if (!isGithubEvent || !signature)
+  if (!isGithubEvent || !signature) {
     return info(request, response, 400, 'Missing signature or event type on GitHub webhook')
+  }
 
   const computedSignature = `sha1=${crypto.createHmac('sha1', githubSecret).update(request.body).digest('hex')}`
-  if (!test && !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(computedSignature)))
+  if (!test && !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(computedSignature))) {
     return info(request, response, 400, 'X-Hub-Signature does not match blob signature')
+  }
   return true
 }
 
@@ -131,7 +139,9 @@ function validateGitHubSignature(request, response) {
  * @returns {any}
  */
 function validateGitHubCall(request, response) {
-  if (!validateGitHubSignature(request, response)) return false
+  if (!validateGitHubSignature(request, response)) {
+    return false
+  }
   let body = request.body
   if (Buffer.isBuffer(body)) {
     body = JSON.parse(body.toString('utf8'))
@@ -140,7 +150,9 @@ function validateGitHubCall(request, response) {
   }
 
   const isValidPullRequest = body.pull_request && validPrActions.includes(body.action)
-  if (!isValidPullRequest) return info(request, response, 200)
+  if (!isValidPullRequest) {
+    return info(request, response, 200)
+  }
   return body
 }
 

--- a/test/business/definitionServiceTest.js
+++ b/test/business/definitionServiceTest.js
@@ -106,7 +106,9 @@ describe('Definition Service', () => {
     const { service } = setup()
     service.definitionStore.list = coordinates => {
       coordinates.revision = '2.3'
-      if (coordinates.name === 'missing') return Promise.resolve([])
+      if (coordinates.name === 'missing') {
+        return Promise.resolve([])
+      }
       return Promise.resolve([coordinates.toString().toLowerCase()])
     }
     const coordinates = [
@@ -671,14 +673,22 @@ function setupWithDelegates(
 function validate(definition) {
   // Tack on a dummy coordinates to keep the schema happy. Tool summarizations do not have to include coordinates
   definition.coordinates = { type: 'npm', provider: 'npmjs', namespace: null, name: 'foo', revision: '1.0' }
-  if (!validator.validate('definition', definition)) throw new Error(validator.errorsText())
+  if (!validator.validate('definition', definition)) {
+    throw new Error(validator.errorsText())
+  }
 }
 
 function createDefinition(facets, files, tools) {
   const result = {}
-  if (facets) set(result, 'described.facets', facets)
-  if (files) result.files = files
-  if (tools) set(result, 'described.tools', tools)
+  if (facets) {
+    set(result, 'described.facets', facets)
+  }
+  if (files) {
+    result.files = files
+  }
+  if (tools) {
+    set(result, 'described.tools', tools)
+  }
   return result
 }
 

--- a/test/business/scoring.js
+++ b/test/business/scoring.js
@@ -164,7 +164,9 @@ function createDefinition(declared, files) {
     // collect up the flie license expressions
     const expressions = Array.from(
       files.reduce((list, file) => {
-        if (!file.facets || file.facets.includes('core')) list.add(file.license)
+        if (!file.facets || file.facets.includes('core')) {
+          list.add(file.license)
+        }
         return list
       }, new Set())
     ).filter(e => e)

--- a/test/lib/rateLimit.js
+++ b/test/lib/rateLimit.js
@@ -286,7 +286,9 @@ async function tryBeyondLimit(max, client) {
   let counter = 0
   while (counter < max + 10) {
     const response = await client.get('/')
-    if (!response.ok) break
+    if (!response.ok) {
+      break
+    }
     counter++
   }
   return counter

--- a/test/lib/spdx.js
+++ b/test/lib/spdx.js
@@ -235,7 +235,9 @@ describe('SPDX utility functions', () => {
       'net-snmp': 'Net-SNMP'
     }
     for (let input of Object.keys(data)) {
-      if (input === 'null') input = null
+      if (input === 'null') {
+        input = null
+      }
       expect(SPDX.normalize(input)).to.eq(data[input])
     }
   })
@@ -251,7 +253,9 @@ describe('SPDX utility functions', () => {
       null: null
     }
     for (let input of Object.keys(data)) {
-      if (input === 'null') input = null
+      if (input === 'null') {
+        input = null
+      }
       expect(SPDX.lookupByName(input)).to.eq(data[input])
     }
   })

--- a/test/providers/caching/redis.js
+++ b/test/providers/caching/redis.js
@@ -134,7 +134,9 @@ describe('Redis Cache', () => {
     afterEach(() => {
       sandbox.restore()
       // Clear store
-      for (const key of Object.keys(store)) delete store[key]
+      for (const key of Object.keys(store)) {
+        delete store[key]
+      }
     })
 
     describe('Format Detection', () => {

--- a/test/providers/caching/redisConfig.js
+++ b/test/providers/caching/redisConfig.js
@@ -37,7 +37,9 @@ describe('redisConfig.serviceFactory', () => {
 
   function expectConfigGetCalled(configSpy, keys) {
     assert.strictEqual(configSpy.callCount, keys.length)
-    for (const k of keys) assert.ok(configSpy.calledWith(k))
+    for (const k of keys) {
+      assert.ok(configSpy.calledWith(k))
+    }
   }
 
   it('uses provided options only', () => {

--- a/test/providers/harvest/crawlerConfig.js
+++ b/test/providers/harvest/crawlerConfig.js
@@ -43,8 +43,9 @@ describe('crawlerConfig.serviceFactory (TTL cases)', () => {
 
     // Keys fetched
     assert.strictEqual(configGet.callCount, 3)
-    for (const k of ['CRAWLER_API_AUTH_TOKEN', 'CRAWLER_API_URL', 'HARVEST_CACHE_TTL_IN_SECONDS'])
+    for (const k of ['CRAWLER_API_AUTH_TOKEN', 'CRAWLER_API_URL', 'HARVEST_CACHE_TTL_IN_SECONDS']) {
       assert.ok(configGet.calledWith(k))
+    }
 
     // Wrapper received TTL and harvester
     assert.strictEqual(result.received.cacheTTLInSeconds, 120)

--- a/test/providers/store/abstractFileStore.js
+++ b/test/providers/store/abstractFileStore.js
@@ -30,7 +30,9 @@ describe('AbstractFileStore', () => {
     beforeEach(() => {
       const recursiveStub = async path => {
         path = path.replace(/\\/g, '/')
-        if (path.includes('error')) throw new Error('test error')
+        if (path.includes('error')) {
+          throw new Error('test error')
+        }
         const result = Object.keys(data).filter(p => p.startsWith(path))
         if (result.length === 0) {
           const error = new Error('test')
@@ -317,8 +319,11 @@ describe('AbstractFileStore', () => {
         'node:fs': {
           readFile: (path, cb) => {
             const entry = sampleEntries.find(e => e.path === path)
-            if (entry) cb(null, JSON.stringify(entry))
-            else cb(new Error('Not found'))
+            if (entry) {
+              cb(null, JSON.stringify(entry))
+            } else {
+              cb(new Error('Not found'))
+            }
           }
         }
       })

--- a/test/providers/store/azblobAttachment.js
+++ b/test/providers/store/azblobAttachment.js
@@ -38,8 +38,12 @@ const data = {
 function createStore() {
   const blobServiceStub = {
     getBlobToText: sinon.stub().callsFake((_container, path, cb) => {
-      if (path.includes('error')) return cb(new Error('test error'))
-      if (data[path]) return cb(null, data[path])
+      if (path.includes('error')) {
+        return cb(new Error('test error'))
+      }
+      if (data[path]) {
+        return cb(null, data[path])
+      }
       const error = new Error('not found')
       error.statusCode = 404
       cb(error)

--- a/test/providers/store/azblobDefinition.js
+++ b/test/providers/store/azblobDefinition.js
@@ -109,7 +109,9 @@ function createStore(data) {
       .stub()
       .callsFake(async (_container, name, _continuation, _metadata, callback) => {
         name = name.toLowerCase()
-        if (name.includes('error')) return callback(new Error('test error'))
+        if (name.includes('error')) {
+          return callback(new Error('test error'))
+        }
         callback(null, {
           continuationToken: null,
           entries: Object.keys(data)
@@ -118,18 +120,28 @@ function createStore(data) {
         })
       }),
     createBlockBlobFromText: sinon.stub().callsFake(async (_container, name, _content, _metadata, callback) => {
-      if (name.includes('error')) return callback(new Error('test error'))
+      if (name.includes('error')) {
+        return callback(new Error('test error'))
+      }
       callback()
     }),
     deleteBlob: sinon.stub().callsFake(async (_container, name, callback) => {
-      if (name.includes('error')) return callback(new Error('test error'))
-      if (name.includes('missing')) return callback({ code: 'BlobNotFound' })
+      if (name.includes('error')) {
+        return callback(new Error('test error'))
+      }
+      if (name.includes('missing')) {
+        return callback({ code: 'BlobNotFound' })
+      }
       callback()
     }),
     getBlobToText: sinon.stub().callsFake(async (_container, name, callback) => {
-      if (name.includes('error')) return callback(new Error('test error'))
+      if (name.includes('error')) {
+        return callback(new Error('test error'))
+      }
       name = name.toLowerCase()
-      if (data[name]) return callback(null, data[name])
+      if (data[name]) {
+        return callback(null, data[name])
+      }
       const error = new Error('not found')
       error.code = 'BlobNotFound'
       callback(error)

--- a/test/providers/store/fileAttachment.js
+++ b/test/providers/store/fileAttachment.js
@@ -18,8 +18,12 @@ describe('FileAttachmentStore list definitions', () => {
     const fsStub = {
       readFile: (path, cb) => {
         path = path.replace(/\\/g, '/')
-        if (path.includes('error')) return cb(new Error('test error'))
-        if (data[path]) return cb(null, data[path])
+        if (path.includes('error')) {
+          return cb(new Error('test error'))
+        }
+        if (data[path]) {
+          return cb(null, data[path])
+        }
         const error = new Error('not found')
         error.code = 'ENOENT'
         cb(error)

--- a/test/providers/store/fileDefintion.js
+++ b/test/providers/store/fileDefintion.js
@@ -27,7 +27,9 @@ describe('FileDefinitionStore list definitions', () => {
   before(() => {
     sinon.stub(AbstractFileStore.prototype, 'list').callsFake(async (coordinates, visitor) => {
       const path = coordinates.toString()
-      if (path.includes('error')) throw new Error('test error')
+      if (path.includes('error')) {
+        throw new Error('test error')
+      }
       return Object.keys(data)
         .map(key => (key.startsWith(path) ? visitor(data[key]) : null))
         .filter(e => e)

--- a/test/providers/store/fileHarvest.js
+++ b/test/providers/store/fileHarvest.js
@@ -30,7 +30,9 @@ describe('FileHarvestStore list tool results', () => {
   before(() => {
     sinon.stub(AbstractFileStore.prototype, 'list').callsFake(async (coordinates, visitor) => {
       const path = coordinates.toString()
-      if (path.includes('error')) throw new Error('test error')
+      if (path.includes('error')) {
+        throw new Error('test error')
+      }
       return Object.keys(data)
         .map(key => (key.startsWith(path) ? visitor(data[key].contents) : null))
         .filter(e => e)

--- a/test/providers/store/mongoDefinition.js
+++ b/test/providers/store/mongoDefinition.js
@@ -237,7 +237,9 @@ function createStore(data) {
   const collectionStub = {
     find: sinon.stub().callsFake(async filter => {
       const partitionKey = filter['_mongo.partitionKey']
-      if (partitionKey?.toString().includes('error')) throw new Error('test error')
+      if (partitionKey?.toString().includes('error')) {
+        throw new Error('test error')
+      }
       // return an object that mimics a Mongo cursor (i.e., has toArray)
       return {
         toArray: () => {
@@ -249,8 +251,11 @@ function createStore(data) {
         },
         forEach: cb => {
           for (const key of Object.keys(data)) {
-            if (typeof partitionKey === 'string' && key.indexOf(partitionKey) > -1) cb(data[key])
-            else if (partitionKey.exec?.(key)) cb(data[key])
+            if (typeof partitionKey === 'string' && key.indexOf(partitionKey) > -1) {
+              cb(data[key])
+            } else if (partitionKey.exec?.(key)) {
+              cb(data[key])
+            }
           }
         },
         [Symbol.asyncIterator]() {
@@ -261,7 +266,9 @@ function createStore(data) {
           let i = 0
           return {
             next() {
-              if (i < matches.length) return Promise.resolve({ value: data[matches[i++]], done: false })
+              if (i < matches.length) {
+                return Promise.resolve({ value: data[matches[i++]], done: false })
+              }
               return Promise.resolve({ value: undefined, done: true })
             }
           }

--- a/test/providers/store/mongoDefinitionPagination.js
+++ b/test/providers/store/mongoDefinitionPagination.js
@@ -287,7 +287,9 @@ class ContinousFetch {
       fetchedCounter += retrieved.count
       dispatchCounter++
 
-      if (!retrieved.continuationToken) break
+      if (!retrieved.continuationToken) {
+        break
+      }
     }
     return fetchedCounter
   }

--- a/test/providers/store/trimmedDefinitionPagination.js
+++ b/test/providers/store/trimmedDefinitionPagination.js
@@ -19,7 +19,9 @@ describe('Mongo Definition Store: Trimmed', () => {
 async function createStore(options, defs) {
   const mongoStore = Store({ ...options, ...dbOptions })
   await mongoStore.initialize()
-  for (const def of defs) delete def._mongo
+  for (const def of defs) {
+    delete def._mongo
+  }
   await mongoStore.collection.insertMany(defs)
   return mongoStore
 }

--- a/test/providers/summary/scancode/legacy-summarizer.js
+++ b/test/providers/summary/scancode/legacy-summarizer.js
@@ -15,7 +15,9 @@ describe('ScanCodeLegacySummarizer basic compatability', () => {
     const coordinates = { type: 'npm', provider: 'npmjs' }
     for (const version of scancodeVersions) {
       const harvestData = getHarvestData(version, 'npm-basic')
-      if (!harvestData) continue
+      if (!harvestData) {
+        continue
+      }
       const result = summarizer.summarize(coordinates, harvestData)
       assert.equal(result.licensed.declared, 'ISC', `Declared license mismatch for version ${version}`)
       assert.equal(result.described.releaseDate, '2017-05-19', `releaseDate mismatch for version ${version}`)
@@ -37,7 +39,9 @@ describe('ScanCodeLegacySummarizer basic compatability', () => {
     }
     for (const version of scancodeVersions) {
       const harvestData = getHarvestData(version, 'npm-large')
-      if (!harvestData) continue
+      if (!harvestData) {
+        continue
+      }
       const result = summarizer.summarize(coordinates, harvestData)
       assert.equal(
         result.licensed.declared,
@@ -125,7 +129,9 @@ describe('ScanCodeLegacySummarizer basic compatability', () => {
     const undefinedOverrides = ['2.9.2', '2.9.8']
     for (const version of scancodeVersions) {
       const harvestData = getHarvestData(version, 'gem')
-      if (!harvestData) continue
+      if (!harvestData) {
+        continue
+      }
       const result = summarizer.summarize(coordinates, harvestData)
 
       assert.equal(
@@ -143,7 +149,9 @@ describe('ScanCodeLegacySummarizer basic compatability', () => {
     const coordinates = { type: 'git', provider: 'github' }
     for (const version of scancodeVersions) {
       const harvestData = getHarvestData(version, 'git')
-      if (!harvestData) continue
+      if (!harvestData) {
+        continue
+      }
       const result = summarizer.summarize(coordinates, harvestData)
       assert.equal(result.licensed.declared, 'ISC', `Declared license mismatch for version ${version}`)
       assert.equal(result.described.releaseDate, '2017-02-24', `releaseDate mismatch for version ${version}`)
@@ -157,7 +165,9 @@ describe('ScanCodeLegacySummarizer basic compatability', () => {
     const coordinates = { type: 'pypi', provider: 'pypi', name: 'redis', revision: '3.0.1' }
     for (const version of scancodeVersions) {
       const harvestData = getHarvestData(version, 'python')
-      if (!harvestData) continue
+      if (!harvestData) {
+        continue
+      }
       const result = summarizer.summarize(coordinates, harvestData)
       assert.equal(result.licensed.declared, 'MIT', `Declared license mismatch for version ${version}`)
       assert.equal(result.described.releaseDate, '2018-11-15', `releaseDate mismatch for version ${version}`)

--- a/test/routes/origins.js
+++ b/test/routes/origins.js
@@ -267,7 +267,9 @@ describe('GitHub origin routes', () => {
       res.on('end', resolve)
       res.on('error', reject)
       router.handle(req, res, err => {
-        if (err) reject(err)
+        if (err) {
+          reject(err)
+        }
       })
     })
 
@@ -294,7 +296,9 @@ describe('GitHub origin routes', () => {
       res.on('end', resolve)
       res.on('error', reject)
       router.handle(req, res, err => {
-        if (err) reject(err)
+        if (err) {
+          reject(err)
+        }
       })
     })
 
@@ -338,7 +342,9 @@ describe('GitHub origin routes', () => {
       res.on('end', resolve)
       res.on('error', reject)
       router.handle(req, res, err => {
-        if (err) reject(err)
+        if (err) {
+          reject(err)
+        }
       })
     })
 
@@ -377,7 +383,9 @@ describe('GitHub origin routes', () => {
       res.on('finish', resolve)
       res.on('error', reject)
       router.handle(req, res, err => {
-        if (err) reject(err)
+        if (err) {
+          reject(err)
+        }
       })
     })
 
@@ -407,7 +415,9 @@ describe('GitHub origin routes', () => {
       res.on('end', resolve)
       res.on('error', reject)
       router.handle(req, res, err => {
-        if (err) reject(err)
+        if (err) {
+          reject(err)
+        }
       })
     })
 

--- a/test/summary/clearlyDefined.js
+++ b/test/summary/clearlyDefined.js
@@ -78,7 +78,9 @@ function setupMaven(releaseDate, sourceInfo, projectSummary) {
   const harvested = {}
   setIfValue(harvested, 'releaseDate', releaseDate)
   setIfValue(harvested, 'manifest.summary.project', projectSummary)
-  if (sourceInfo) harvested.sourceInfo = createSourceLocation(sourceInfo)
+  if (sourceInfo) {
+    harvested.sourceInfo = createSourceLocation(sourceInfo)
+  }
   return { coordinates, harvested }
 }
 
@@ -131,7 +133,9 @@ function setupNuGet({ releaseDate, sourceInfo, packageEntries }) {
   const harvested = {}
   setIfValue(harvested, 'releaseDate', releaseDate)
   setIfValue(harvested, 'manifest.packageEntries', packageEntries)
-  if (sourceInfo) harvested.sourceInfo = createSourceLocation(sourceInfo)
+  if (sourceInfo) {
+    harvested.sourceInfo = createSourceLocation(sourceInfo)
+  }
   return { coordinates, harvested }
 }
 
@@ -166,7 +170,9 @@ function setupSourceArchive(releaseDate, sourceInfo) {
   const coordinates = EntityCoordinates.fromString('sourcearchive/github/-/test/1.0')
   const harvested = {}
   setIfValue(harvested, 'releaseDate', releaseDate)
-  if (sourceInfo) harvested.sourceInfo = createSourceLocation(sourceInfo)
+  if (sourceInfo) {
+    harvested.sourceInfo = createSourceLocation(sourceInfo)
+  }
   return { coordinates, harvested }
 }
 
@@ -279,7 +285,9 @@ function setupNpm(releaseDate, license, homepage, bugs, sourceInfo) {
   setIfValue(registryData, 'manifest.homepage', homepage)
   setIfValue(registryData, 'manifest.bugs', bugs)
   const harvested = { registryData }
-  if (sourceInfo) harvested.sourceInfo = createSourceLocation(sourceInfo)
+  if (sourceInfo) {
+    harvested.sourceInfo = createSourceLocation(sourceInfo)
+  }
   const coordinates = EntityCoordinates.fromString('npm/npmjs/-/test/1.0')
   return { coordinates, harvested }
 }
@@ -336,9 +344,14 @@ function setupGem(releaseDate, licenses, sourceInfo) {
   const coordinates = EntityCoordinates.fromString('gem/rubygems/-/test/1.0')
   const harvested = {}
   setIfValue(harvested, 'releaseDate', releaseDate)
-  if (typeof licenses === 'string') setIfValue(harvested, 'registryData.license', licenses)
-  else setIfValue(harvested, 'registryData.licenses', licenses)
-  if (sourceInfo) harvested.sourceInfo = createSourceLocation(sourceInfo)
+  if (typeof licenses === 'string') {
+    setIfValue(harvested, 'registryData.license', licenses)
+  } else {
+    setIfValue(harvested, 'registryData.licenses', licenses)
+  }
+  if (sourceInfo) {
+    harvested.sourceInfo = createSourceLocation(sourceInfo)
+  }
   return { coordinates, harvested }
 }
 
@@ -377,7 +390,9 @@ function setupPypi(releaseDate, license, sourceInfo) {
   setIfValue(harvested, 'registryData.releases', {
     '1.0': [{ filename: 'py-1.7.0.tar.gz', url: 'https://clearlydefined.com' }]
   })
-  if (sourceInfo) harvested.sourceInfo = createSourceLocation()
+  if (sourceInfo) {
+    harvested.sourceInfo = createSourceLocation()
+  }
   return { coordinates, harvested }
 }
 
@@ -653,9 +668,12 @@ function setupDebian({ isSrc, releaseDate, registryData, sourceInfo, declaredLic
 
 function validate(definition) {
   // Tack on a dummy coordinates to keep the schema happy. Tool summarizations do not have to include coordinates
-  if (!definition.coordinates)
+  if (!definition.coordinates) {
     definition.coordinates = { type: 'npm', provider: 'npmjs', namespace: null, name: 'foo', revision: '1.0' }
-  if (!validator.validate('definition', definition)) throw new Error(validator.errorsText())
+  }
+  if (!validator.validate('definition', definition)) {
+    throw new Error(validator.errorsText())
+  }
 }
 
 function createSourceLocation() {

--- a/test/summary/clearlydefinedTests.js
+++ b/test/summary/clearlydefinedTests.js
@@ -310,23 +310,27 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
     for (const license of Object.keys(data)) {
       const result = {}
       summarizer.addNpmData(result, { registryData: { manifest: { license: license } } }, npmTestCoordinates)
-      if (data[license])
+      if (data[license]) {
         assert.deepEqual(result, {
           ...expectedResult,
           licensed: { declared: data[license] }
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
 
     for (const license of Object.keys(data)) {
       const result = {}
       summarizer.addNpmData(result, { registryData: { manifest: { license: { type: license } } } }, npmTestCoordinates)
-      if (data[license])
+      if (data[license]) {
         assert.deepEqual(result, {
           ...expectedResult,
           licensed: { declared: data[license] }
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
 
     for (const license of Object.keys(data)) {
@@ -337,7 +341,9 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
           ...expectedResult,
           licensed: { declared: data[license] }
         })
-      } else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
 
     for (const license of Object.keys(data)) {
@@ -348,7 +354,9 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
           ...expectedResult,
           licensed: { declared: data[license] }
         })
-      } else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
 
     const licenseArray = ['MIT']
@@ -397,7 +405,9 @@ describe('ClearlyDescribedSummarizer addNpmData', () => {
           urls: expectedUrls
         }
       }
-      if (data[date] !== null) expected.described.releaseDate = data[date]
+      if (data[date] !== null) {
+        expected.described.releaseDate = data[date]
+      }
       assert.deepEqual(result, expected)
     }
   })
@@ -511,12 +521,14 @@ describe('ClearlyDescribedSummarizer addNuGetData', () => {
     for (const licenseExpression of Object.keys(data)) {
       const result = {}
       summarizer.addNuGetData(result, { manifest: { licenseExpression } }, nugetTestCoordinates)
-      if (data[licenseExpression])
+      if (data[licenseExpression]) {
         assert.deepEqual(result, {
           ...expectedResult,
           licensed: { declared: data[licenseExpression] }
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
   })
 
@@ -534,12 +546,14 @@ describe('ClearlyDescribedSummarizer addNuGetData', () => {
     for (const licenseUrl of Object.keys(data)) {
       const result = {}
       summarizer.addNuGetData(result, { manifest: { licenseUrl } }, nugetTestCoordinates)
-      if (data[licenseUrl])
+      if (data[licenseUrl]) {
         assert.deepEqual(result, {
           ...expectedResult,
           licensed: { declared: data[licenseUrl] }
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
   })
 })
@@ -599,12 +613,14 @@ describe('ClearlyDescribedSummarizer addMavenData', () => {
         { manifest: { summary: { project: { licenses: [{ license: { url } }] } } } },
         testCoordinates
       )
-      if (data[url])
+      if (data[url]) {
         assert.deepEqual(result, {
           ...expectedResult,
           licensed: { declared: data[url] }
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
   })
 
@@ -625,14 +641,16 @@ describe('ClearlyDescribedSummarizer addMavenData', () => {
     data.forEach((expected, licenses) => {
       const result = {}
       summarizer.addMavenData(result, { manifest: { summary: { project: { licenses } } } }, testCoordinates)
-      if (expected)
+      if (expected) {
         assert.deepEqual(result, {
           described: {
             urls: expectedUrls
           },
           licensed: { declared: expected }
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     })
   })
 })
@@ -663,12 +681,14 @@ describe('ClearlyDescribedSummarizer addMavenData', () => {
         { manifest: { summary: { project: { licenses: [{ license: { url } }] } } } },
         testCoordinatesMavenGoogle
       )
-      if (data[url])
+      if (data[url]) {
         assert.deepEqual(result, {
           ...expectedResult,
           licensed: { declared: data[url] }
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
   })
 
@@ -689,14 +709,16 @@ describe('ClearlyDescribedSummarizer addMavenData', () => {
     data.forEach((expected, licenses) => {
       const result = {}
       summarizer.addMavenData(result, { manifest: { summary: { project: { licenses } } } }, testCoordinatesMavenGoogle)
-      if (expected)
+      if (expected) {
         assert.deepEqual(result, {
           described: {
             urls: expectedUrls
           },
           licensed: { declared: expected }
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     })
   })
 })
@@ -724,12 +746,14 @@ describe('ClearlyDescribedSummarizer addSourceArchiveData', () => {
         { manifest: { summary: { project: { licenses: [{ license: { url } }] } } } },
         sourceArchiveTestCoordinates
       )
-      if (data[url])
+      if (data[url]) {
         assert.deepEqual(result, {
           ...expectedResult,
           licensed: { declared: data[url] }
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
   })
 
@@ -763,8 +787,11 @@ describe('ClearlyDescribedSummarizer addSourceArchiveData', () => {
         { manifest: { summary: { licenses: [{ license }] } } },
         sourceArchiveTestCoordinates
       )
-      if (expected) assert.deepEqual(result, { described: { urls: expectedUrls }, licensed: { declared: expected } })
-      else assert.deepEqual(result, expectedResult)
+      if (expected) {
+        assert.deepEqual(result, { described: { urls: expectedUrls }, licensed: { declared: expected } })
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     })
   })
 })
@@ -809,11 +836,13 @@ describe('ClearlyDescribedSummarizer addGitData', () => {
         { manifest: { summary: { project: { licenses: [{ license: { url } }] } } } },
         testCoordinatesGit
       )
-      if (data[url])
+      if (data[url]) {
         assert.deepEqual(result, {
           ...expectedResult
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
   })
 
@@ -847,11 +876,13 @@ describe('ClearlyDescribedSummarizer addGitData', () => {
         { manifest: { summary: { project: { licenses: [{ license: { url } }] } } } },
         testCoordinatesGitLab
       )
-      if (data[url])
+      if (data[url]) {
         assert.deepEqual(result, {
           ...expectedResult
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
   })
 })
@@ -890,11 +921,13 @@ describe('ClearlyDescribedSummarizer addGoData', () => {
         { manifest: { summary: { project: { licenses: [{ license: { url } }] } } } },
         testCoordinatesGo
       )
-      if (data[url])
+      if (data[url]) {
         assert.deepEqual(result, {
           ...expectedResult
         })
-      else assert.deepEqual(result, expectedResult)
+      } else {
+        assert.deepEqual(result, expectedResult)
+      }
     }
   })
 
@@ -922,11 +955,13 @@ describe('ClearlyDescribedSummarizer addGoData', () => {
         { manifest: { summary: { project: { licenses: [{ license: { url } }] } } } },
         testEncodedCoordinatesGo
       )
-      if (testData[url])
+      if (testData[url]) {
         assert.deepEqual(result, {
           ...expectedDecodedResult
         })
-      else assert.deepEqual(result, expectedDecodedResult)
+      } else {
+        assert.deepEqual(result, expectedDecodedResult)
+      }
     }
   })
 

--- a/test/summary/fossology.js
+++ b/test/summary/fossology.js
@@ -168,9 +168,12 @@ describe('Mixed summarization', () => {
 
 function validate(definition) {
   // Tack on a dummy coordinates to keep the schema happy. Tool summarizations do not have to include coordinates
-  if (!definition.coordinates)
+  if (!definition.coordinates) {
     definition.coordinates = { type: 'npm', provider: 'npmjs', namespace: null, name: 'foo', revision: '1.0' }
-  if (!validator.validate('definition', definition)) throw new Error(validator.errorsText())
+  }
+  if (!validator.validate('definition', definition)) {
+    throw new Error(validator.errorsText())
+  }
 }
 
 function setup(files, coordinateSpec) {
@@ -184,7 +187,9 @@ function setup(files, coordinateSpec) {
 }
 
 function setupNomos(result, data) {
-  if (!data) return
+  if (!data) {
+    return
+  }
   const licenses = data.map(file => file.licenses).filter(e => e)
   result.nomos = {
     version: '3.4.0',
@@ -196,7 +201,9 @@ function setupNomos(result, data) {
 }
 
 function setupMonk(result, data) {
-  if (!data) return
+  if (!data) {
+    return
+  }
   const files = data.map(x => x.output).filter(x => x)
   result.monk = {
     version: '3.4.0',
@@ -205,7 +212,9 @@ function setupMonk(result, data) {
 }
 
 function setupCopyright(result, data) {
-  if (!data) return
+  if (!data) {
+    return
+  }
   const content = stripType(data)
   result.copyright = {
     version: '3.4.0',
@@ -226,11 +235,12 @@ function buildNomosFile(path, license) {
 }
 
 function buildMonkFile(path, license, type = 'full') {
-  if (type === 'full')
+  if (type === 'full') {
     return {
       type: 'monk',
       output: `found full match between \\"${path}\\" and \\"${license}\\" (rf_pk=311); matched: 61+1022`
     }
+  }
 }
 
 function buildCopyrightFile(path, parties) {

--- a/test/summary/scancode.js
+++ b/test/summary/scancode.js
@@ -267,9 +267,12 @@ describe('ScanCodeLegacySummarizer', () => {
 
 function validate(definition) {
   // Tack on a dummy coordinates to keep the schema happy. Tool summarizations do not have to include coordinates
-  if (!definition.coordinates)
+  if (!definition.coordinates) {
     definition.coordinates = { type: 'npm', provider: 'npmjs', namespace: null, name: 'foo', revision: '1.0' }
-  if (!validator.validate('definition', definition)) throw new Error(validator.errorsText())
+  }
+  if (!validator.validate('definition', definition)) {
+    throw new Error(validator.errorsText())
+  }
 }
 
 function setup(files, coordinateSpec, scancode_version = '30.1.0') {
@@ -283,7 +286,9 @@ function setup(files, coordinateSpec, scancode_version = '30.1.0') {
 
 function buildFile(path, license, holders, score = 100, rule = {}, fileProps = {}) {
   const wrapHolders = holders ? { statements: holders.map(holder => `Copyright ${holder}`) } : null
-  if (!Array.isArray(license)) license = [license]
+  if (!Array.isArray(license)) {
+    license = [license]
+  }
   return {
     path,
     type: 'file',


### PR DESCRIPTION
Enables the [`useBlockStatements`](https://biomejs.dev/linter/rules/use-block-statements/) lint rule at error level in biome.json and applies the autofix across the codebase.

All `if`, `else`, `for`, and `while` statements now require curly braces, preventing ambiguous or error-prone braceless control flow.