### PR TITLE
Fix: https://github.com/amzn/tiny-attribution-generator is out of maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "spdx-license-list": "6.11.0",
     "swagger-ui-express": "5.0.1",
     "throat": "6.0.2",
-    "tiny-attribution-generator": "0.1.3",
+    "tiny-attribution-generator": "github:clearlydefined/tiny-attribution-generator#v0.1.3",
     "tmp": "0.2.5",
     "winston": "3.19.0",
     "xml2js": "0.6.2"


### PR DESCRIPTION
Fixed by GitFix AI Agent.

Updated the 'tiny-attribution-generator' dependency from version '0.1.3' to the ClearlyDefined fork on GitHub ('github:clearlydefined/tiny-attribution-generator#v0.1.3'). This addresses the issue of the original amzn repository being unmaintained by pointing to a fork managed by the ClearlyDefined community.

Test: 1. Verify the 'package.json' file has the updated dependency source. 2. Run 'npm install' and ensure the package is downloaded correctly from the GitHub fork. 3. Run 'npm test' to confirm that the service still functions correctly with the forked dependency.