### PR TITLE
Fix: Docker build npm creds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ENV APP_VERSION=$APP_VERSION
 ARG BUILD_SHA="UNKNOWN"
 ENV BUILD_SHA=$BUILD_SHA
 
-COPY .npmrc package*.json /tmp/
-RUN cd /tmp && npm install --production
+COPY package*.json /tmp/
+RUN --mount=type=secret,id=npmrc,target=/tmp/.npmrc cd /tmp && npm install --production
 RUN mkdir -p "${APPDIR}" && cp -a /tmp/node_modules "${APPDIR}"
 
 WORKDIR "${APPDIR}"


### PR DESCRIPTION
Fixed by GitFix AI Agent.

To resolve the issue of accessing private npm packages on npm.pkg.github.com while maintaining security, I updated the Dockerfile to use Docker BuildKit's secret mounting feature. Specifically, I removed '.npmrc' from the 'COPY' instruction, which previously baked the credentials into the image layers. I then modified the 'npm install' command to use '--mount=type=secret,id=npmrc,target=/tmp/.npmrc'. This temporarily mounts the credentials into the working directory during the dependency installation phase only, ensuring they are not present in the final container image or its history.

Test: 1. Create a local '.npmrc' file containing the GitHub registry configuration and authentication token (e.g., //npm.pkg.github.com/:_authToken=${TOKEN}).
2. Build the image with BuildKit enabled and the secret provided: 'DOCKER_BUILDKIT=1 docker build --secret id=npmrc,src=.npmrc -t clearlydefined-service .'.
3. Verify that the '@clearlydefined/spdx' package is successfully retrieved and the build completes.
4. Run 'docker history clearlydefined-service' to confirm that no '.npmrc' file was added as a file system layer.
5. Run the image and verify that '/opt/service/.npmrc' does not exist.