### PR TITLE
Fix Application Insights telemetry loss caused by namespace import

### DIFF
--- a/lib/mockInsights.ts
+++ b/lib/mockInsights.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { Contracts, TelemetryClient } from 'applicationinsights'
-import * as appInsights from 'applicationinsights'
+import appInsights from 'applicationinsights'
 
 /** Common interface for telemetry clients (real or mock). */
 export interface InsightsClient {

--- a/test/lib/mockInsights.ts
+++ b/test/lib/mockInsights.ts
@@ -1,0 +1,20 @@
+// (c) Copyright 2026, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import appInsights from 'applicationinsights'
+import { expect } from 'chai'
+
+const FAKE_CONNECTION_STRING =
+  'InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://fake.invalid/'
+
+describe('applicationinsights default import', () => {
+  it('defaultClient is populated after setup().start()', () => {
+    appInsights
+      .setup(FAKE_CONNECTION_STRING)
+      .setAutoCollectPerformance(false, false)
+      .setAutoCollectDependencies(true)
+      .start()
+
+    expect(appInsights.defaultClient, 'defaultClient should be set after .start()').to.not.be.undefined
+  })
+})


### PR DESCRIPTION
Fixes #1561

## Problem

PR #1536 switched `lib/mockInsights.ts` to a namespace import (`import * as appInsights from 'applicationinsights'`). The `applicationinsights` package is CJS and assigns `defaultClient` to `exports` lazily when `.start()` is called. A namespace import captures a frozen snapshot at load time and never sees that assignment, so `appInsights.defaultClient` stays `undefined` — silently dropping all telemetry.

## Fix

Revert to a default import, which holds a live reference to `module.exports` and sees the assignment. Add a regression test that fails with the namespace import and passes with the fix.