### PR TITLE
Stop assigning inside expressions

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -29,7 +29,6 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noAssignInExpressions": "off",
         "noExplicitAny": "off",
         "noDuplicateTestHooks": "off",
         "noConsole": { "level": "off", "options": { "allow": ["log"] } },

--- a/providers/stores/azblobHarvestStore.js
+++ b/providers/stores/azblobHarvestStore.js
@@ -141,7 +141,8 @@ class AzHarvestBlobStore extends AbstractAzBlobStore {
         if (!tool || !toolVersion) {
           return result
         }
-        const current = (result[tool] = result[tool] || {})
+        result[tool] = result[tool] || {}
+        const current = result[tool]
         current[toolVersion] = entry.content
         return result
       }, result)

--- a/providers/stores/fileHarvestStore.js
+++ b/providers/stores/fileHarvestStore.js
@@ -113,7 +113,8 @@ class FileHarvestStore extends AbstractFileStore {
     )
     return contents.reduce((result, entry) => {
       const { tool, toolVersion } = this._toResultCoordinatesFromStoragePath(entry.name)
-      const current = (result[tool] = result[tool] || {})
+      result[tool] = result[tool] || {}
+      const current = result[tool]
       current[toolVersion] = entry.content
       return result
     }, {})


### PR DESCRIPTION
Biome's `noAssignInExpressions` rule was turned off. There were only two violations: compound assignments used as initializers like `const x = (obj.prop = val)`. Each got split into two lines. Behavior is the same. The override in biome.json is removed so the rule falls back to its default (error, via `recommended: true`).