### PR TITLE
Replace any with proper types in .d.ts files, fix export type error

### DIFF
--- a/lib/fetch.d.ts
+++ b/lib/fetch.d.ts
@@ -21,7 +21,7 @@ export interface FetchRequestOptions {
   /** HTTP headers to include in the request. */
   headers?: Record<string, string>
   /** Request body data. */
-  body?: any
+  body?: unknown
   /** Whether to include credentials in cross-origin requests. */
   withCredentials?: boolean
   /** Whether to throw an error for HTTP error status codes. Defaults to `true`. */
@@ -36,8 +36,6 @@ export interface FetchResponse<T = any> extends AxiosResponse<T> {
   statusCode: number
   /** HTTP status message (alias for `statusText`). */
   statusMessage: string
-  /** Response configuration used for the request. */
-  config: any
 }
 
 /** HTTP error with status code information. */

--- a/lib/rateLimit.d.ts
+++ b/lib/rateLimit.d.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import type { NextFunction, Request, Response } from 'express'
-import type { Store } from 'express-rate-limit'
+import type { Options as ExpressRateLimitOptions, Store } from 'express-rate-limit'
+import type { RedisClientType } from 'redis'
 import type { ICache } from '../providers/caching'
 import type { Logger } from '../providers/logging'
 
@@ -33,7 +34,7 @@ export interface ExtendedRateLimitConfig extends LegacyRateLimitConfig {
 /** Redis-specific configuration for rate limiting */
 export interface RedisRateLimitConfig {
   /** Redis client instance */
-  client: any
+  client: RedisClientType
   /** Prefix for Redis keys used by the rate limiter */
   prefix: string
 }
@@ -67,7 +68,7 @@ export type RateLimitMiddleware = (req: Request, res: Response, next: NextFuncti
 /** Base rate limiter class that provides rate limiting functionality using express-rate-limit */
 declare class RateLimiter {
   /** Configuration options for the rate limiter */
-  protected options: any
+  protected options: RateLimiterOptions
 
   /** Logger instance for rate limiter operations */
   protected logger: Logger
@@ -80,7 +81,7 @@ declare class RateLimiter {
    *
    * @param opts - Configuration options for the rate limiter
    */
-  constructor(opts: any)
+  constructor(opts: RateLimiterOptions)
 
   /**
    * Initializes the rate limiter with optional store
@@ -104,20 +105,20 @@ declare class RateLimiter {
    * @param store - Optional store for rate limit data persistence
    * @returns Options object for express-rate-limit
    */
-  static buildOptions(config: any, store?: Store): any
+  static buildOptions(config: RateLimitConfig, store?: Store): Partial<ExpressRateLimitOptions>
 }
 
 /** Redis-based rate limiter that extends RateLimiter with Redis persistence */
 declare class RedisBasedRateLimiter extends RateLimiter {
   /** Redis client instance */
-  private _client: any
+  private _client: RedisClientType | undefined
 
   /**
    * Creates a new RedisBasedRateLimiter instance
    *
    * @param opts - Configuration options including Redis client
    */
-  constructor(opts: any)
+  constructor(opts: RateLimiterOptions)
 
   /**
    * Initializes the Redis-based rate limiter
@@ -134,13 +135,13 @@ declare class RedisBasedRateLimiter extends RateLimiter {
    * @param config - Redis configuration with prefix
    * @returns Redis store instance for express-rate-limit
    */
-  static buildRedisStore(client: any, config: any): Store
+  static buildRedisStore(client: RedisClientType, config: RedisRateLimitConfig): Store
 }
 
 /** Abstract base class for middleware delegates that create rate limiting middleware asynchronously */
 declare abstract class AbstractMiddlewareDelegate {
   /** Configuration options for the middleware delegate */
-  protected options: any
+  protected options: RateLimiterFactoryOptions
 
   /** Logger instance for middleware operations */
   protected logger: Logger
@@ -153,7 +154,7 @@ declare abstract class AbstractMiddlewareDelegate {
    *
    * @param opts - Configuration options for the middleware delegate
    */
-  constructor(opts: any)
+  constructor(opts: RateLimiterFactoryOptions)
 
   /**
    * Gets the rate limiting middleware function
@@ -203,7 +204,7 @@ declare class BatchApiMiddlewareDelegate extends AbstractMiddlewareDelegate {
  * @param opts - Configuration options for the rate limiter
  * @returns RateLimiter or RedisBasedRateLimiter instance
  */
-declare function createRateLimiter(opts: any): RateLimiter | RedisBasedRateLimiter
+declare function createRateLimiter(opts: RateLimiterOptions): RateLimiter | RedisBasedRateLimiter
 
 /**
  * Builds rate limiter options from configuration
@@ -214,7 +215,12 @@ declare function createRateLimiter(opts: any): RateLimiter | RedisBasedRateLimit
  * @param logger - Logger instance
  * @returns Rate limiter options
  */
-declare function buildOpts(config: LegacyRateLimitConfig, cachingService: ICache, prefix: string, logger?: Logger): any
+declare function buildOpts(
+  config: LegacyRateLimitConfig,
+  cachingService: ICache,
+  prefix: string,
+  logger?: Logger
+): RateLimiterOptions
 
 /**
  * Creates an API rate limiter instance
@@ -241,8 +247,8 @@ declare function createBatchApiLimiter(options?: RateLimiterFactoryOptions): Rat
  * @returns Express middleware function for API rate limiting
  */
 declare function setupApiRateLimiterAfterCachingInit(
-  config: any,
-  cachingService: any,
+  config: RateLimiterFactoryOptions['config'],
+  cachingService: ICache,
   logger?: Logger
 ): RateLimitMiddleware
 
@@ -255,8 +261,8 @@ declare function setupApiRateLimiterAfterCachingInit(
  * @returns Express middleware function for batch API rate limiting
  */
 declare function setupBatchApiRateLimiterAfterCachingInit(
-  config: any,
-  cachingService: any,
+  config: RateLimiterFactoryOptions['config'],
+  cachingService: ICache,
   logger?: Logger
 ): RateLimitMiddleware
 

--- a/providers/search/abstractSearch.d.ts
+++ b/providers/search/abstractSearch.d.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
+import type { Definition } from '../../business/definitionService'
+import type { EntityCoordinates } from '../../lib/entityCoordinates'
+
 export interface SearchOptions {
   [key: string]: any
 }
@@ -14,25 +17,25 @@ export declare class AbstractSearch {
   initialize(): Promise<void>
 
   /** Look up a result by coordinates. */
-  get(coordinates: any): Promise<any>
+  get(coordinates: EntityCoordinates): Promise<Definition | null>
 
   /** Suggest coordinates matching a pattern. */
   suggestCoordinates(pattern: string): Promise<string[]>
 
   /** Add one or more definitions to the search index. */
-  store(definition: any): void
+  store(definition: Definition): void
 
   /** Query the search index. */
-  query(body: any): any
+  query(body: Record<string, unknown>): unknown
 
   /** Remove a definition from the search index by coordinates. */
-  delete(coordinates: any): void
+  delete(coordinates: EntityCoordinates): void
 
   /** Extract unique license expressions from a definition's facets. */
-  protected _getLicenses(definition: any): string[]
+  protected _getLicenses(definition: Definition): string[]
 
   /** Extract unique attribution parties from a definition's facets. */
-  protected _getAttributions(definition: any): string[]
+  protected _getAttributions(definition: Definition): string[]
 }
 
 export default AbstractSearch

--- a/types/winston-azure-application-insights.d.ts
+++ b/types/winston-azure-application-insights.d.ts
@@ -6,8 +6,8 @@
  */
 
 declare module 'winston-azure-application-insights' {
-  import type * as winston from 'winston'
   import type * as appInsights from 'applicationinsights'
+  import type * as winston from 'winston'
 
   /** Winston log levels mapped to Application Insights severity levels. */
   type WinstonLevel =
@@ -117,5 +117,5 @@ declare module 'winston-azure-application-insights' {
 
   // Export the transport constructor for use with winston.add()
   export const AzureApplicationInsightsLogger: AzureApplicationInsightsLoggerConstructor
-  export { getMessageLevel, defaultFormatter }
+  export type { defaultFormatter, getMessageLevel }
 }


### PR DESCRIPTION
Replaces `any` with proper types in four `.d.ts` files and fixes the one tsc error.

`lib/rateLimit.d.ts` had the most. 17 `any` types across constructor params, class fields, factory functions, and the setup functions. These now use `RateLimiterOptions`, `RateLimiterFactoryOptions`, `RedisClientType`, `Partial<ExpressRateLimitOptions>`, and so on.

`providers/search/abstractSearch.d.ts` method params now use `EntityCoordinates` and `Definition` instead of `any`.

`lib/fetch.d.ts`: `body` param is `unknown`, and a redundant `config: any` field (already inherited from `AxiosResponse`) is removed.

`types/winston-azure-application-insights.d.ts`: `export` -> `export type` for type-only exports. This was the only tsc error.

No runtime changes. tsc passes clean.