### PR TITLE
Fix: New Maven provider: Clojars

### DIFF
--- a/lib/entityCoordinates.ts
+++ b/lib/entityCoordinates.ts
@@ -22,7 +22,8 @@ const REVISION = 0x1
  */
 const toLowerCaseMap: Record<string, number> = {
   github: NAMESPACE | NAME,
-  pypi: NAME
+  pypi: NAME,
+  clojars: NAMESPACE | NAME
 }
 
 /**


### PR DESCRIPTION
Fixed by GitFix AI Agent.

I have added 'clojars' to the `toLowerCaseMap` with the `NAMESPACE | NAME` bitwise flags. This ensures that coordinates for artifacts from the Clojars repository are correctly normalized to lowercase for both the namespace (groupId) and name (artifactId), which is the standard behavior for Maven-compatible providers in the ClearlyDefined ecosystem where case-insensitivity is common for lookups.

Test: Verify by creating a new EntityCoordinates instance: `new EntityCoordinates('maven', 'Clojars', 'Org.Clojure', 'Clojure', '1.10.1')`. The resulting instance should have: 1. `provider` set to 'clojars' (lowercase), 2. `namespace` set to 'org.clojure' (lowercase), 3. `name` set to 'clojure' (lowercase). Finally, calling `toString()` should produce 'maven/clojars/org.clojure/clojure/1.10.1'.