### PR TITLE
Eliminate _upgradeLock by unifying serialization under computeLock

### DIFF
--- a/business/definitionService.d.ts
+++ b/business/definitionService.d.ts
@@ -431,6 +431,19 @@ export declare class DefinitionService {
   ): Promise<Definition | undefined>
 
   /**
+   * Acquire computeLock, evaluate shouldCompute(), and conditionally compute+store+curate.
+   * Serializes compute per coordinate — check-then-act is atomic inside the lock.
+   *
+   * @param coordinates - The coordinates to compute
+   * @param shouldCompute - Returns true to proceed with compute, false to skip
+   * @returns The computed definition or undefined if skipped
+   */
+  computeStoreAndCurateIf(
+    coordinates: EntityCoordinates,
+    shouldCompute: () => Promise<boolean>
+  ): Promise<Definition | undefined>
+
+  /**
    * Compute the final representation of the specified definition
    *
    * @param coordinates - The entity for which we are computing

--- a/business/definitionService.js
+++ b/business/definitionService.js
@@ -65,6 +65,8 @@ const computeLock = require('../providers/caching/memory')({
 
 const currentSchema = '1.7.0'
 
+const COMPUTE_LOCK_WARN_MS = 60_000
+
 const weights = {
   declared: 30,
   discovered: 25,
@@ -375,19 +377,58 @@ class DefinitionService {
    * @returns {Promise<Definition>} The computed definition
    */
   async computeStoreAndCurate(coordinates) {
-    // one coordinate a time through this method so no duplicate auto curation will be created.
+    return this._withComputeLock(coordinates, async () => {
+      const definition = await this._computeAndStore(coordinates)
+      await this.curationService.autoCurate(definition)
+      return definition
+    })
+  }
+
+  /**
+   * Acquire computeLock, evaluate shouldCompute(), and conditionally compute+store+curate.
+   * @param {EntityCoordinates} coordinates
+   * @param {() => Promise<boolean>} shouldCompute - Returns true to proceed, false to skip.
+   *   Should be lightweight and read-only (e.g. getStored + validate); it runs inside the lock.
+   * @returns {Promise<Definition | undefined>}
+   */
+  async computeStoreAndCurateIf(coordinates, shouldCompute) {
+    return this._withComputeLock(coordinates, async () => {
+      if (!(await shouldCompute())) {
+        return undefined
+      }
+      const definition = await this._computeAndStore(coordinates)
+      await this.curationService.autoCurate(definition)
+      return definition
+    })
+  }
+
+  /**
+   * Acquire computeLock and run the action while holding the lock.
+   * @param {EntityCoordinates} coordinates
+   * @param {() => Promise<T>} action - Work to perform while holding the lock.
+   * @returns {Promise<T>}
+   * @template T
+   * @private
+   */
+  async _withComputeLock(coordinates, action) {
     this.logger.debug('3:memory_lock:start', {
       ts: new Date().toISOString(),
       coordinates: coordinates.toString()
     })
+    const lockWaitStart = Date.now()
+    let lockWarnLogged = false
     while (computeLock.get(coordinates.toString())) {
       await new Promise(resolve => setTimeout(resolve, 500))
+      if (!lockWarnLogged && Date.now() - lockWaitStart > COMPUTE_LOCK_WARN_MS) {
+        this.logger.warn(`computeLock spin-wait exceeded ${COMPUTE_LOCK_WARN_MS / 1000}s`, {
+          coordinates: coordinates.toString()
+        })
+        lockWarnLogged = true
+      }
     }
     try {
       computeLock.set(coordinates.toString(), true)
-      const definition = await this._computeAndStore(coordinates)
-      await this.curationService.autoCurate(definition)
-      return definition
+      return await action()
     } finally {
       computeLock.delete(coordinates.toString())
     }
@@ -399,15 +440,7 @@ class DefinitionService {
    * @returns {Promise<Definition>} The computed definition
    */
   async computeAndStore(coordinates) {
-    while (computeLock.get(coordinates.toString())) {
-      await new Promise(resolve => setTimeout(resolve, 500)) // one coordinate a time through this method so we always get latest
-    }
-    try {
-      computeLock.set(coordinates.toString(), true)
-      return await this._computeAndStore(coordinates)
-    } finally {
-      computeLock.delete(coordinates.toString())
-    }
+    return this._withComputeLock(coordinates, () => this._computeAndStore(coordinates))
   }
 
   /**
@@ -418,12 +451,9 @@ class DefinitionService {
    * @returns {Promise<Definition | undefined>} The computed definition or undefined if skipped
    */
   async computeAndStoreIfNecessary(coordinates, tool, toolRevision) {
-    while (computeLock.get(coordinates.toString())) {
-      await new Promise(resolve => setTimeout(resolve, 500)) // one coordinate a time through this method so we always get latest
-    }
-    try {
-      computeLock.set(coordinates.toString(), true)
-      if (!(await this._isToolResultNew(coordinates, tool, toolRevision))) {
+    return this._withComputeLock(coordinates, async () => {
+      const isNew = await this._isToolResultNew(coordinates, tool, toolRevision)
+      if (!isNew) {
         this.logger.info('definition computation skipped: tool result processed', {
           coordinates: coordinates.toString(),
           tool,
@@ -432,9 +462,7 @@ class DefinitionService {
         return undefined
       }
       return await this._computeAndStore(coordinates)
-    } finally {
-      computeLock.delete(coordinates.toString())
-    }
+    })
   }
 
   /**

--- a/providers/upgrade/computePolicy.d.ts
+++ b/providers/upgrade/computePolicy.d.ts
@@ -4,15 +4,9 @@
 import type { Definition, DefinitionService, RecomputeContext } from '../../business/definitionService'
 import type { EntityCoordinates } from '../../lib/entityCoordinates'
 import type { Logger } from '../logging'
-import type { ICache } from '../caching'
 
 export interface MissingDefinitionComputePolicy {
   initialize?(): Promise<void> | void
-  setupProcessing?(
-    definitionService?: DefinitionService,
-    logger?: Logger,
-    once?: boolean,
-    cache?: ICache
-  ): Promise<void> | void
+  setupProcessing?(definitionService?: DefinitionService, logger?: Logger, once?: boolean): Promise<void> | void
   compute(definitionService: RecomputeContext, coordinates: EntityCoordinates): Promise<Definition>
 }

--- a/providers/upgrade/defUpgradeQueue.d.ts
+++ b/providers/upgrade/defUpgradeQueue.d.ts
@@ -3,7 +3,6 @@
 
 import type { IQueue } from '../queueing'
 import type { Logger } from '../logging'
-import type { ICache } from '../caching'
 import type { Definition } from '../../business/definitionService'
 import type { DefinitionService } from '../../business/definitionService'
 import { DefinitionVersionChecker, type DefinitionVersionCheckerOptions } from './defVersionCheck'
@@ -44,9 +43,8 @@ declare class DefinitionQueueUpgrader extends DefinitionVersionChecker {
    * @param definitionService - The service used to recompute definitions
    * @param logger - Logger instance
    * @param once - If true, process one batch and stop (for testing)
-   * @param cache - Optional lock cache
    */
-  setupProcessing(definitionService: DefinitionService, logger: Logger, once?: boolean, cache?: ICache): Promise<void>
+  setupProcessing(definitionService: DefinitionService, logger: Logger, once?: boolean): Promise<void>
 }
 
 export default DefinitionQueueUpgrader

--- a/providers/upgrade/defUpgradeQueue.js
+++ b/providers/upgrade/defUpgradeQueue.js
@@ -8,7 +8,6 @@ const { setup } = require('./process')
  * @typedef {import('../../business/definitionService').Definition} Definition
  * @typedef {import('../../business/definitionService').DefinitionService} DefinitionService
  * @typedef {import('../logging').Logger} Logger
- * @typedef {import('../caching').ICache} ICache
  */
 
 class DefinitionQueueUpgrader extends DefinitionVersionChecker {
@@ -73,12 +72,11 @@ class DefinitionQueueUpgrader extends DefinitionVersionChecker {
    * @param {DefinitionService} definitionService
    * @param {Logger} logger
    * @param {boolean} [once]
-   * @param {ICache} [cache]
    */
-  setupProcessing(definitionService, logger, once, cache) {
+  setupProcessing(definitionService, logger, once) {
     // Use a plain DefinitionVersionChecker (not `this`) so the queue processor returns undefined
     // for stale definitions and triggers recompute — rather than re-queuing them again.
-    return setup(this._upgrade, definitionService, logger, once, new DefinitionVersionChecker(this.options), cache)
+    return setup(this._upgrade, definitionService, logger, once, new DefinitionVersionChecker(this.options))
   }
 }
 

--- a/providers/upgrade/defVersionCheck.d.ts
+++ b/providers/upgrade/defVersionCheck.d.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import type { Logger } from '../logging'
-import type { ICache } from '../caching'
 import type { Definition, DefinitionService, UpgradeHandler } from '../../business/definitionService'
 
 /** Configuration options for DefinitionVersionChecker */
@@ -37,7 +36,7 @@ export declare class DefinitionVersionChecker implements UpgradeHandler {
   initialize(): Promise<void>
 
   /** No-op setup (exists for interface compatibility with subclass overrides) */
-  setupProcessing(definitionService?: DefinitionService, logger?: Logger, once?: boolean, cache?: ICache): void
+  setupProcessing(definitionService?: DefinitionService, logger?: Logger, once?: boolean): void
 
   /**
    * Extracts a string representation of coordinates from a definition.

--- a/providers/upgrade/delayedComputePolicy.d.ts
+++ b/providers/upgrade/delayedComputePolicy.d.ts
@@ -21,7 +21,7 @@ export declare class DelayedComputePolicy implements MissingDefinitionComputePol
 
   initialize(): Promise<void>
 
-  setupProcessing(definitionService: DefinitionService, logger: Logger, once?: boolean, cache?: ICache): Promise<void>
+  setupProcessing(definitionService: DefinitionService, logger: Logger, once?: boolean): Promise<void>
 
   compute(definitionService: RecomputeContext, coordinates: EntityCoordinates): Promise<Definition>
 }

--- a/providers/upgrade/delayedComputePolicy.js
+++ b/providers/upgrade/delayedComputePolicy.js
@@ -12,7 +12,6 @@ const Cache = require('../caching/memory')
 /** @typedef {import('../../business/definitionService').Definition} Definition */
 /** @typedef {import('../../lib/entityCoordinates')} EntityCoordinates */
 /** @typedef {import('../logging').Logger} Logger */
-/** @typedef {import('../caching').ICache} ICache */
 
 class DelayedComputePolicy {
   static _enqueueCacheTtlSeconds = 60 * 20 /* 20 mins */
@@ -35,11 +34,10 @@ class DelayedComputePolicy {
    * @param {DefinitionService} definitionService
    * @param {Logger} logger
    * @param {boolean} [once]
-   * @param {ICache} [cache]
    */
-  setupProcessing(definitionService, logger, once, cache) {
+  setupProcessing(definitionService, logger, once) {
     const upgradePolicy = new SkipUpgradePolicy()
-    return setup(this._compute, definitionService, logger, once, upgradePolicy, cache)
+    return setup(this._compute, definitionService, logger, once, upgradePolicy)
   }
 
   /**

--- a/providers/upgrade/process.d.ts
+++ b/providers/upgrade/process.d.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import type { DefinitionService, UpgradeHandler } from '../../business/definitionService'
-import type { ICache } from '../caching'
 import type { Logger } from '../logging'
 import type { DequeuedMessage, IQueue } from '../queueing'
 
@@ -36,21 +35,17 @@ export declare class QueueHandler {
 
 /**
  * Processes upgrade messages by recomputing stale definitions.
- * Uses an in-memory lock to prevent concurrent upgrades for the same coordinates.
+ * Serialization is handled by computeLock in definitionService via computeStoreAndCurateIf.
  */
 export declare class DefinitionUpgrader implements MessageHandler {
-  /** Delay in milliseconds between lock-retry attempts */
-  static readonly delayInMSeconds: number
-
   logger: Logger
 
   /**
    * @param definitionService - Service for fetching and recomputing definitions
    * @param logger - Logger instance
    * @param upgradePolicy - Policy that validates whether stored definitions need upgrade
-   * @param cache - Lock cache; defaults to a new in-memory cache with 5 min TTL
    */
-  constructor(definitionService: DefinitionService, logger: Logger, upgradePolicy: UpgradeHandler, cache?: ICache)
+  constructor(definitionService: DefinitionService, logger: Logger, upgradePolicy: UpgradeHandler)
 
   /**
    * Processes a single dequeued upgrade message.
@@ -68,13 +63,11 @@ export declare class DefinitionUpgrader implements MessageHandler {
  * @param logger - Logger instance
  * @param once - If true, processes one batch and stops
  * @param upgradePolicy - Upgrade policy (defaults to a new DefinitionVersionChecker)
- * @param cache - Optional lock cache; passed through to DefinitionUpgrader
  */
 export declare function setup(
   queue: IQueue,
   definitionService: DefinitionService,
   logger: Logger,
   once?: boolean,
-  upgradePolicy?: UpgradeHandler,
-  cache?: ICache
+  upgradePolicy?: UpgradeHandler
 ): Promise<void>

--- a/providers/upgrade/process.js
+++ b/providers/upgrade/process.js
@@ -4,7 +4,6 @@
 const { get } = require('lodash')
 const EntityCoordinates = require('../../lib/entityCoordinates')
 const { factory } = require('./defVersionCheck')
-const Cache = require('../caching/memory')
 
 /**
  * @typedef {import('../queueing').IQueue} IQueue
@@ -12,7 +11,6 @@ const Cache = require('../caching/memory')
  * @typedef {import('../../business/definitionService').DefinitionService} DefinitionService
  * @typedef {import('../../business/definitionService').UpgradeHandler} UpgradeHandler
  * @typedef {import('../logging').Logger} Logger
- * @typedef {import('../caching').ICache} ICache
  */
 
 class QueueHandler {
@@ -60,26 +58,16 @@ class QueueHandler {
 }
 
 class DefinitionUpgrader {
-  static _defaultTtlSeconds = 60 * 20 /* 20 mins */
-  static delayInMSeconds = 500
-
   /**
    * @param {DefinitionService} definitionService
    * @param {Logger} logger
    * @param {UpgradeHandler} upgradePolicy
-   * @param {ICache} [cache]
    */
-  constructor(
-    definitionService,
-    logger,
-    upgradePolicy,
-    cache = Cache({ defaultTtlSeconds: DefinitionUpgrader._defaultTtlSeconds })
-  ) {
+  constructor(definitionService, logger, upgradePolicy) {
     this.logger = logger
     this._definitionService = definitionService
     this._upgradePolicy = upgradePolicy
     this._upgradePolicy.currentSchema = definitionService.currentSchema
-    this._upgradeLock = cache
   }
 
   /** @param {DequeuedMessage} message */
@@ -90,24 +78,14 @@ class DefinitionUpgrader {
     }
     coordinates = EntityCoordinates.fromObject(coordinates)
 
-    while (this._upgradeLock.get(coordinates.toString())) {
-      await new Promise(resolve => setTimeout(resolve, DefinitionUpgrader.delayInMSeconds))
-    }
     try {
-      this._upgradeLock.set(coordinates.toString(), true)
-      await this._upgradeIfNecessary(coordinates)
-    } finally {
-      this._upgradeLock.delete(coordinates.toString())
-    }
-  }
-
-  /** @param {import('../../lib/entityCoordinates')} coordinates */
-  async _upgradeIfNecessary(coordinates) {
-    try {
-      const existing = await this._definitionService.getStored(coordinates)
-      const result = await this._upgradePolicy.validate(existing)
-      if (!result) {
-        await this._definitionService.computeStoreAndCurate(coordinates)
+      const result = await this._definitionService.computeStoreAndCurateIf(coordinates, async () => {
+        const existing = await this._definitionService.getStored(coordinates)
+        const valid = await this._upgradePolicy.validate(existing)
+        // validate returns truthy when definition is valid (skip compute)
+        return !valid
+      })
+      if (result) {
         this.logger.info('Handled definition upgrade', { coordinates })
       } else {
         this.logger.debug('Skipped definition upgrade', { coordinates })
@@ -128,17 +106,9 @@ class DefinitionUpgrader {
  * @param {Logger} _logger
  * @param {boolean} [once]
  * @param {UpgradeHandler} [_upgradePolicy]
- * @param {ICache} [cache]
  */
-function setup(
-  _queue,
-  _definitionService,
-  _logger,
-  once = false,
-  _upgradePolicy = factory({ logger: _logger }),
-  cache
-) {
-  const defUpgrader = new DefinitionUpgrader(_definitionService, _logger, _upgradePolicy, cache)
+function setup(_queue, _definitionService, _logger, once = false, _upgradePolicy = factory({ logger: _logger })) {
+  const defUpgrader = new DefinitionUpgrader(_definitionService, _logger, _upgradePolicy)
   const queueHandler = new QueueHandler(_queue, _logger, defUpgrader)
   return queueHandler.work(once)
 }

--- a/providers/upgrade/recomputeHandler.d.ts
+++ b/providers/upgrade/recomputeHandler.d.ts
@@ -3,7 +3,6 @@
 
 import type { Logger } from '../logging'
 import type { IQueue } from '../queueing'
-import type { ICache } from '../caching'
 import type {
   Definition,
   DefinitionService,
@@ -18,12 +17,7 @@ import type { DefinitionVersionCheckerOptions } from './defVersionCheck'
 /** Upgrade policy accepted by RecomputeHandler: an UpgradeHandler with optional lifecycle hooks */
 export interface UpgradePolicy extends UpgradeHandler {
   initialize?(): Promise<void> | void
-  setupProcessing?(
-    definitionService?: DefinitionService,
-    logger?: Logger,
-    once?: boolean,
-    cache?: ICache
-  ): Promise<void> | void
+  setupProcessing?(definitionService?: DefinitionService, logger?: Logger, once?: boolean): Promise<void> | void
 }
 
 export interface DelayedFactoryOptions {

--- a/providers/upgrade/recomputeHandler.js
+++ b/providers/upgrade/recomputeHandler.js
@@ -6,7 +6,6 @@ const DefinitionQueueUpgrader = require('./defUpgradeQueue')
 const { OnDemandComputePolicy } = require('./onDemandComputePolicy')
 const { DelayedComputePolicy } = require('./delayedComputePolicy')
 const memoryQueueConfig = require('./memoryQueueConfig')
-const Cache = require('../caching/memory')
 const logger = require('../logging/logger')
 
 /** @typedef {import('../../business/definitionService').DefinitionService} DefinitionService */
@@ -21,16 +20,11 @@ const logger = require('../logging/logger')
 /** @typedef {import('./recomputeHandler').DelayedFactoryOptions} DelayedFactoryOptions */
 
 class RecomputeHandler {
-  static _sharedCacheTtlSeconds = 60 * 5 /* 5 mins */
-
   /** @param {RecomputeHandlerOptions} options */
   constructor(options) {
     this._upgradePolicy = options.upgradePolicy
     this._computePolicy = options.computePolicy
     this._logger = options.logger || logger()
-    this._sharedCache = Cache({
-      defaultTtlSeconds: RecomputeHandler._sharedCacheTtlSeconds
-    })
   }
 
   /** @param {string} schemaVersion */
@@ -76,8 +70,8 @@ class RecomputeHandler {
       computePolicy: getPolicyName(this._computePolicy)
     })
     await Promise.all([
-      this._upgradePolicy.setupProcessing?.(definitionService, logger, once, this._sharedCache),
-      this._computePolicy.setupProcessing?.(definitionService, logger, once, this._sharedCache)
+      this._upgradePolicy.setupProcessing?.(definitionService, logger, once),
+      this._computePolicy.setupProcessing?.(definitionService, logger, once)
     ])
     this._logger.debug('Recompute handler processing setup complete', {
       once: !!once,

--- a/test/business/definitionServiceTest.ts
+++ b/test/business/definitionServiceTest.ts
@@ -325,6 +325,70 @@ describe('Definition Service', () => {
       expect(service.compute.getCall(0).args[0]).to.deep.eq(coordinates)
     })
   })
+
+  describe('computeStoreAndCurateIf', () => {
+    let service
+    let coordinates
+    let autoCurate
+
+    beforeEach(() => {
+      autoCurate = sinon.stub().resolves()
+      ;({ service, coordinates } = setup(createDefinition(null, null, ['scancode/3.2.2'])))
+      service.curationService = {
+        apply: (_coordinates, _curationSpec, definition) => Promise.resolve(definition),
+        autoCurate
+      }
+      sinon.spy(service, 'compute')
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('computes and auto-curates when predicate returns true', async () => {
+      const result = await service.computeStoreAndCurateIf(coordinates, async () => true)
+      expect(service.compute.calledOnce).to.be.true
+      expect(autoCurate.calledOnce).to.be.true
+      expect(result).to.exist
+    })
+
+    it('skips compute and auto-curation when predicate returns false', async () => {
+      const result = await service.computeStoreAndCurateIf(coordinates, async () => false)
+      expect(service.compute.notCalled).to.be.true
+      expect(autoCurate.notCalled).to.be.true
+      expect(result).to.be.undefined
+    })
+
+    it('releases lock after predicate throws', async () => {
+      await expect(
+        service.computeStoreAndCurateIf(coordinates, async () => {
+          throw new Error('predicate error')
+        })
+      ).to.be.rejectedWith('predicate error')
+
+      const result = await service.computeStoreAndCurateIf(coordinates, async () => true)
+      expect(service.compute.calledOnce).to.be.true
+      expect(result).to.exist
+    })
+
+    it('serializes concurrent calls for the same coordinates', async () => {
+      const predicate = sinon.stub().onFirstCall().resolves(true).onSecondCall().resolves(false)
+
+      const [first, second] = await Promise.all([
+        service.computeStoreAndCurateIf(coordinates, predicate),
+        service.computeStoreAndCurateIf(coordinates, predicate)
+      ])
+
+      expect(predicate.calledTwice).to.be.true
+      expect(service.compute.calledOnce).to.be.true
+      expect(autoCurate.calledOnce).to.be.true
+      expect(first).to.exist
+      expect(second).to.be.undefined
+
+      // verify calls are serialized: first predicate completes before second starts
+      expect(predicate.getCall(1).calledAfter(service.compute.getCall(0))).to.be.true
+    })
+  })
 })
 
 describe('Definition Service Facet management', () => {

--- a/test/providers/upgrade/delayedComputePolicyTest.ts
+++ b/test/providers/upgrade/delayedComputePolicyTest.ts
@@ -99,26 +99,23 @@ describe('DelayedComputePolicy', () => {
     })
 
     it('skips recompute when definition already exists', async () => {
-      const getStored = sinon.stub().resolves({ coordinates, _meta: { schemaVersion: '0.0.1' } })
-      const computeStoreAndCurate = sinon.stub().resolves()
-      const service = { currentSchema: '1.7.0', getStored, computeStoreAndCurate } as unknown as DefinitionService
+      const computeStoreAndCurateIf = sinon.stub().resolves(undefined)
+      const service = { currentSchema: '1.7.0', computeStoreAndCurateIf } as unknown as DefinitionService
 
       await policy.setupProcessing(service, createMockLogger(), true)
 
-      expect(getStored.calledOnce).to.be.true
-      expect(computeStoreAndCurate.notCalled).to.be.true
+      expect(computeStoreAndCurateIf.calledOnce).to.be.true
       expect(queue.delete.calledOnce).to.be.true
     })
 
     it('recomputes when definition is missing', async () => {
-      const getStored = sinon.stub().resolves(undefined)
-      const computeStoreAndCurate = sinon.stub().resolves()
-      const service = { currentSchema: '1.7.0', getStored, computeStoreAndCurate } as unknown as DefinitionService
+      const definition = { coordinates, _meta: { schemaVersion: '1.7.0' } }
+      const computeStoreAndCurateIf = sinon.stub().resolves(definition)
+      const service = { currentSchema: '1.7.0', computeStoreAndCurateIf } as unknown as DefinitionService
 
       await policy.setupProcessing(service, createMockLogger(), true)
 
-      expect(getStored.calledOnce).to.be.true
-      expect(computeStoreAndCurate.calledOnce).to.be.true
+      expect(computeStoreAndCurateIf.calledOnce).to.be.true
       expect(queue.delete.calledOnce).to.be.true
     })
   })

--- a/test/providers/upgrade/processTest.ts
+++ b/test/providers/upgrade/processTest.ts
@@ -99,7 +99,7 @@ describe('Definition Upgrade Queue Processing', () => {
     beforeEach(() => {
       definitionService = {
         getStored: sinon.stub(),
-        computeStoreAndCurate: sinon.stub().resolves()
+        computeStoreAndCurateIf: sinon.stub()
       }
       versionChecker = {
         validate: sinon.stub()
@@ -107,47 +107,67 @@ describe('Definition Upgrade Queue Processing', () => {
       upgrader = new DefinitionUpgrader(definitionService, logger, versionChecker)
     })
 
-    it('recomputes a definition, if a definition is not up-to-date', async () => {
-      definitionService.getStored.resolves(definition)
-      versionChecker.validate.resolves()
+    it('delegates to computeStoreAndCurateIf and logs when definition was recomputed', async () => {
+      definitionService.computeStoreAndCurateIf.resolves(definition)
 
       await upgrader.processMessage(message)
-      expect(definitionService.getStored.calledOnce).to.be.true
-      expect(versionChecker.validate.calledOnce).to.be.true
-      expect(definitionService.computeStoreAndCurate.calledOnce).to.be.true
+      expect(definitionService.computeStoreAndCurateIf.calledOnce).to.be.true
+      expect(definitionService.computeStoreAndCurateIf.getCall(0).args[0]).to.deep.eq(
+        EntityCoordinates.fromObject(definition.coordinates)
+      )
+      expect(logger.info.calledOnce).to.be.true
     })
 
-    it('skips compute if a definition is up-to-date', async () => {
-      definitionService.getStored.resolves(definition)
-      versionChecker.validate.resolves(definition)
+    it('delegates to computeStoreAndCurateIf and logs debug when compute was skipped', async () => {
+      definitionService.computeStoreAndCurateIf.resolves(undefined)
 
       await upgrader.processMessage(message)
-      expect(definitionService.getStored.calledOnce).to.be.true
-      expect(versionChecker.validate.calledOnce).to.be.true
-      expect(definitionService.computeStoreAndCurate.notCalled).to.be.true
-    })
-
-    it('computes if a definition does not exist', async () => {
-      definitionService.getStored.resolves()
-      versionChecker.validate.resolves()
-
-      await upgrader.processMessage(message)
-      expect(definitionService.getStored.calledOnce).to.be.true
-      expect(versionChecker.validate.calledOnce).to.be.true
-      expect(definitionService.computeStoreAndCurate.calledOnce).to.be.true
+      expect(definitionService.computeStoreAndCurateIf.calledOnce).to.be.true
+      expect(logger.debug.calledOnce).to.be.true
+      expect(logger.info.notCalled).to.be.true
     })
 
     it('skips if there is no coordinates', async () => {
       await upgrader.processMessage({ data: {} })
-      expect(definitionService.getStored.notCalled).to.be.true
-      expect(versionChecker.validate.notCalled).to.be.true
-      expect(definitionService.computeStoreAndCurate.notCalled).to.be.true
+      expect(definitionService.computeStoreAndCurateIf.notCalled).to.be.true
+    })
+
+    it('predicate skips compute when policy validates the definition', async () => {
+      definitionService.getStored.resolves(definition)
+      versionChecker.validate.resolves(definition) // truthy = valid → predicate returns false → skip
+      let predicateResult: boolean | undefined
+      definitionService.computeStoreAndCurateIf.callsFake(async (_coords, shouldCompute) => {
+        predicateResult = await shouldCompute()
+        return predicateResult ? definition : undefined
+      })
+
+      await upgrader.processMessage(message)
+      expect(predicateResult).to.be.false
+      expect(definitionService.getStored.calledOnceWith(EntityCoordinates.fromObject(definition.coordinates))).to.be
+        .true
+      expect(versionChecker.validate.calledOnceWith(definition)).to.be.true
+      expect(logger.debug.calledOnce).to.be.true
+    })
+
+    it('predicate proceeds with compute when policy returns falsy', async () => {
+      definitionService.getStored.resolves(definition)
+      versionChecker.validate.resolves(undefined) // falsy = stale → predicate returns true → compute
+      let predicateResult: boolean | undefined
+      definitionService.computeStoreAndCurateIf.callsFake(async (_coords, shouldCompute) => {
+        predicateResult = await shouldCompute()
+        return predicateResult ? definition : undefined
+      })
+
+      await upgrader.processMessage(message)
+      expect(predicateResult).to.be.true
+      expect(definitionService.getStored.calledOnceWith(EntityCoordinates.fromObject(definition.coordinates))).to.be
+        .true
+      expect(versionChecker.validate.calledOnceWith(definition)).to.be.true
+      expect(logger.info.calledOnce).to.be.true
     })
 
     it('handles exception by rethrowing with coordinates and the original error message', async () => {
-      definitionService.getStored.resolves(definition)
-      versionChecker.validate.resolves()
-      definitionService.computeStoreAndCurate.rejects(new Error('test'))
+      definitionService.computeStoreAndCurateIf.rejects(new Error('test'))
 
       await expect(upgrader.processMessage(message)).to.be.rejectedWith(Error, /pypi\/pypi\/-\/test\/revision: test/)
     })
@@ -163,10 +183,9 @@ describe('Definition Upgrade Queue Processing', () => {
     let queue
     let handler
     let definitionService
-    let versionChecker
     beforeEach(() => {
       let definitionUpgrader
-      ;({ definitionService, versionChecker, definitionUpgrader } = setupDefinitionUpgrader(logger))
+      ;({ definitionService, definitionUpgrader } = setupDefinitionUpgrader(logger))
       queue = {
         dequeueMultiple: sinon.stub().resolves([message]),
         delete: sinon.stub().resolves()
@@ -174,10 +193,8 @@ describe('Definition Upgrade Queue Processing', () => {
       handler = new QueueHandler(queue, logger, definitionUpgrader)
     })
 
-    it('handles exception and logs the coordinates and the original error message', async () => {
-      definitionService.getStored.resolves(definition)
-      versionChecker.validate.resolves()
-      definitionService.computeStoreAndCurate.rejects(new Error('test'))
+    it('handles exception and logs the error', async () => {
+      definitionService.computeStoreAndCurateIf.rejects(new Error('test'))
 
       await handler.work(true)
       expect(queue.dequeueMultiple.calledOnce).to.be.true
@@ -187,23 +204,18 @@ describe('Definition Upgrade Queue Processing', () => {
     })
 
     it('skips compute if a definition is up-to-date', async () => {
-      definitionService.getStored.resolves(definition)
-      versionChecker.validate.resolves(definition)
+      definitionService.computeStoreAndCurateIf.resolves(undefined)
 
       await handler.work(true)
-      expect(definitionService.getStored.calledOnce).to.be.true
-      expect(versionChecker.validate.calledOnce).to.be.true
-      expect(definitionService.computeStoreAndCurate.notCalled).to.be.true
+      expect(definitionService.computeStoreAndCurateIf.calledOnce).to.be.true
       expect(queue.delete.called).to.be.true
     })
 
     it('recomputes a definition, if a definition is not up-to-date', async () => {
-      definitionService.getStored.resolves(definition)
-      versionChecker.validate.resolves()
+      definitionService.computeStoreAndCurateIf.resolves(definition)
+
       await handler.work(true)
-      expect(definitionService.getStored.calledOnce).to.be.true
-      expect(versionChecker.validate.calledOnce).to.be.true
-      expect(definitionService.computeStoreAndCurate.calledOnce).to.be.true
+      expect(definitionService.computeStoreAndCurateIf.calledOnce).to.be.true
       expect(queue.delete.called).to.be.true
     })
   })
@@ -212,7 +224,7 @@ describe('Definition Upgrade Queue Processing', () => {
 function setupDefinitionUpgrader(logger) {
   const definitionService = {
     getStored: sinon.stub(),
-    computeStoreAndCurate: sinon.stub().resolves()
+    computeStoreAndCurateIf: sinon.stub()
   }
   const versionChecker = {
     validate: sinon.stub()

--- a/test/providers/upgrade/recomputeHandlerTest.ts
+++ b/test/providers/upgrade/recomputeHandlerTest.ts
@@ -8,7 +8,8 @@ chai.use(chaiAsPromised)
 
 import { expect } from 'chai'
 import sinon from 'sinon'
-import type { DefinitionService, RecomputeContext } from '../../../business/definitionService.js'
+import type { Definition, DefinitionService, RecomputeContext } from '../../../business/definitionService.js'
+import DefinitionServiceFactory from '../../../business/definitionService.js'
 import EntityCoordinates from '../../../lib/entityCoordinates.js'
 import type { IQueue } from '../../../providers/queueing/index.js'
 import DefinitionQueueUpgrader from '../../../providers/upgrade/defUpgradeQueue.js'
@@ -17,7 +18,7 @@ import { DelayedComputePolicy } from '../../../providers/upgrade/delayedComputeP
 import memoryQueueConfig from '../../../providers/upgrade/memoryQueueConfig.js'
 import { OnDemandComputePolicy } from '../../../providers/upgrade/onDemandComputePolicy.js'
 import { defaultFactory, delayedFactory, RecomputeHandler } from '../../../providers/upgrade/recomputeHandler.js'
-import { createMockLogger, type StubbedLogger } from '../../helpers/mockLogger.ts'
+import { createMockLogger, createSilentLogger, type StubbedLogger } from '../../helpers/mockLogger.ts'
 
 const TEST_COORDINATES = 'npm/npmjs/-/leftpad/1.0.0'
 
@@ -83,19 +84,8 @@ describe('RecomputeHandler', () => {
 
       expect(upgradePolicy.setupProcessing.calledOnce).to.be.true
       expect(computePolicy.setupProcessing.calledOnce).to.be.true
-      expect(upgradePolicy.setupProcessing.firstCall.args.slice(0, 3)).to.deep.equal([definitionService, logger, true])
-      expect(computePolicy.setupProcessing.firstCall.args.slice(0, 3)).to.deep.equal([definitionService, logger, true])
-    })
-
-    it('passes the same shared cache to both policies', async () => {
-      const definitionService = { currentSchema: '1.7.0' } as unknown as DefinitionService
-
-      await handler.setupProcessing(definitionService, logger, false)
-
-      const upgradeCache = upgradePolicy.setupProcessing.firstCall.args[3]
-      const computeCache = computePolicy.setupProcessing.firstCall.args[3]
-      expect(upgradeCache).to.exist
-      expect(upgradeCache).to.equal(computeCache)
+      expect(upgradePolicy.setupProcessing.firstCall.args).to.deep.equal([definitionService, logger, true])
+      expect(computePolicy.setupProcessing.firstCall.args).to.deep.equal([definitionService, logger, true])
     })
   })
 
@@ -209,9 +199,8 @@ describe('delayedFactory', () => {
   })
 })
 
-describe('shared cache', () => {
-  it('deduplicates compute across upgrade and compute queues for same coordinates', async () => {
-    // Arrange: wire both queues through a single handler with shared cache
+describe('upgrade and compute queue wiring', () => {
+  it('both queues delegate to computeStoreAndCurateIf with the correct coordinates', async () => {
     const upgradeQueue = memoryQueueConfig.upgrade()
     const computeQueue = memoryQueueConfig.compute()
     const coordinates = EntityCoordinates.fromString(TEST_COORDINATES)
@@ -221,29 +210,43 @@ describe('shared cache', () => {
       queue: { upgrade: () => upgradeQueue, compute: () => computeQueue }
     })
 
-    // Simulate storage: first compute "stores" the definition so subsequent lookups find it
-    const storedDef = { coordinates, _meta: { schemaVersion: '1.7.0' } }
-    const getStored = sinon.stub().resolves(undefined)
-    const computeStoreAndCurate = sinon.stub().callsFake(async () => {
-      getStored.resolves(storedDef)
-    })
+    const computeStoreAndCurateIf = sinon.stub().resolves(undefined)
     const definitionService = {
       currentSchema: '1.7.0',
-      getStored,
-      computeStoreAndCurate
+      computeStoreAndCurateIf
     } as unknown as DefinitionService
 
-    // Act: enqueue same coordinates into both queues, then process both
     await handler.initialize()
-    await upgradeQueue.queue(
-      Buffer.from(JSON.stringify({ coordinates, _meta: { schemaVersion: '0.0.1' } })).toString('base64')
-    )
-    await computeQueue.queue(Buffer.from(JSON.stringify({ coordinates })).toString('base64'))
+    await upgradeQueue.queue(buildMessage({ coordinates, _meta: { schemaVersion: '0.0.1' } }))
+    await computeQueue.queue(buildMessage({ coordinates }))
     await handler.setupProcessing(definitionService, logger, true)
 
-    // Assert: first processor computes and "stores" (getStored now returns storedDef).
-    // Second processor sees stored def after shared cache lock releases, so it skips recompute.
-    expect(computeStoreAndCurate.calledOnce).to.be.true
+    // Each queue message results in exactly one computeStoreAndCurateIf call with the right coordinates
+    expect(computeStoreAndCurateIf.calledTwice).to.be.true
+    expect(computeStoreAndCurateIf.getCall(0).args[0]).to.deep.equal(coordinates)
+    expect(computeStoreAndCurateIf.getCall(1).args[0]).to.deep.equal(coordinates)
+  })
+
+  it('computes only once when both queues race for the same coordinates', async () => {
+    const upgradeQueue = memoryQueueConfig.upgrade()
+    const computeQueue = memoryQueueConfig.compute()
+    const coordinates = EntityCoordinates.fromString(TEST_COORDINATES)
+    const logger = createMockLogger()
+    const handler = delayedFactory({
+      logger,
+      queue: { upgrade: () => upgradeQueue, compute: () => computeQueue }
+    })
+
+    // Real service so computeStoreAndCurateIf's lock actually serializes the two concurrent calls
+    const service = createRealDefinitionService(coordinates)
+
+    await handler.initialize()
+    await upgradeQueue.queue(buildMessage({ coordinates, _meta: { schemaVersion: '0.0.1' } }))
+    await computeQueue.queue(buildMessage({ coordinates }))
+    await handler.setupProcessing(service, logger, true)
+
+    // The lock serializes the two calls: the first computes, the second re-checks getStored and skips
+    expect(service.compute.calledOnce).to.be.true
   })
 })
 
@@ -271,6 +274,47 @@ const createQueue = (): { [K in keyof IQueue]: sinon.SinonStub } => ({
   dequeueMultiple: sinon.stub().resolves([]),
   delete: sinon.stub().resolves()
 })
+
+const buildMessage = (data: Record<string, unknown>): string => Buffer.from(JSON.stringify(data)).toString('base64')
+
+const createRealDefinitionService = (
+  coordinates: EntityCoordinates
+): DefinitionService & { compute: sinon.SinonStub } => {
+  const harvestService = { done: sinon.stub().resolves() } // called by _store
+  const definitionStore = { store: sinon.stub().resolves() } // called by _store
+  const cache = { set: sinon.stub().resolves(), delete: sinon.stub() } // called by _store
+  const curationService = { autoCurate: sinon.stub().resolves() } // called by computeStoreAndCurateIf
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial implementations for unused dependencies
+  const service = (DefinitionServiceFactory as (...args: any[]) => DefinitionService)(
+    null,
+    harvestService,
+    null,
+    null,
+    curationService,
+    definitionStore,
+    null,
+    cache,
+    null
+  )
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- logger is an internal property
+  ;(service as any).logger = createSilentLogger()
+
+  // getStored starts null; compute "stores" the result so subsequent predicate evaluations skip
+  let stored: Definition | null = null
+  sinon.stub(service, 'getStored').callsFake(async () => stored)
+  sinon.stub(service, 'compute').callsFake(async () => {
+    const def = {
+      coordinates,
+      _meta: { schemaVersion: '1.7.0' },
+      described: { tools: ['tool/1.0'] }
+    } as unknown as Definition
+    stored = def
+    return def
+  })
+
+  return service as DefinitionService & { compute: sinon.SinonStub }
+}
 
 const createDefinitionService = (): RecomputeContext =>
   ({


### PR DESCRIPTION

The queue processing path had two overlapping spin locks:
- _upgradeLock (process.js, 20-min TTL) — serialized processMessage per coordinate
- computeLock (definitionService.js, 5-min TTL) — serialized _computeAndStore per coordinate

These were nested (not competing), but having two locks with different TTLs at different layers was complex to reason about.

Changes:
- Extract _withComputeLock as the private lock primitive — acquires computeLock, runs the action while holding it, releases in finally; all compute paths delegate to it
- Add computeStoreAndCurateIf(coordinates, shouldCompute) — evaluates the predicate atomically inside the lock, computes, stores, and auto-curates if predicate returns true
- computeStoreAndCurate, computeAndStore, and computeAndStoreIfNecessary all call _withComputeLock directly with inline actions — no intermediate delegation
- Rewrite DefinitionUpgrader.processMessage to call computeStoreAndCurateIf directly with an inline predicate (getStored + policy.validate), removing _upgradeIfNecessary
- Remove _upgradeLock, cache constructor param, _defaultTtlSeconds, and Cache require from DefinitionUpgrader — computeLock is now the sole serialization point
- Remove _sharedCache and its injection into setupProcessing across RecomputeHandler, DefUpgradeQueue, and DelayedComputePolicy — no longer needed
- Add COMPUTE_LOCK_WARN_MS constant (60s) and 3:memory_lock:start debug log before the lock wait so lock wait duration can be measured
- Add one-shot spin-wait warning log after waiting >60s to surface hot-spot coordinates in production; threshold chosen just above p85 lock wait (~57s over 20 days)
- Remove unused ICache typedef from providers/upgrade/process.js
- Add unit tests for computeStoreAndCurateIf; strengthen processTest predicate tests to assert the full chain: getStored → validate (calledOnceWith) → predicate boolean → outcome