### PR TITLE
Consolidate store types

### DIFF
--- a/business/definitionService.d.ts
+++ b/business/definitionService.d.ts
@@ -234,6 +234,8 @@ export interface CurationService {
 
 /** Definition store interface */
 export interface DefinitionStore {
+  /** Initialize the store (connect to backing service, etc.) */
+  initialize(): Promise<void>
   /** Get a definition by coordinates */
   get(coordinates: EntityCoordinates): Promise<Definition | null>
   /** Store a definition */

--- a/providers/stores/azblobAttachmentStore.ts
+++ b/providers/stores/azblobAttachmentStore.ts
@@ -5,30 +5,23 @@ import { promisify } from 'node:util'
 import azure from 'azure-storage'
 import Bottleneck from 'bottleneck'
 import type { Logger } from '../logging/index.js'
+import type { AzBlobStoreOptions } from './abstractAzblobStore.ts'
 
 const limiter = new Bottleneck({ maxConcurrent: 1000 })
 
 import logger from '../logging/logger.ts'
-
-/** Options for configuring an AzBlobAttachmentStore */
-export interface AzBlobAttachmentStoreOptions {
-  /** Azure Storage connection string */
-  connectionString: string
-  /** Name of the blob container */
-  containerName: string
-}
 
 /**
  * Azure Blob Storage implementation for storing and retrieving attachments.
  * Uses rate limiting to control concurrent access.
  */
 export class AzBlobAttachmentStore {
-  options: AzBlobAttachmentStoreOptions
+  options: AzBlobStoreOptions
   containerName: string
   logger: Logger
   declare blobService: any
 
-  constructor(options: AzBlobAttachmentStoreOptions) {
+  constructor(options: AzBlobStoreOptions) {
     this.options = options
     this.containerName = options.containerName
     this.logger = logger()
@@ -68,4 +61,4 @@ export class AzBlobAttachmentStore {
 /**
  * Factory function to create an AzBlobAttachmentStore instance.
  */
-export default (options: AzBlobAttachmentStoreOptions): AzBlobAttachmentStore => new AzBlobAttachmentStore(options)
+export default (options: AzBlobStoreOptions): AzBlobAttachmentStore => new AzBlobAttachmentStore(options)

--- a/providers/stores/azblobDefinitionStore.ts
+++ b/providers/stores/azblobDefinitionStore.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import lodash from 'lodash'
+import type { Definition, DefinitionStore } from '../../business/definitionService.js'
 import type { EntityCoordinates } from '../../lib/entityCoordinates.ts'
 import EntityCoordinatesClass from '../../lib/entityCoordinates.ts'
 import type { AzBlobStoreOptions, BlobEntry } from './abstractAzblobStore.ts'
@@ -12,18 +13,11 @@ const { sortedUniq } = lodash
 
 import { promisify } from 'node:util'
 
-/** Definition object with coordinates */
-export interface Definition {
-  /** The coordinates identifying this definition */
-  coordinates: EntityCoordinates
-  [key: string]: any
-}
-
 /**
  * Azure Blob Storage implementation for storing component definitions.
  * Extends AbstractAzBlobStore with definition-specific functionality.
  */
-export class AzBlobDefinitionStore extends AbstractAzBlobStore {
+export class AzBlobDefinitionStore extends AbstractAzBlobStore implements DefinitionStore {
   /**
    * List all of the definitions for the given coordinates.
    */

--- a/providers/stores/dispatchDefinitionStore.ts
+++ b/providers/stores/dispatchDefinitionStore.ts
@@ -1,27 +1,15 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
+import type {
+  Definition,
+  DefinitionFindQuery,
+  DefinitionFindResult,
+  DefinitionStore
+} from '../../business/definitionService.js'
 import type { EntityCoordinates } from '../../lib/entityCoordinates.ts'
 import type { Logger } from '../logging/index.js'
 import logger from '../logging/logger.ts'
-import type { FindResult, MongoDefinitionQuery } from './abstractMongoDefinitionStore.ts'
-
-/** Definition object with coordinates */
-export interface Definition {
-  /** The coordinates identifying this definition */
-  coordinates: EntityCoordinates
-  [key: string]: any
-}
-
-/** Interface for definition stores that can be dispatched to */
-export interface DefinitionStore {
-  initialize(): Promise<void>
-  get(coordinates: EntityCoordinates): Promise<Definition | null>
-  list(coordinates: EntityCoordinates): Promise<string[] | null>
-  store(definition: Definition): Promise<any>
-  delete(coordinates: EntityCoordinates): Promise<any>
-  find(query: MongoDefinitionQuery, continuationToken?: string): Promise<FindResult | null>
-}
 
 /** Options for configuring a DispatchDefinitionStore */
 export interface DispatchDefinitionStoreOptions {
@@ -36,7 +24,7 @@ export interface DispatchDefinitionStoreOptions {
  * Sequential operations (get, list, find) return the first successful result.
  * Parallel operations (initialize, store, delete) run on all stores concurrently.
  */
-export class DispatchDefinitionStore {
+export class DispatchDefinitionStore implements DefinitionStore {
   stores: DefinitionStore[]
   logger: Logger
 
@@ -83,7 +71,7 @@ export class DispatchDefinitionStore {
   /**
    * Find definitions from the first store that returns results.
    */
-  find(query: MongoDefinitionQuery, continuationToken = ''): Promise<FindResult | null> {
+  find(query: DefinitionFindQuery, continuationToken = ''): Promise<DefinitionFindResult> {
     return this._performInSequence(store => store.find(query, continuationToken))
   }
 

--- a/providers/stores/fileDefinitionStore.ts
+++ b/providers/stores/fileDefinitionStore.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import lodash from 'lodash'
 import { mkdirp } from 'mkdirp'
+import type { Definition } from '../../business/definitionService.js'
 import type { EntityCoordinates } from '../../lib/entityCoordinates.ts'
 import EntityCoordinatesClass from '../../lib/entityCoordinates.ts'
 import type { FileStoreOptions } from './abstractFileStore.ts'
@@ -13,13 +14,6 @@ import AbstractFileStore from './abstractFileStore.ts'
 const { sortedUniq } = lodash
 
 import { promisify } from 'node:util'
-
-/** Definition object with coordinates */
-export interface Definition {
-  /** The coordinates identifying this definition */
-  coordinates: EntityCoordinates
-  [key: string]: any
-}
 
 /**
  * File system implementation for storing component definitions.

--- a/providers/stores/mongo.ts
+++ b/providers/stores/mongo.ts
@@ -8,6 +8,7 @@ import type { FindResult, MongoDefinitionQuery, MongoDefinitionStoreOptions } fr
 
 const { clone, get, range, escapeRegExp } = lodash
 
+import type { DefinitionStore } from '../../business/definitionService.js'
 import AbstractMongoDefinitionStore from './abstractMongoDefinitionStore.ts'
 
 /** Definition object with coordinates and files */
@@ -25,7 +26,7 @@ export interface Definition {
  * MongoDB implementation for storing component definitions with pagination support.
  * Stores large definitions across multiple pages to handle MongoDB document size limits.
  */
-export class MongoStore extends AbstractMongoDefinitionStore {
+export class MongoStore extends AbstractMongoDefinitionStore implements DefinitionStore {
   /**
    * List all of the matching components for the given coordinates.
    * Accepts partial coordinates.

--- a/providers/stores/trimmedMongoDefinitionStore.ts
+++ b/providers/stores/trimmedMongoDefinitionStore.ts
@@ -3,6 +3,7 @@
 
 import lodash from 'lodash'
 import type { UpdateResult } from 'mongodb'
+import type { DefinitionStore } from '../../business/definitionService.js'
 import type { EntityCoordinates } from '../../lib/entityCoordinates.ts'
 import type { FindResult, MongoDefinitionQuery, MongoDefinitionStoreOptions } from './abstractMongoDefinitionStore.ts'
 import AbstractMongoDefinitionStore from './abstractMongoDefinitionStore.ts'
@@ -23,7 +24,7 @@ export interface TrimmedDefinition {
  * Stores definitions without file data for faster queries and smaller storage.
  * Does not support get or list operations - use for find queries only.
  */
-export class TrimmedMongoDefinitionStore extends AbstractMongoDefinitionStore {
+export class TrimmedMongoDefinitionStore extends AbstractMongoDefinitionStore implements DefinitionStore {
   /**
    * List operation is not supported by this store.
    */


### PR DESCRIPTION
Addresses the review comments on #1542.

- Removed 3 duplicate `Definition` interfaces from store files, importing from `business/definitionService` instead
- Added `initialize()` to the canonical `DefinitionStore` interface
- Added `implements DefinitionStore` to `DispatchDefinitionStore`, `AzBlobDefinitionStore`, `MongoStore`, `TrimmedMongoDefinitionStore`
- Replaced `AzBlobAttachmentStoreOptions` with `AzBlobStoreOptions` (only difference was an optional `logger` field)
- `FileDefinitionStore` left without `implements` because its `find()` returns `any[]` not `DefinitionFindResult`

Stacked on #1542.