### PR TITLE
Add two-layer inflight lock to CacheBasedHarvester to prevent duplicate harvest dispatch

### DIFF
--- a/providers/caching/index.d.ts
+++ b/providers/caching/index.d.ts
@@ -50,6 +50,16 @@ export interface ICache {
    * @param item - The key of the item to remove
    */
   delete(item: string): Promise<void> | void
+
+  /**
+   * Atomically sets an item only when the key is absent.
+   *
+   * @param item - The key to set
+   * @param value - The string value to store
+   * @param ttlSeconds - Time-to-live in seconds
+   * @returns true when set succeeds, false when key already exists
+   */
+  setIfAbsent(item: string, value: string, ttlSeconds: number): Promise<boolean> | boolean
 }
 
 /**

--- a/providers/caching/index.d.ts
+++ b/providers/caching/index.d.ts
@@ -52,16 +52,6 @@ export interface ICache {
   delete(item: string): Promise<void> | void
 
   /**
-   * Atomically sets an item only when the key is absent.
-   *
-   * @param item - The key to set
-   * @param value - The string value to store
-   * @param ttlSeconds - Time-to-live in seconds
-   * @returns true when set succeeds, false when key already exists
-   */
-  setIfAbsent(item: string, value: string, ttlSeconds: number): Promise<boolean> | boolean
-
-  /**
    * Atomically acquires all keys in a single operation. If any key is already held,
    * all previously acquired keys in this call are released before returning false.
    *

--- a/providers/caching/index.d.ts
+++ b/providers/caching/index.d.ts
@@ -60,6 +60,17 @@ export interface ICache {
    * @returns true when set succeeds, false when key already exists
    */
   setIfAbsent(item: string, value: string, ttlSeconds: number): Promise<boolean> | boolean
+
+  /**
+   * Atomically acquires all keys in a single operation. If any key is already held,
+   * all previously acquired keys in this call are released before returning false.
+   *
+   * @param keys - The keys to acquire
+   * @param value - The string value to store for each key
+   * @param ttlSeconds - Time-to-live in seconds for each key
+   * @returns true when all keys were acquired, false when any key was already held
+   */
+  setIfAbsentBatch(keys: string[], value: string, ttlSeconds: number): Promise<boolean> | boolean
 }
 
 /**

--- a/providers/caching/memory.ts
+++ b/providers/caching/memory.ts
@@ -37,6 +37,16 @@ class MemoryCache implements ICache, ISyncCache<unknown> {
     return undefined
   }
 
+  /** Atomically stores an item only when absent within this process. */
+  setIfAbsent(item: string, value: string, ttlSeconds: number): boolean {
+    const existing = this.cache.get(item)
+    if (existing !== null && existing !== undefined) {
+      return false
+    }
+    this.cache.put(item, value, ttlSeconds * 1000)
+    return true
+  }
+
   /** Removes an item from the cache */
   delete(item: string): undefined {
     this.cache.del(item)

--- a/providers/caching/memory.ts
+++ b/providers/caching/memory.ts
@@ -39,7 +39,7 @@ class MemoryCache implements ICache, ISyncCache<unknown> {
 
   /** Atomically stores an item only when absent within this process. */
   setIfAbsent(item: string, value: string, ttlSeconds: number): boolean {
-    const existing = this.cache.get(item)
+    const existing = this.cache.get(item) ?? null
     if (existing !== null) {
       return false
     }

--- a/providers/caching/memory.ts
+++ b/providers/caching/memory.ts
@@ -40,7 +40,7 @@ class MemoryCache implements ICache, ISyncCache<unknown> {
   /** Atomically stores an item only when absent within this process. */
   setIfAbsent(item: string, value: string, ttlSeconds: number): boolean {
     const existing = this.cache.get(item)
-    if (existing !== null && existing !== undefined) {
+    if (existing !== null) {
       return false
     }
     this.cache.put(item, value, ttlSeconds * 1000)

--- a/providers/caching/memory.ts
+++ b/providers/caching/memory.ts
@@ -47,6 +47,19 @@ class MemoryCache implements ICache, ISyncCache<unknown> {
     return true
   }
 
+  /** Acquires all keys in one synchronous pass. Releases partial keys and returns false on first miss. */
+  setIfAbsentBatch(keys: string[], value: string, ttlSeconds: number): boolean {
+    const acquired: string[] = []
+    for (const key of keys) {
+      if (!this.setIfAbsent(key, value, ttlSeconds)) {
+        acquired.forEach(k => this.delete(k))
+        return false
+      }
+      acquired.push(key)
+    }
+    return true
+  }
+
   /** Removes an item from the cache */
   delete(item: string): undefined {
     this.cache.del(item)

--- a/providers/caching/redis.ts
+++ b/providers/caching/redis.ts
@@ -26,6 +26,28 @@ export interface RedisCacheOptions extends BaseCacheOptions {
 const objectPrefix = '*!~%'
 
 /**
+ * Lua script that acquires all KEYS atomically with SET NX EX.
+ * On the first key that is already held, releases all previously acquired keys and returns 0.
+ * The acquire+rollback sequence runs atomically inside one script invocation.
+ * Returns 1 when all keys were acquired.
+ * ARGV[1] = ttl in seconds, ARGV[2] = value to store.
+ */
+const SET_IF_ABSENT_BATCH_SCRIPT = `
+local ttl = tonumber(ARGV[1])
+local value = ARGV[2]
+for i = 1, #KEYS do
+  local ok = redis.call('SET', KEYS[i], value, 'NX', 'EX', ttl)
+  if not ok then
+    for j = 1, i - 1 do
+      redis.call('DEL', KEYS[j])
+    end
+    return 0
+  end
+end
+return 1
+`
+
+/**
  * Redis-based cache implementation with compression support
  *
  * This class provides a caching interface using Redis as the backing store. All cached values are compressed using pako
@@ -36,11 +58,13 @@ class RedisCache implements ICache {
   private declare logger: Logger
   private declare _client: RedisClientType | null
   private declare _clientReady: Promise<void> | null
+  private declare _setIfAbsentBatchSha: string | null
 
   /** Creates a new RedisCache instance */
   constructor(options: RedisCacheOptions) {
     this.options = options
     this.logger = options.logger || logger()
+    this._setIfAbsentBatchSha = null
   }
 
   /**
@@ -55,8 +79,9 @@ class RedisCache implements ICache {
     }
     if (!this._clientReady) {
       this._clientReady = RedisCache.initializeClient(this.options, this.logger)
-        .then(client => {
+        .then(async client => {
           this._client = client
+          this._setIfAbsentBatchSha = await client.scriptLoad(SET_IF_ABSENT_BATCH_SCRIPT)
         })
         .catch(error => {
           this._clientReady = null
@@ -140,6 +165,25 @@ class RedisCache implements ICache {
   async setIfAbsent(item: string, value: string, ttlSeconds: number): Promise<boolean> {
     const result = await this._client!.set(item, value, { condition: 'NX', EX: ttlSeconds })
     return result === 'OK'
+  }
+
+  /**
+   * Atomically acquires all keys in one round-trip via Lua and rolls back partial keys on miss.
+   * Note: keys are unlocked via DEL semantics; strict owner-token unlock is a future hardening step.
+   */
+  async setIfAbsentBatch(keys: string[], value: string, ttlSeconds: number): Promise<boolean> {
+    const args = { keys, arguments: [String(ttlSeconds), value] }
+    try {
+      const result = await this._client!.evalSha(this._setIfAbsentBatchSha!, args)
+      return result === 1
+    } catch (err: any) {
+      if (err?.message?.includes('NOSCRIPT')) {
+        this._setIfAbsentBatchSha = await this._client!.scriptLoad(SET_IF_ABSENT_BATCH_SCRIPT)
+        const result = await this._client!.evalSha(this._setIfAbsentBatchSha, args)
+        return result === 1
+      }
+      throw err
+    }
   }
 
   /** Removes an item from the Redis cache */

--- a/providers/caching/redis.ts
+++ b/providers/caching/redis.ts
@@ -161,12 +161,6 @@ class RedisCache implements ICache {
     }
   }
 
-  /** Atomically stores an item only when absent. Intended for distributed lock keys. */
-  async setIfAbsent(item: string, value: string, ttlSeconds: number): Promise<boolean> {
-    const result = await this._client!.set(item, value, { condition: 'NX', EX: ttlSeconds })
-    return result === 'OK'
-  }
-
   /**
    * Atomically acquires all keys in one round-trip via Lua and rolls back partial keys on miss.
    * Note: keys are unlocked via DEL semantics; strict owner-token unlock is a future hardening step.

--- a/providers/caching/redis.ts
+++ b/providers/caching/redis.ts
@@ -136,6 +136,12 @@ class RedisCache implements ICache {
     }
   }
 
+  /** Atomically stores an item only when absent. Intended for distributed lock keys. */
+  async setIfAbsent(item: string, value: string, ttlSeconds: number): Promise<boolean> {
+    const result = await this._client!.set(item, value, { condition: 'NX', EX: ttlSeconds })
+    return result === 'OK'
+  }
+
   /** Removes an item from the Redis cache */
   async delete(item: string): Promise<void> {
     await this._client!.del(item)

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -161,7 +161,7 @@ export class CacheBasedHarvester {
     await this._acquireLocksWithRetry(
       sortedKeys,
       keys => this._acquireSortedInflightKeys(keys),
-      keys => this._releaseInflightKeys(keys, { throwOnFailure: true }),
+      keys => this._releaseInflightKeys(keys),
       () => this._getLockRetryDelayMs(),
       'inflight'
     )
@@ -187,7 +187,7 @@ export class CacheBasedHarvester {
         return
       }
 
-      const missedKey = sortedKeys[acquired.length] || 'unknown'
+      const missedKey = acquired.length > 0 ? sortedKeys[acquired.length] : 'unknown'
       this.logger.debug(
         `${label} lock miss on attempt ${attempts}: acquired ${acquired.length}/${sortedKeys.length}; first missed key ${missedKey}; releasing partial locks.`
       )
@@ -207,18 +207,12 @@ export class CacheBasedHarvester {
   }
 
   async _acquireSortedInflightKeys(sortedKeys: string[]): Promise<string[]> {
-    const acquired: string[] = []
     try {
-      for (const key of sortedKeys) {
-        const lockAcquired = await this._cache.setIfAbsent(key, '1', this.inflightTTLInSeconds)
-        if (!lockAcquired) {
-          break
-        }
-        acquired.push(key)
-      }
-      return acquired
+      const allAcquired = await this._cache.setIfAbsentBatch(sortedKeys, '1', this.inflightTTLInSeconds)
+      return allAcquired ? sortedKeys : []
     } catch (error) {
-      await this._releaseInflightKeys(acquired)
+      // Lua may have acquired some keys before throwing — release all to be safe (DEL is idempotent).
+      await this._releaseInflightKeys(sortedKeys)
       throw error
     }
   }
@@ -228,18 +222,12 @@ export class CacheBasedHarvester {
     await this._releaseInflightKeys(keys)
   }
 
-  async _releaseInflightKeys(keys: string[], options: { throwOnFailure?: boolean } = {}): Promise<void> {
-    const { throwOnFailure = false } = options
+  async _releaseInflightKeys(keys: string[]): Promise<void> {
     const results = await Promise.allSettled(keys.map(key => this._cache.delete(key)))
-    const reasons: unknown[] = []
     for (const result of results) {
       if (result.status === 'rejected') {
-        reasons.push(result.reason)
         this.logger.error('Error releasing inflight lock', result.reason)
       }
-    }
-    if (throwOnFailure && reasons.length) {
-      throw new AggregateError(reasons, `Failed to release ${reasons.length} inflight lock(s)`)
     }
   }
 

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -66,12 +66,13 @@ const concurrencyLimit = 10
 /**
  * Default maximum lock acquire wait in milliseconds for the Redis layer.
  * The local layer uses lockAcquireTimeoutMs + localLockTimeoutBufferMs to cover
- * a full Redis acquisition cycle plus work inside the lock.
+ * the full time a holder can spend inside the local lock: up to lockAcquireTimeoutMs
+ * waiting for Redis, plus localLockTimeoutBufferMs for work inside the Redis lock.
  * Worst-case total blocking per harvest call: 2 × lockAcquireTimeoutMs + localLockTimeoutBufferMs.
  * Keep lockAcquireTimeoutMs below upstream request timeouts so callers receive a structured error.
  */
-const lockAcquireTimeoutMs = 30 * 1000
-/** Extra buffer added to the local lock timeout to cover work inside the Redis lock. */
+const lockAcquireTimeoutMs = 25 * 1000
+/** Buffer added to the local lock waiter timeout to cover dispatch work done inside the Redis lock. */
 const localLockTimeoutBufferMs = 10 * 1000
 
 /**
@@ -151,10 +152,6 @@ export class CacheBasedHarvester {
   }
 
   async _acquireLocalInflightKeys(sortedKeys: string[]): Promise<void> {
-    // Uses the same competitive retry pattern as the Redis path rather than a waiter queue.
-    // Fairness and wake-up latency do not matter here: the Redis lock + tracking filter is
-    // the ultimate arbiter of which request dispatches a harvest, so local acquisition order
-    // has no observable effect on correctness.
     await this._acquireLocksWithRetry(
       sortedKeys,
       keys => this._acquireSortedLocalInflightKeys(keys),
@@ -222,9 +219,9 @@ export class CacheBasedHarvester {
       await release(acquired)
 
       if (Date.now() - started >= timeoutMs) {
-        throw new Error(
-          `Timed out acquiring ${label} harvest coordinate locks after ${attempts} attempt(s) in ${Date.now() - started}ms`
-        )
+        const msg = `Timed out acquiring ${label} harvest coordinate locks after ${attempts} attempt(s) in ${Date.now() - started}ms (timeout: ${timeoutMs}ms)`
+        this.logger.warn(msg)
+        throw new Error(msg)
       }
       const delay = retryDelayMs()
       this.logger.debug(

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -48,6 +48,7 @@ export interface Options {
   lockRetryDelayMaxMs?: number
   lockAcquireTimeoutMs?: number
   localLockRetryDelayMs?: number
+  localLockTimeoutBufferMs?: number
   concurrencyLimit?: number
 }
 
@@ -63,10 +64,15 @@ const localLockRetryDelayMs = 5
 /** Default max concurrent cache reads during pre-filter. */
 const concurrencyLimit = 10
 /**
- * Default maximum lock acquire wait in milliseconds.
- * Keep this below upstream request timeouts so callers receive a structured error.
+ * Default maximum lock acquire wait in milliseconds for the Redis layer.
+ * The local layer uses lockAcquireTimeoutMs + localLockTimeoutBufferMs to cover
+ * a full Redis acquisition cycle plus work inside the lock.
+ * Worst-case total blocking per harvest call: 2 × lockAcquireTimeoutMs + localLockTimeoutBufferMs.
+ * Keep lockAcquireTimeoutMs below upstream request timeouts so callers receive a structured error.
  */
 const lockAcquireTimeoutMs = 30 * 1000
+/** Extra buffer added to the local lock timeout to cover work inside the Redis lock. */
+const localLockTimeoutBufferMs = 10 * 1000
 
 /**
  * Cache-based harvester that tracks and filters harvest operations to avoid duplicates. This class provides efficient
@@ -84,6 +90,7 @@ export class CacheBasedHarvester {
   declare lockRetryDelayMaxMs: number
   declare lockAcquireTimeoutMs: number
   declare localLockRetryDelayMs: number
+  declare localLockTimeoutBufferMs: number
   declare concurrencyLimit: number
 
   constructor(options: Options) {
@@ -91,13 +98,14 @@ export class CacheBasedHarvester {
     this._cache = options.cachingService
     this._harvester = options.harvester
     this._localInflightKeys = new Set()
-    this.cacheTTLInSeconds = options.cacheTTLInSeconds || cacheTTLInSeconds
-    this.inflightTTLInSeconds = options.inflightTTLInSeconds || inflightTTLInSeconds
-    this.lockRetryDelayMinMs = options.lockRetryDelayMinMs || lockRetryDelayMinMs
-    this.lockRetryDelayMaxMs = options.lockRetryDelayMaxMs || lockRetryDelayMaxMs
-    this.lockAcquireTimeoutMs = options.lockAcquireTimeoutMs || lockAcquireTimeoutMs
-    this.localLockRetryDelayMs = options.localLockRetryDelayMs || localLockRetryDelayMs
-    this.concurrencyLimit = options.concurrencyLimit || concurrencyLimit
+    this.cacheTTLInSeconds = options.cacheTTLInSeconds ?? cacheTTLInSeconds
+    this.inflightTTLInSeconds = options.inflightTTLInSeconds ?? inflightTTLInSeconds
+    this.lockRetryDelayMinMs = options.lockRetryDelayMinMs ?? lockRetryDelayMinMs
+    this.lockRetryDelayMaxMs = options.lockRetryDelayMaxMs ?? lockRetryDelayMaxMs
+    this.lockAcquireTimeoutMs = options.lockAcquireTimeoutMs ?? lockAcquireTimeoutMs
+    this.localLockRetryDelayMs = options.localLockRetryDelayMs ?? localLockRetryDelayMs
+    this.localLockTimeoutBufferMs = options.localLockTimeoutBufferMs ?? localLockTimeoutBufferMs
+    this.concurrencyLimit = options.concurrencyLimit ?? concurrencyLimit
   }
 
   async harvest(spec: HarvestEntry | HarvestEntry[], turbo?: boolean): Promise<void> {
@@ -151,7 +159,8 @@ export class CacheBasedHarvester {
       sortedKeys,
       keys => this._acquireSortedLocalInflightKeys(keys),
       keys => this._releaseLocalInflightKeys(keys),
-      this.localLockRetryDelayMs,
+      () => this.localLockRetryDelayMs,
+      this.lockAcquireTimeoutMs + this.localLockTimeoutBufferMs,
       'local inflight'
     )
   }
@@ -180,6 +189,7 @@ export class CacheBasedHarvester {
       keys => this._acquireSortedInflightKeys(keys),
       keys => this._releaseInflightKeys(keys),
       () => this._getLockRetryDelayMs(),
+      this.lockAcquireTimeoutMs,
       'inflight'
     )
   }
@@ -188,7 +198,8 @@ export class CacheBasedHarvester {
     sortedKeys: string[],
     tryAcquire: (keys: string[]) => Promise<string[]> | string[],
     release: (keys: string[]) => Promise<void> | void,
-    retryDelayMs: number | (() => number),
+    retryDelayMs: () => number,
+    timeoutMs: number,
     label: string
   ): Promise<void> {
     const started = Date.now()
@@ -204,18 +215,18 @@ export class CacheBasedHarvester {
         return
       }
 
-      const missedKey = acquired.length > 0 ? sortedKeys[acquired.length] : 'unknown'
+      const missedKey = sortedKeys[acquired.length] ?? 'unknown'
       this.logger.debug(
         `${label} lock miss on attempt ${attempts}: acquired ${acquired.length}/${sortedKeys.length}; first missed key ${missedKey}; releasing partial locks.`
       )
       await release(acquired)
 
-      if (Date.now() - started >= this.lockAcquireTimeoutMs) {
+      if (Date.now() - started >= timeoutMs) {
         throw new Error(
           `Timed out acquiring ${label} harvest coordinate locks after ${attempts} attempt(s) in ${Date.now() - started}ms`
         )
       }
-      const delay = typeof retryDelayMs === 'function' ? retryDelayMs() : retryDelayMs
+      const delay = retryDelayMs()
       this.logger.debug(
         `Retrying ${label} lock acquisition in ${delay}ms (attempt ${attempts + 1}, elapsed ${Date.now() - started}ms).`
       )

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -44,12 +44,26 @@ export interface Options {
   harvester: Harvester
   concurrencyLimit?: number
   cacheTTLInSeconds?: number
+  inflightTTLInSeconds?: number
+  lockRetryDelayMinMs?: number
+  lockRetryDelayMaxMs?: number
+  lockAcquireTimeoutMs?: number
 }
 
 /** Default cache TTL: 1 day in seconds */
 const cacheTTLInSeconds = 60 * 60 * 24
 /** Default concurrency limit for parallel operations */
 const concurrencyLimit = 10
+/** Default lock TTL: 5 minutes in seconds */
+const inflightTTLInSeconds = 60 * 5
+/** Default lock retry delay range in milliseconds */
+const lockRetryDelayMinMs = 50
+const lockRetryDelayMaxMs = 250
+/**
+ * Default maximum lock acquire wait in milliseconds.
+ * Keep this below upstream request timeouts so callers receive a structured error.
+ */
+const lockAcquireTimeoutMs = 30 * 1000
 
 /**
  * Cache-based harvester that tracks and filters harvest operations to avoid duplicates. This class provides efficient
@@ -62,6 +76,10 @@ export class CacheBasedHarvester {
   declare _harvester: Harvester
   declare concurrencyLimit: number
   declare cacheTTLInSeconds: number
+  declare inflightTTLInSeconds: number
+  declare lockRetryDelayMinMs: number
+  declare lockRetryDelayMaxMs: number
+  declare lockAcquireTimeoutMs: number
 
   constructor(options: Options) {
     this.logger = options.logger || logger()
@@ -69,19 +87,103 @@ export class CacheBasedHarvester {
     this._harvester = options.harvester
     this.concurrencyLimit = options.concurrencyLimit || concurrencyLimit
     this.cacheTTLInSeconds = options.cacheTTLInSeconds || cacheTTLInSeconds
+    this.inflightTTLInSeconds = options.inflightTTLInSeconds || inflightTTLInSeconds
+    this.lockRetryDelayMinMs = options.lockRetryDelayMinMs || lockRetryDelayMinMs
+    this.lockRetryDelayMaxMs = options.lockRetryDelayMaxMs || lockRetryDelayMaxMs
+    this.lockAcquireTimeoutMs = options.lockAcquireTimeoutMs || lockAcquireTimeoutMs
   }
 
   async harvest(spec: HarvestEntry | HarvestEntry[], turbo?: boolean): Promise<void> {
     const entries = Array.isArray(spec) ? spec : [spec]
     const uniqueEntries = this._filterOutDuplicatedCoordinates(entries)
-    const harvests = await this._filterOutTracked(uniqueEntries)
-    if (!harvests.length) {
+    if (!uniqueEntries.length) {
       this.logger.debug('No new harvests to process.')
       return
     }
-    this.logger.debug(`Starting harvest for ${harvests.length} entries.`)
-    await this._harvester.harvest(harvests, turbo)
-    await this._trackHarvests(harvests)
+
+    await this._acquireAllInflightLocks(uniqueEntries)
+    try {
+      const harvests = await this._filterOutTracked(uniqueEntries)
+      if (!harvests.length) {
+        this.logger.debug('No new harvests to process.')
+        return
+      }
+      this.logger.debug(`Starting harvest for ${harvests.length} entries.`)
+      await this._harvester.harvest(harvests, turbo)
+      await this._trackHarvests(harvests)
+    } finally {
+      await this._releaseInflightLocks(uniqueEntries)
+    }
+  }
+
+  async _acquireAllInflightLocks(entries: HarvestEntry[]): Promise<void> {
+    const started = Date.now()
+    const sortedKeys = [
+      ...new Set(entries.map(entry => this._getInflightKey(entry.coordinates)).filter(Boolean))
+    ].sort()
+
+    while (true) {
+      const acquired = await this._acquireSortedInflightKeys(sortedKeys)
+      if (acquired.length === sortedKeys.length) {
+        return
+      }
+
+      await this._releaseInflightKeys(acquired)
+      if (Date.now() - started >= this.lockAcquireTimeoutMs) {
+        throw new Error(`Timed out acquiring harvest coordinate locks after ${this.lockAcquireTimeoutMs}ms`)
+      }
+      await this._sleep(this._getLockRetryDelayMs())
+    }
+  }
+
+  async _acquireSortedInflightKeys(sortedKeys: string[]): Promise<string[]> {
+    const acquired: string[] = []
+    try {
+      for (const key of sortedKeys) {
+        const lockAcquired = await this._cache.setIfAbsent(key, '1', this.inflightTTLInSeconds)
+        if (!lockAcquired) {
+          break
+        }
+        acquired.push(key)
+      }
+      return acquired
+    } catch (error) {
+      await this._releaseInflightKeys(acquired)
+      throw error
+    }
+  }
+
+  async _releaseInflightLocks(entries: HarvestEntry[]): Promise<void> {
+    const keys = entries.map(entry => this._getInflightKey(entry.coordinates))
+    await this._releaseInflightKeys(keys)
+  }
+
+  async _releaseInflightKeys(keys: string[]): Promise<void> {
+    await Promise.all(
+      keys.map(
+        throat(this.concurrencyLimit, async key => {
+          await this._cache.delete(key)
+        })
+      )
+    )
+  }
+
+  _getInflightKey(coordinates: EntityCoordinates | string): string {
+    if (!coordinates) {
+      return ''
+    }
+    return `hrv_inflight_${coordinates.toString().toLowerCase()}`
+  }
+
+  _getLockRetryDelayMs(): number {
+    if (this.lockRetryDelayMaxMs <= this.lockRetryDelayMinMs) {
+      return this.lockRetryDelayMinMs
+    }
+    return this.lockRetryDelayMinMs + Math.floor(Math.random() * (this.lockRetryDelayMaxMs - this.lockRetryDelayMinMs))
+  }
+
+  _sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms))
   }
 
   _filterOutDuplicatedCoordinates(entries: HarvestEntry[]): HarvestEntry[] {

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -50,11 +50,11 @@ export interface Options {
 
 /** Default cache TTL: 1 day in seconds */
 const cacheTTLInSeconds = 60 * 60 * 24
-/** Default lock TTL: 5 minutes in seconds */
-const inflightTTLInSeconds = 60 * 5
-/** Default lock retry delay range in milliseconds */
-const lockRetryDelayMinMs = 50
-const lockRetryDelayMaxMs = 250
+/** Default lock TTL: 1 minute in seconds */
+const inflightTTLInSeconds = 60
+/** Default lock retry jitter range in milliseconds */
+const lockRetryDelayMinMs = 300
+const lockRetryDelayMaxMs = 500
 /**
  * Default maximum lock acquire wait in milliseconds.
  * Keep this below upstream request timeouts so callers receive a structured error.

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import lodash from 'lodash'
+import throat from 'throat'
 import type EntityCoordinates from '../../lib/entityCoordinates.ts'
 import type { ICache } from '../caching/index.js'
 import type { Logger } from '../logging/index.js'
@@ -47,6 +48,7 @@ export interface Options {
   lockRetryDelayMaxMs?: number
   lockAcquireTimeoutMs?: number
   localLockRetryDelayMs?: number
+  concurrencyLimit?: number
 }
 
 /** Default cache TTL: 1 day in seconds */
@@ -58,6 +60,8 @@ const lockRetryDelayMinMs = 300
 const lockRetryDelayMaxMs = 500
 /** Default local lock retry delay in milliseconds — short since contention is in-process */
 const localLockRetryDelayMs = 5
+/** Default max concurrent cache reads during pre-filter. */
+const concurrencyLimit = 10
 /**
  * Default maximum lock acquire wait in milliseconds.
  * Keep this below upstream request timeouts so callers receive a structured error.
@@ -80,6 +84,7 @@ export class CacheBasedHarvester {
   declare lockRetryDelayMaxMs: number
   declare lockAcquireTimeoutMs: number
   declare localLockRetryDelayMs: number
+  declare concurrencyLimit: number
 
   constructor(options: Options) {
     this.logger = options.logger || logger()
@@ -92,6 +97,7 @@ export class CacheBasedHarvester {
     this.lockRetryDelayMaxMs = options.lockRetryDelayMaxMs || lockRetryDelayMaxMs
     this.lockAcquireTimeoutMs = options.lockAcquireTimeoutMs || lockAcquireTimeoutMs
     this.localLockRetryDelayMs = options.localLockRetryDelayMs || localLockRetryDelayMs
+    this.concurrencyLimit = options.concurrencyLimit || concurrencyLimit
   }
 
   async harvest(spec: HarvestEntry | HarvestEntry[], turbo?: boolean): Promise<void> {
@@ -103,13 +109,24 @@ export class CacheBasedHarvester {
       return
     }
 
-    const sortedInflightKeys = uniqueEntries.map(entry => this._getInflightKey(entry.coordinates)).sort()
+    // Pre-filter: read tracking cache without holding any locks.
+    // Best-effort optimisation — the recheck under the lock is the authoritative
+    // guard against the TOCTOU window between here and lock acquisition.
+    const candidateEntries = await this._filterOutTracked(uniqueEntries, this.concurrencyLimit)
+    if (!candidateEntries.length) {
+      this.logger.debug('No new harvests to process.')
+      return
+    }
+
+    // Compute keys only for candidates so the lock batch is as small as possible.
+    const sortedInflightKeys = candidateEntries.map(entry => this._getInflightKey(entry.coordinates)).sort()
 
     await this._acquireLocalInflightKeys(sortedInflightKeys)
     try {
       await this._acquireAllInflightLocks(sortedInflightKeys)
       try {
-        const harvests = await this._filterOutTracked(uniqueEntries)
+        // Recheck under lock: guards the TOCTOU window between pre-filter and lock acquisition.
+        const harvests = await this._filterOutTracked(candidateEntries)
         if (!harvests.length) {
           this.logger.debug('No new harvests to process.')
           return
@@ -118,7 +135,7 @@ export class CacheBasedHarvester {
         await this._harvester.harvest(harvests, turbo)
         await this._trackHarvests(harvests)
       } finally {
-        await this._releaseInflightLocks(uniqueEntries)
+        await this._releaseInflightKeys(sortedInflightKeys)
       }
     } finally {
       this._releaseLocalInflightKeys(sortedInflightKeys)
@@ -217,11 +234,6 @@ export class CacheBasedHarvester {
     }
   }
 
-  async _releaseInflightLocks(entries: HarvestEntry[]): Promise<void> {
-    const keys = entries.map(entry => this._getInflightKey(entry.coordinates))
-    await this._releaseInflightKeys(keys)
-  }
-
   async _releaseInflightKeys(keys: string[]): Promise<void> {
     const results = await Promise.allSettled(keys.map(key => this._cache.delete(key)))
     for (const result of results) {
@@ -254,10 +266,12 @@ export class CacheBasedHarvester {
     return uniqBy(validEntries, entry => this._getCacheKey(entry.coordinates))
   }
 
-  async _filterOutTracked(entries: HarvestEntry[]): Promise<HarvestEntry[]> {
-    const filteredEntries = await Promise.all(
-      entries.map(async (entry: HarvestEntry) => ((await this._isTrackedHarvest(entry)) ? null : entry))
-    )
+  async _filterOutTracked(entries: HarvestEntry[], concurrency?: number): Promise<HarvestEntry[]> {
+    // Skip throat when entries are already at/below the limit to avoid unnecessary wrapping.
+    const isConcurrencyValid = concurrency !== undefined && concurrency > 0 && concurrency < entries.length
+    const mapper = async (entry: HarvestEntry) => ((await this._isTrackedHarvest(entry)) ? null : entry)
+    const filteredEntries = await Promise.all(entries.map(isConcurrencyValid ? throat(concurrency!, mapper) : mapper))
+
     return filteredEntries.filter((entry): entry is HarvestEntry => entry !== null)
   }
 

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -4,7 +4,8 @@
 import lodash from 'lodash'
 import throat from 'throat'
 import type EntityCoordinates from '../../lib/entityCoordinates.ts'
-import type { ICache } from '../caching/index.js'
+import type { ICache, ISyncCache } from '../caching/index.js'
+import memoryCache from '../caching/memory.ts'
 import type { Logger } from '../logging/index.js'
 import logger from '../logging/logger.ts'
 
@@ -41,6 +42,7 @@ export interface Harvester {
 export interface Options {
   logger?: Logger
   cachingService: ICache
+  localLockCache?: ISyncCache<string>
   harvester: Harvester
   cacheTTLInSeconds?: number
   inflightTTLInSeconds?: number
@@ -84,7 +86,7 @@ export class CacheBasedHarvester {
   declare logger: Logger
   declare _cache: ICache
   declare _harvester: Harvester
-  declare _localInflightKeys: Set<string>
+  declare _localInflightKeys: ISyncCache<string>
   declare cacheTTLInSeconds: number
   declare inflightTTLInSeconds: number
   declare lockRetryDelayMinMs: number
@@ -92,13 +94,13 @@ export class CacheBasedHarvester {
   declare lockAcquireTimeoutMs: number
   declare localLockRetryDelayMs: number
   declare localLockTimeoutBufferMs: number
+  declare localLockTTLSeconds: number
   declare concurrencyLimit: number
 
   constructor(options: Options) {
     this.logger = options.logger || logger()
     this._cache = options.cachingService
     this._harvester = options.harvester
-    this._localInflightKeys = new Set()
     this.cacheTTLInSeconds = options.cacheTTLInSeconds ?? cacheTTLInSeconds
     this.inflightTTLInSeconds = options.inflightTTLInSeconds ?? inflightTTLInSeconds
     this.lockRetryDelayMinMs = options.lockRetryDelayMinMs ?? lockRetryDelayMinMs
@@ -106,7 +108,9 @@ export class CacheBasedHarvester {
     this.lockAcquireTimeoutMs = options.lockAcquireTimeoutMs ?? lockAcquireTimeoutMs
     this.localLockRetryDelayMs = options.localLockRetryDelayMs ?? localLockRetryDelayMs
     this.localLockTimeoutBufferMs = options.localLockTimeoutBufferMs ?? localLockTimeoutBufferMs
+    this.localLockTTLSeconds = Math.ceil((this.lockAcquireTimeoutMs + this.localLockTimeoutBufferMs) / 1000)
     this.concurrencyLimit = options.concurrencyLimit ?? concurrencyLimit
+    this._localInflightKeys = options.localLockCache ?? memoryCache({ defaultTtlSeconds: this.localLockTTLSeconds })
   }
 
   async harvest(spec: HarvestEntry | HarvestEntry[], turbo?: boolean): Promise<void> {
@@ -165,10 +169,10 @@ export class CacheBasedHarvester {
   _acquireSortedLocalInflightKeys(sortedKeys: string[]): string[] {
     const acquired: string[] = []
     for (const key of sortedKeys) {
-      if (this._localInflightKeys.has(key)) {
+      if (this._localInflightKeys.get(key) !== null) {
         break
       }
-      this._localInflightKeys.add(key)
+      this._localInflightKeys.set(key, '1', this.localLockTTLSeconds)
       acquired.push(key)
     }
     return acquired

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -115,18 +115,32 @@ export class CacheBasedHarvester {
     const sortedKeys = [
       ...new Set(entries.map(entry => this._getInflightKey(entry.coordinates)).filter(Boolean))
     ].sort()
+    let attempts = 0
 
     while (true) {
+      attempts += 1
       const acquired = await this._acquireSortedInflightKeys(sortedKeys)
       if (acquired.length === sortedKeys.length) {
+        this.logger.debug(
+          `Acquired ${acquired.length}/${sortedKeys.length} inflight locks after ${attempts} attempt(s) in ${Date.now() - started}ms.`
+        )
         return
       }
 
+      const missedKey = sortedKeys[acquired.length] || 'unknown'
+      this.logger.debug(
+        `Inflight lock miss on attempt ${attempts}: acquired ${acquired.length}/${sortedKeys.length}; first missed key ${missedKey}; releasing partial locks.`
+      )
       await this._releaseInflightKeys(acquired)
+
       if (Date.now() - started >= this.lockAcquireTimeoutMs) {
         throw new Error(`Timed out acquiring harvest coordinate locks after ${this.lockAcquireTimeoutMs}ms`)
       }
-      await this._sleep(this._getLockRetryDelayMs())
+      const retryDelayMs = this._getLockRetryDelayMs()
+      this.logger.debug(
+        `Retrying inflight lock acquisition in ${retryDelayMs}ms (attempt ${attempts + 1}, elapsed ${Date.now() - started}ms).`
+      )
+      await this._sleep(retryDelayMs)
     }
   }
 

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -46,6 +46,7 @@ export interface Options {
   lockRetryDelayMinMs?: number
   lockRetryDelayMaxMs?: number
   lockAcquireTimeoutMs?: number
+  localLockRetryDelayMs?: number
 }
 
 /** Default cache TTL: 1 day in seconds */
@@ -55,6 +56,8 @@ const inflightTTLInSeconds = 60
 /** Default lock retry jitter range in milliseconds */
 const lockRetryDelayMinMs = 300
 const lockRetryDelayMaxMs = 500
+/** Default local lock retry delay in milliseconds — short since contention is in-process */
+const localLockRetryDelayMs = 5
 /**
  * Default maximum lock acquire wait in milliseconds.
  * Keep this below upstream request timeouts so callers receive a structured error.
@@ -70,21 +73,25 @@ export class CacheBasedHarvester {
   declare logger: Logger
   declare _cache: ICache
   declare _harvester: Harvester
+  declare _localInflightKeys: Set<string>
   declare cacheTTLInSeconds: number
   declare inflightTTLInSeconds: number
   declare lockRetryDelayMinMs: number
   declare lockRetryDelayMaxMs: number
   declare lockAcquireTimeoutMs: number
+  declare localLockRetryDelayMs: number
 
   constructor(options: Options) {
     this.logger = options.logger || logger()
     this._cache = options.cachingService
     this._harvester = options.harvester
+    this._localInflightKeys = new Set()
     this.cacheTTLInSeconds = options.cacheTTLInSeconds || cacheTTLInSeconds
     this.inflightTTLInSeconds = options.inflightTTLInSeconds || inflightTTLInSeconds
     this.lockRetryDelayMinMs = options.lockRetryDelayMinMs || lockRetryDelayMinMs
     this.lockRetryDelayMaxMs = options.lockRetryDelayMaxMs || lockRetryDelayMaxMs
     this.lockAcquireTimeoutMs = options.lockAcquireTimeoutMs || lockAcquireTimeoutMs
+    this.localLockRetryDelayMs = options.localLockRetryDelayMs || localLockRetryDelayMs
   }
 
   async harvest(spec: HarvestEntry | HarvestEntry[], turbo?: boolean): Promise<void> {
@@ -96,50 +103,106 @@ export class CacheBasedHarvester {
       return
     }
 
-    await this._acquireAllInflightLocks(uniqueEntries)
+    const sortedInflightKeys = uniqueEntries.map(entry => this._getInflightKey(entry.coordinates)).sort()
+
+    await this._acquireLocalInflightKeys(sortedInflightKeys)
     try {
-      const harvests = await this._filterOutTracked(uniqueEntries)
-      if (!harvests.length) {
-        this.logger.debug('No new harvests to process.')
-        return
+      await this._acquireAllInflightLocks(sortedInflightKeys)
+      try {
+        const harvests = await this._filterOutTracked(uniqueEntries)
+        if (!harvests.length) {
+          this.logger.debug('No new harvests to process.')
+          return
+        }
+        this.logger.debug(`Starting harvest for ${harvests.length} entries.`)
+        await this._harvester.harvest(harvests, turbo)
+        await this._trackHarvests(harvests)
+      } finally {
+        await this._releaseInflightLocks(uniqueEntries)
       }
-      this.logger.debug(`Starting harvest for ${harvests.length} entries.`)
-      await this._harvester.harvest(harvests, turbo)
-      await this._trackHarvests(harvests)
     } finally {
-      await this._releaseInflightLocks(uniqueEntries)
+      this._releaseLocalInflightKeys(sortedInflightKeys)
     }
   }
 
-  async _acquireAllInflightLocks(entries: HarvestEntry[]): Promise<void> {
+  async _acquireLocalInflightKeys(sortedKeys: string[]): Promise<void> {
+    // Uses the same competitive retry pattern as the Redis path rather than a waiter queue.
+    // Fairness and wake-up latency do not matter here: the Redis lock + tracking filter is
+    // the ultimate arbiter of which request dispatches a harvest, so local acquisition order
+    // has no observable effect on correctness.
+    await this._acquireLocksWithRetry(
+      sortedKeys,
+      keys => this._acquireSortedLocalInflightKeys(keys),
+      keys => this._releaseLocalInflightKeys(keys),
+      this.localLockRetryDelayMs,
+      'local inflight'
+    )
+  }
+
+  _acquireSortedLocalInflightKeys(sortedKeys: string[]): string[] {
+    const acquired: string[] = []
+    for (const key of sortedKeys) {
+      if (this._localInflightKeys.has(key)) {
+        break
+      }
+      this._localInflightKeys.add(key)
+      acquired.push(key)
+    }
+    return acquired
+  }
+
+  _releaseLocalInflightKeys(keys: string[]): void {
+    for (const key of keys) {
+      this._localInflightKeys.delete(key)
+    }
+  }
+
+  async _acquireAllInflightLocks(sortedKeys: string[]): Promise<void> {
+    await this._acquireLocksWithRetry(
+      sortedKeys,
+      keys => this._acquireSortedInflightKeys(keys),
+      keys => this._releaseInflightKeys(keys, { throwOnFailure: true }),
+      () => this._getLockRetryDelayMs(),
+      'inflight'
+    )
+  }
+
+  async _acquireLocksWithRetry(
+    sortedKeys: string[],
+    tryAcquire: (keys: string[]) => Promise<string[]> | string[],
+    release: (keys: string[]) => Promise<void> | void,
+    retryDelayMs: number | (() => number),
+    label: string
+  ): Promise<void> {
     const started = Date.now()
-    const sortedKeys = entries.map(entry => this._getInflightKey(entry.coordinates)).sort()
     let attempts = 0
 
     while (true) {
       attempts += 1
-      const acquired = await this._acquireSortedInflightKeys(sortedKeys)
+      const acquired = await tryAcquire(sortedKeys)
       if (acquired.length === sortedKeys.length) {
         this.logger.debug(
-          `Acquired ${acquired.length}/${sortedKeys.length} inflight locks after ${attempts} attempt(s) in ${Date.now() - started}ms.`
+          `Acquired ${acquired.length}/${sortedKeys.length} ${label} lock(s) after ${attempts} attempt(s) in ${Date.now() - started}ms.`
         )
         return
       }
 
       const missedKey = sortedKeys[acquired.length] || 'unknown'
       this.logger.debug(
-        `Inflight lock miss on attempt ${attempts}: acquired ${acquired.length}/${sortedKeys.length}; first missed key ${missedKey}; releasing partial locks.`
+        `${label} lock miss on attempt ${attempts}: acquired ${acquired.length}/${sortedKeys.length}; first missed key ${missedKey}; releasing partial locks.`
       )
-      await this._releaseInflightKeys(acquired, { throwOnFailure: true })
+      await release(acquired)
 
       if (Date.now() - started >= this.lockAcquireTimeoutMs) {
-        throw new Error(`Timed out acquiring harvest coordinate locks after ${this.lockAcquireTimeoutMs}ms`)
+        throw new Error(
+          `Timed out acquiring ${label} harvest coordinate locks after ${attempts} attempt(s) in ${Date.now() - started}ms`
+        )
       }
-      const retryDelayMs = this._getLockRetryDelayMs()
+      const delay = typeof retryDelayMs === 'function' ? retryDelayMs() : retryDelayMs
       this.logger.debug(
-        `Retrying inflight lock acquisition in ${retryDelayMs}ms (attempt ${attempts + 1}, elapsed ${Date.now() - started}ms).`
+        `Retrying ${label} lock acquisition in ${delay}ms (attempt ${attempts + 1}, elapsed ${Date.now() - started}ms).`
       )
-      await this._sleep(retryDelayMs)
+      await this._sleep(delay)
     }
   }
 

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -89,6 +89,7 @@ export class CacheBasedHarvester {
 
   async harvest(spec: HarvestEntry | HarvestEntry[], turbo?: boolean): Promise<void> {
     const entries = Array.isArray(spec) ? spec : [spec]
+    // _filterOutDuplicatedCoordinates removes falsy coordinates and deduplicates keys.
     const uniqueEntries = this._filterOutDuplicatedCoordinates(entries)
     if (!uniqueEntries.length) {
       this.logger.debug('No new harvests to process.')
@@ -112,9 +113,7 @@ export class CacheBasedHarvester {
 
   async _acquireAllInflightLocks(entries: HarvestEntry[]): Promise<void> {
     const started = Date.now()
-    const sortedKeys = [
-      ...new Set(entries.map(entry => this._getInflightKey(entry.coordinates)).filter(Boolean))
-    ].sort()
+    const sortedKeys = entries.map(entry => this._getInflightKey(entry.coordinates)).sort()
     let attempts = 0
 
     while (true) {
@@ -131,7 +130,7 @@ export class CacheBasedHarvester {
       this.logger.debug(
         `Inflight lock miss on attempt ${attempts}: acquired ${acquired.length}/${sortedKeys.length}; first missed key ${missedKey}; releasing partial locks.`
       )
-      await this._releaseInflightKeys(acquired)
+      await this._releaseInflightKeys(acquired, { throwOnFailure: true })
 
       if (Date.now() - started >= this.lockAcquireTimeoutMs) {
         throw new Error(`Timed out acquiring harvest coordinate locks after ${this.lockAcquireTimeoutMs}ms`)
@@ -166,8 +165,19 @@ export class CacheBasedHarvester {
     await this._releaseInflightKeys(keys)
   }
 
-  async _releaseInflightKeys(keys: string[]): Promise<void> {
-    await Promise.all(keys.map(key => this._cache.delete(key)))
+  async _releaseInflightKeys(keys: string[], options: { throwOnFailure?: boolean } = {}): Promise<void> {
+    const { throwOnFailure = false } = options
+    const results = await Promise.allSettled(keys.map(key => this._cache.delete(key)))
+    const reasons: unknown[] = []
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        reasons.push(result.reason)
+        this.logger.error('Error releasing inflight lock', result.reason)
+      }
+    }
+    if (throwOnFailure && reasons.length) {
+      throw new AggregateError(reasons, `Failed to release ${reasons.length} inflight lock(s)`)
+    }
   }
 
   _getInflightKey(coordinates: EntityCoordinates | string): string {
@@ -222,11 +232,7 @@ export class CacheBasedHarvester {
   }
 
   async _trackHarvests(harvestEntries: HarvestEntry[]): Promise<void> {
-    const results = await Promise.allSettled(
-      harvestEntries.map(async (entry: HarvestEntry) => {
-        await this._track(entry)
-      })
-    )
+    const results = await Promise.allSettled(harvestEntries.map(entry => this._track(entry)))
     for (const result of results) {
       if (result.status === 'rejected') {
         this.logger.error(result.reason)

--- a/providers/harvest/cacheBasedCrawler.ts
+++ b/providers/harvest/cacheBasedCrawler.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import lodash from 'lodash'
-import throat from 'throat'
 import type EntityCoordinates from '../../lib/entityCoordinates.ts'
 import type { ICache } from '../caching/index.js'
 import type { Logger } from '../logging/index.js'
@@ -42,7 +41,6 @@ export interface Options {
   logger?: Logger
   cachingService: ICache
   harvester: Harvester
-  concurrencyLimit?: number
   cacheTTLInSeconds?: number
   inflightTTLInSeconds?: number
   lockRetryDelayMinMs?: number
@@ -52,8 +50,6 @@ export interface Options {
 
 /** Default cache TTL: 1 day in seconds */
 const cacheTTLInSeconds = 60 * 60 * 24
-/** Default concurrency limit for parallel operations */
-const concurrencyLimit = 10
 /** Default lock TTL: 5 minutes in seconds */
 const inflightTTLInSeconds = 60 * 5
 /** Default lock retry delay range in milliseconds */
@@ -74,7 +70,6 @@ export class CacheBasedHarvester {
   declare logger: Logger
   declare _cache: ICache
   declare _harvester: Harvester
-  declare concurrencyLimit: number
   declare cacheTTLInSeconds: number
   declare inflightTTLInSeconds: number
   declare lockRetryDelayMinMs: number
@@ -85,7 +80,6 @@ export class CacheBasedHarvester {
     this.logger = options.logger || logger()
     this._cache = options.cachingService
     this._harvester = options.harvester
-    this.concurrencyLimit = options.concurrencyLimit || concurrencyLimit
     this.cacheTTLInSeconds = options.cacheTTLInSeconds || cacheTTLInSeconds
     this.inflightTTLInSeconds = options.inflightTTLInSeconds || inflightTTLInSeconds
     this.lockRetryDelayMinMs = options.lockRetryDelayMinMs || lockRetryDelayMinMs
@@ -159,13 +153,7 @@ export class CacheBasedHarvester {
   }
 
   async _releaseInflightKeys(keys: string[]): Promise<void> {
-    await Promise.all(
-      keys.map(
-        throat(this.concurrencyLimit, async key => {
-          await this._cache.delete(key)
-        })
-      )
-    )
+    await Promise.all(keys.map(key => this._cache.delete(key)))
   }
 
   _getInflightKey(coordinates: EntityCoordinates | string): string {
@@ -193,11 +181,7 @@ export class CacheBasedHarvester {
 
   async _filterOutTracked(entries: HarvestEntry[]): Promise<HarvestEntry[]> {
     const filteredEntries = await Promise.all(
-      entries.map(
-        throat(this.concurrencyLimit, async (entry: HarvestEntry) =>
-          (await this._isTrackedHarvest(entry)) ? null : entry
-        )
-      )
+      entries.map(async (entry: HarvestEntry) => ((await this._isTrackedHarvest(entry)) ? null : entry))
     )
     return filteredEntries.filter((entry): entry is HarvestEntry => entry !== null)
   }
@@ -225,11 +209,9 @@ export class CacheBasedHarvester {
 
   async _trackHarvests(harvestEntries: HarvestEntry[]): Promise<void> {
     const results = await Promise.allSettled(
-      harvestEntries.map(
-        throat(this.concurrencyLimit, async (entry: HarvestEntry) => {
-          await this._track(entry)
-        })
-      )
+      harvestEntries.map(async (entry: HarvestEntry) => {
+        await this._track(entry)
+      })
     )
     for (const result of results) {
       if (result.status === 'rejected') {

--- a/test/providers/caching/memory.ts
+++ b/test/providers/caching/memory.ts
@@ -70,4 +70,49 @@ describe('MemoryCache', () => {
       }
     })
   })
+
+  describe('setIfAbsentBatch', () => {
+    let cache: ReturnType<typeof memoryCacheFactory>
+
+    beforeEach(() => {
+      cache = memoryCacheFactory()
+    })
+
+    it('returns true and sets all keys when all absent', () => {
+      const result = cache.setIfAbsentBatch(['k1', 'k2', 'k3'], '1', 60)
+      assert.strictEqual(result, true)
+      assert.strictEqual(cache.get('k1'), '1')
+      assert.strictEqual(cache.get('k2'), '1')
+      assert.strictEqual(cache.get('k3'), '1')
+    })
+
+    it('returns false and sets nothing when first key already held', () => {
+      cache.setIfAbsent('k1', 'held', 60)
+      const result = cache.setIfAbsentBatch(['k1', 'k2'], '1', 60)
+      assert.strictEqual(result, false)
+      assert.strictEqual(cache.get('k2'), null)
+    })
+
+    it('returns false and releases partial keys when middle key already held', () => {
+      cache.setIfAbsent('k2', 'held', 60)
+      const result = cache.setIfAbsentBatch(['k1', 'k2', 'k3'], '1', 60)
+      assert.strictEqual(result, false)
+      assert.strictEqual(cache.get('k1'), null, 'k1 should be released')
+      assert.strictEqual(cache.get('k3'), null, 'k3 should never have been set')
+    })
+
+    it('returns false and releases all preceding keys when last key is already held', () => {
+      cache.setIfAbsent('k3', 'held', 60)
+      const result = cache.setIfAbsentBatch(['k1', 'k2', 'k3'], '1', 60)
+      assert.strictEqual(result, false)
+      assert.strictEqual(cache.get('k1'), null, 'k1 should be released')
+      assert.strictEqual(cache.get('k2'), null, 'k2 should be released')
+      assert.strictEqual(cache.get('k3'), 'held', 'held key should be untouched')
+    })
+
+    it('returns true for empty key list', () => {
+      const result = cache.setIfAbsentBatch([], '1', 60)
+      assert.strictEqual(result, true)
+    })
+  })
 })

--- a/test/providers/caching/memory.ts
+++ b/test/providers/caching/memory.ts
@@ -1,0 +1,73 @@
+// (c) Copyright 2026, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import assert from 'node:assert'
+import sinon from 'sinon'
+import memoryCacheFactory from '../../../providers/caching/memory.ts'
+
+describe('MemoryCache', () => {
+  describe('setIfAbsent', () => {
+    let cache: ReturnType<typeof memoryCacheFactory>
+
+    beforeEach(() => {
+      cache = memoryCacheFactory()
+    })
+
+    it('returns true and stores value when key is absent', () => {
+      const result = cache.setIfAbsent('lock_key', '1', 120)
+      assert.strictEqual(result, true)
+      assert.strictEqual(cache.get('lock_key'), '1')
+    })
+
+    it('returns false when key already exists', () => {
+      cache.setIfAbsent('lock_key', '1', 120)
+      const result = cache.setIfAbsent('lock_key', '1', 120)
+      assert.strictEqual(result, false)
+    })
+
+    it('does not overwrite existing value', () => {
+      cache.setIfAbsent('lock_key', 'first', 120)
+      cache.setIfAbsent('lock_key', 'second', 120)
+      assert.strictEqual(cache.get('lock_key'), 'first')
+    })
+
+    it('different keys are independent', () => {
+      const r1 = cache.setIfAbsent('key1', '1', 120)
+      const r2 = cache.setIfAbsent('key2', '1', 120)
+      assert.strictEqual(r1, true)
+      assert.strictEqual(r2, true)
+    })
+
+    it('returns true again after TTL expiry (fake timers)', () => {
+      const clock = sinon.useFakeTimers()
+      try {
+        const timedCache = memoryCacheFactory()
+        timedCache.setIfAbsent('lock_key', '1', 5)
+        assert.strictEqual(timedCache.get('lock_key'), '1')
+
+        clock.tick(5001)
+
+        assert.strictEqual(timedCache.get('lock_key'), null)
+        const result = timedCache.setIfAbsent('lock_key', '1', 5)
+        assert.strictEqual(result, true)
+      } finally {
+        clock.restore()
+      }
+    })
+
+    it('returns false before TTL expiry (fake timers)', () => {
+      const clock = sinon.useFakeTimers()
+      try {
+        const timedCache = memoryCacheFactory()
+        timedCache.setIfAbsent('lock_key', '1', 5)
+
+        clock.tick(4999)
+
+        const result = timedCache.setIfAbsent('lock_key', '1', 5)
+        assert.strictEqual(result, false)
+      } finally {
+        clock.restore()
+      }
+    })
+  })
+})

--- a/test/providers/caching/redis.ts
+++ b/test/providers/caching/redis.ts
@@ -92,16 +92,6 @@ describe('Redis Cache', () => {
       assert.strictEqual(result, null)
     })
 
-    it('sets only when absent with Redis condition NX', async () => {
-      await cache.initialize()
-      const first = await cache.setIfAbsent('lock_foo', '1', 120)
-      const second = await cache.setIfAbsent('lock_foo', '1', 120)
-
-      assert.strictEqual(first, true)
-      assert.strictEqual(second, false)
-      assert.ok(mockClient.set.calledWith('lock_foo', '1', { condition: 'NX', EX: 120 }))
-    })
-
     it('setIfAbsentBatch acquires all keys and returns true when all absent', async () => {
       await cache.initialize()
       const result = await cache.setIfAbsentBatch(['key1', 'key2', 'key3'], '1', 60)

--- a/test/providers/caching/redis.ts
+++ b/test/providers/caching/redis.ts
@@ -146,6 +146,15 @@ describe('Redis Cache', () => {
       assert.ok(mockClient.scriptLoad.calledTwice, 'scriptLoad should be called again after NOSCRIPT')
     })
 
+    it('setIfAbsentBatch returns true for empty key list', async () => {
+      await cache.initialize()
+
+      const result = await cache.setIfAbsentBatch([], '1', 60)
+
+      assert.strictEqual(result, true)
+      assert.strictEqual(Object.keys(store).length, 0, 'No keys should be modified for empty batch')
+    })
+
     it('throws error if redis connection fails', async () => {
       mockClient.connect = () => Promise.reject(new Error('Connection failed'))
       try {

--- a/test/providers/caching/redis.ts
+++ b/test/providers/caching/redis.ts
@@ -19,6 +19,7 @@ describe('Redis Cache', () => {
     const store = {}
     let mockClient
     let cache
+
     beforeEach(() => {
       mockClient = {
         get: async key => Promise.resolve(store[key]),
@@ -34,7 +35,23 @@ describe('Redis Cache', () => {
         },
         connect: async () => Promise.resolve(mockClient),
         on: () => {},
-        quit: sinon.stub().resolves()
+        quit: sinon.stub().resolves(),
+        scriptLoad: sinon.stub().resolves('fakeSha'),
+        evalSha: sinon.stub().callsFake(async (_sha, { keys, arguments: args }) => {
+          const value = args[1]
+          const acquired: string[] = []
+          for (const key of keys) {
+            if (store[key] !== undefined && store[key] !== null) {
+              acquired.forEach(k => {
+                store[k] = null
+              })
+              return 0
+            }
+            store[key] = value
+            acquired.push(key)
+          }
+          return 1
+        })
       }
       sandbox.stub(RedisCache, 'buildRedisClient').returns(mockClient)
       cache = redisCache({ logger } as any)
@@ -42,6 +59,9 @@ describe('Redis Cache', () => {
 
     afterEach(() => {
       sandbox.restore()
+      for (const key of Object.keys(store)) {
+        delete store[key]
+      }
     })
 
     it('works well for a specific tool version', async () => {
@@ -80,6 +100,50 @@ describe('Redis Cache', () => {
       assert.strictEqual(first, true)
       assert.strictEqual(second, false)
       assert.ok(mockClient.set.calledWith('lock_foo', '1', { condition: 'NX', EX: 120 }))
+    })
+
+    it('setIfAbsentBatch acquires all keys and returns true when all absent', async () => {
+      await cache.initialize()
+      const result = await cache.setIfAbsentBatch(['key1', 'key2', 'key3'], '1', 60)
+      assert.strictEqual(result, true)
+      assert.strictEqual(store['key1'], '1')
+      assert.strictEqual(store['key2'], '1')
+      assert.strictEqual(store['key3'], '1')
+    })
+
+    it('setIfAbsentBatch returns false and sets nothing when first key already held', async () => {
+      await cache.initialize()
+      store['key1'] = 'held'
+      const result = await cache.setIfAbsentBatch(['key1', 'key2'], '1', 60)
+      assert.strictEqual(result, false)
+      assert.strictEqual(store['key2'], undefined)
+    })
+
+    it('setIfAbsentBatch returns false and releases partial keys when middle key already held', async () => {
+      await cache.initialize()
+      store['key2'] = 'held'
+      const result = await cache.setIfAbsentBatch(['key1', 'key2', 'key3'], '1', 60)
+      assert.strictEqual(result, false)
+      assert.strictEqual(store['key1'], null, 'key1 should be released (set to null by mock)')
+      assert.strictEqual(store['key3'], undefined, 'key3 should never have been set')
+    })
+
+    it('setIfAbsentBatch loads script once during initialize', async () => {
+      await cache.initialize()
+      assert.ok(mockClient.scriptLoad.calledOnce, 'scriptLoad should be called once on initialize')
+    })
+
+    it('setIfAbsentBatch re-loads script and retries on NOSCRIPT error', async () => {
+      await cache.initialize()
+      mockClient.evalSha
+        .onFirstCall()
+        .rejects(Object.assign(new Error('NOSCRIPT No matching script'), { message: 'NOSCRIPT No matching script' }))
+        .onSecondCall()
+        .resolves(1)
+
+      const result = await cache.setIfAbsentBatch(['key1'], '1', 60)
+      assert.strictEqual(result, true)
+      assert.ok(mockClient.scriptLoad.calledTwice, 'scriptLoad should be called again after NOSCRIPT')
     })
 
     it('throws error if redis connection fails', async () => {
@@ -137,7 +201,9 @@ describe('Redis Cache', () => {
         },
         connect: async () => Promise.resolve(mockClient),
         on: () => {},
-        quit: sinon.stub().resolves()
+        quit: sinon.stub().resolves(),
+        scriptLoad: sinon.stub().resolves('fakeSha'),
+        evalSha: sinon.stub().resolves(1)
       }
       sandbox.stub(RedisCache, 'buildRedisClient').returns(mockClient)
       cache = redisCache({ logger } as any)
@@ -145,7 +211,6 @@ describe('Redis Cache', () => {
 
     afterEach(() => {
       sandbox.restore()
-      // Clear store
       for (const key of Object.keys(store)) {
         delete store[key]
       }
@@ -153,8 +218,8 @@ describe('Redis Cache', () => {
 
     describe('Format Detection', () => {
       it('should detect old binary string format correctly', () => {
-        const oldData = 'xÚ+JMÉ,V°ª5´³0²ä\u0002\u0000\u0011î\u0003ê'
-        const isBase64 = /^[A-Za-z0-9+/]+=*$/.test(oldData)
+        const oldFormatData = '\x78\xDA\x2B\x4A\x4D\xC9\x2C\x56\xB0\xAA\x35\xB4\xB3\x30\xB2\xE4\x02\x00\x11\xEE\x03\xEA'
+        const isBase64 = /^[A-Za-z0-9+/]+=*$/.test(oldFormatData)
         assert.strictEqual(isBase64, false)
       })
 
@@ -312,6 +377,7 @@ describe('Redis Cache', () => {
       })
     })
   })
+
   xdescribe('Integration Test', () => {
     let container
     let redisConfig

--- a/test/providers/caching/redis.ts
+++ b/test/providers/caching/redis.ts
@@ -22,9 +22,13 @@ describe('Redis Cache', () => {
     beforeEach(() => {
       mockClient = {
         get: async key => Promise.resolve(store[key]),
-        set: async (key, value) => {
+        set: sinon.stub().callsFake(async (key, value, options) => {
+          if (options?.condition === 'NX' && store[key] !== undefined && store[key] !== null) {
+            return null
+          }
           store[key] = value
-        },
+          return 'OK'
+        }),
         del: async key => {
           store[key] = null
         },
@@ -66,6 +70,16 @@ describe('Redis Cache', () => {
       await cache.delete('foo')
       const result = await cache.get('foo')
       assert.strictEqual(result, null)
+    })
+
+    it('sets only when absent with Redis condition NX', async () => {
+      await cache.initialize()
+      const first = await cache.setIfAbsent('lock_foo', '1', 120)
+      const second = await cache.setIfAbsent('lock_foo', '1', 120)
+
+      assert.strictEqual(first, true)
+      assert.strictEqual(second, false)
+      assert.ok(mockClient.set.calledWith('lock_foo', '1', { condition: 'NX', EX: 120 }))
     })
 
     it('throws error if redis connection fails', async () => {

--- a/test/providers/caching/redisBatchIntegration.ts
+++ b/test/providers/caching/redisBatchIntegration.ts
@@ -1,0 +1,129 @@
+// (c) Copyright 2026, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import assert from 'node:assert'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { GenericContainer } from 'testcontainers'
+import redisCache from '../../../providers/caching/redis.ts'
+import { createSilentLogger } from '../../helpers/mockLogger.ts'
+
+const logger = createSilentLogger()
+describe('RedisCache setIfAbsentBatch integration', () => {
+  let container: any
+  let cache: ReturnType<typeof redisCache>
+
+  before(async function () {
+    this.timeout(20_000)
+    container = await new GenericContainer('redis').withExposedPorts(6379).start()
+
+    cache = redisCache({
+      service: container.getHost(),
+      port: container.getMappedPort(6379),
+      tls: false,
+      logger
+    }) as any
+
+    await cache.initialize()
+  })
+
+  after(async () => {
+    await cache?.done()
+    await container?.stop()
+  })
+
+  it('acquires all keys atomically in one call', async () => {
+    const keys = ['batch_lock_a', 'batch_lock_b', 'batch_lock_c']
+    const acquired = await cache.setIfAbsentBatch(keys, 'token', 30)
+
+    assert.strictEqual(acquired, true)
+    for (const key of keys) {
+      const value = await cache.client!.get(key)
+      assert.strictEqual(value, 'token')
+    }
+  })
+
+  it('rolls back partial keys on miss', async () => {
+    await cache.client!.set('batch_lock_held', 'held', { EX: 30 })
+
+    const acquired = await cache.setIfAbsentBatch(['batch_lock_first', 'batch_lock_held', 'batch_lock_third'], '1', 30)
+
+    assert.strictEqual(acquired, false)
+    assert.strictEqual(await cache.client!.get('batch_lock_first'), null)
+    assert.strictEqual(await cache.client!.get('batch_lock_held'), 'held')
+    assert.strictEqual(await cache.client!.get('batch_lock_third'), null)
+  })
+
+  it('recovers from NOSCRIPT by re-loading and retrying', async () => {
+    await cache.client!.sendCommand(['SCRIPT', 'FLUSH'])
+
+    const acquired = await cache.setIfAbsentBatch(['batch_lock_noscript'], '1', 30)
+
+    assert.strictEqual(acquired, true)
+    assert.strictEqual(await cache.client!.get('batch_lock_noscript'), '1')
+  })
+
+  it('applies TTL to all batch-acquired keys', async () => {
+    const keys = ['batch_lock_ttl_a', 'batch_lock_ttl_b']
+    const acquired = await cache.setIfAbsentBatch(keys, 'ttl', 1)
+
+    assert.strictEqual(acquired, true)
+    assert.strictEqual(await cache.client!.get(keys[0]), 'ttl')
+    assert.strictEqual(await cache.client!.get(keys[1]), 'ttl')
+
+    await sleep(1_100)
+
+    assert.strictEqual(await cache.client!.get(keys[0]), null)
+    assert.strictEqual(await cache.client!.get(keys[1]), null)
+  })
+
+  it('rolls back all preceding keys when last key is already held', async () => {
+    const lastKey = 'batch_rollback_last'
+    await cache.client!.set(lastKey, 'held', { EX: 30 })
+
+    const acquired = await cache.setIfAbsentBatch(['batch_rollback_a', 'batch_rollback_b', lastKey], '1', 30)
+
+    assert.strictEqual(acquired, false)
+    assert.strictEqual(await cache.client!.get('batch_rollback_a'), null, 'first key should be released')
+    assert.strictEqual(await cache.client!.get('batch_rollback_b'), null, 'second key should be released')
+    assert.strictEqual(await cache.client!.get(lastKey), 'held', 'held key should be untouched')
+  })
+
+  it('re-acquires keys after they are released', async () => {
+    const keys = ['reacquire_a', 'reacquire_b']
+
+    const first = await cache.setIfAbsentBatch(keys, '1', 30)
+    assert.strictEqual(first, true)
+
+    await Promise.all(keys.map(k => cache.client!.del(k)))
+
+    const second = await cache.setIfAbsentBatch(keys, '1', 30)
+    assert.strictEqual(second, true)
+  })
+
+  it('two concurrent callers: exactly one wins all keys', async () => {
+    const keys = ['race_key_a', 'race_key_b', 'race_key_c']
+
+    const cache2 = redisCache({
+      service: container.getHost(),
+      port: container.getMappedPort(6379),
+      tls: false,
+      logger
+    }) as any
+    await cache2.initialize()
+    try {
+      const [r1, r2] = await Promise.all([
+        cache.setIfAbsentBatch(keys, 'caller1', 30),
+        cache2.setIfAbsentBatch(keys, 'caller2', 30)
+      ])
+
+      assert.ok(r1 !== r2, 'exactly one caller should win')
+
+      const winner = r1 ? 'caller1' : 'caller2'
+      for (const key of keys) {
+        assert.strictEqual(await cache.client!.get(key), winner, `${key} should be owned by the winner`)
+      }
+    } finally {
+      await cache2.done()
+    }
+  })
+})

--- a/test/providers/harvest/cacheBasedCrawlerTest.ts
+++ b/test/providers/harvest/cacheBasedCrawlerTest.ts
@@ -5,16 +5,28 @@ import assert from 'node:assert'
 import sinon from 'sinon'
 import cacheBasedHarvester from '../../../providers/harvest/cacheBasedCrawler.ts'
 
+const inflightKey = (coordinates: string): string => `hrv_inflight_${coordinates.toLowerCase()}`
+
 function createCacheMock() {
   return {
     store: {},
+    locks: new Set<string>(),
     async get(key) {
       return this.store[key] || []
     },
     async set(key, value) {
       this.store[key] = value
     },
+    async setIfAbsent(key, value) {
+      if (this.locks.has(key)) {
+        return false
+      }
+      this.locks.add(key)
+      this.store[key] = value
+      return true
+    },
     async delete(key) {
+      this.locks.delete(key)
       delete this.store[key]
     }
   }
@@ -49,7 +61,10 @@ describe('CacheBasedHarvester', () => {
     crawler = cacheBasedHarvester({
       cachingService: cacheMock,
       harvester: harvesterMock,
-      logger: loggerMock as any
+      logger: loggerMock as any,
+      lockRetryDelayMinMs: 1,
+      lockRetryDelayMaxMs: 2,
+      lockAcquireTimeoutMs: 100
     })
   })
 
@@ -113,6 +128,10 @@ describe('CacheBasedHarvester', () => {
       await assert.rejects(async () => {
         await crawler.harvest([foo], false)
       }, 'Expected harvest to throw the harvest errors')
+
+      const key = inflightKey(foo.coordinates)
+      assert.ok(cacheMock.delete.calledWith(key), 'Expected inflight lock to be released after failure')
+      assert.ok(!cacheMock.locks.has(key), 'Expected no inflight lock to remain after failure')
     })
 
     it('handles errors in cache gracefully', async () => {
@@ -120,6 +139,72 @@ describe('CacheBasedHarvester', () => {
       await assert.doesNotReject(async () => {
         await crawler.isTracked(foo.coordinates)
       }, 'Expected isTracked to handle cache errors gracefully')
+    })
+
+    it('serializes concurrent requests for same coordinate', async () => {
+      harvesterMock.harvest.callsFake(async () => {
+        await new Promise(resolve => setTimeout(resolve, 15))
+      })
+
+      await Promise.all([crawler.harvest([foo], false), crawler.harvest([foo], false)])
+
+      assert.strictEqual(harvesterMock.harvest.callCount, 1, 'Expected only one harvest call for same coordinate')
+    })
+
+    it('does not deadlock for opposite coordinate order requests', async () => {
+      harvesterMock.harvest.callsFake(async () => {
+        await new Promise(resolve => setTimeout(resolve, 15))
+      })
+
+      await Promise.all([crawler.harvest([foo, bar], false), crawler.harvest([bar, foo], false)])
+
+      assert.strictEqual(harvesterMock.harvest.callCount, 1, 'Expected one effective harvest due tracked dedup after lock')
+    })
+
+    it('releases partially acquired locks before retrying', async () => {
+      const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
+
+      cacheMock.locks.add(secondKey)
+      setTimeout(() => {
+        cacheMock.locks.delete(secondKey)
+      }, 10)
+
+      await crawler.harvest([foo, bar], false)
+
+      assert.ok(cacheMock.delete.calledWith(firstKey), 'Expected first lock to be released after initial miss')
+      assert.ok(!cacheMock.locks.has(firstKey), 'Expected first lock to be released at end of harvest')
+      assert.ok(!cacheMock.locks.has(secondKey), 'Expected second lock to be released at end of harvest')
+    })
+
+    it('throws when lock acquisition exceeds timeout', async () => {
+      const keyFoo = inflightKey(foo.coordinates)
+      cacheMock.locks.add(keyFoo)
+
+      await assert.rejects(async () => {
+        await crawler.harvest([foo], false)
+      }, /Timed out acquiring harvest coordinate locks/)
+    })
+
+    it('releases partially acquired locks when setIfAbsent throws mid-acquire', async () => {
+      const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
+
+      cacheMock.setIfAbsent = sinon.stub().callsFake(async key => {
+        if (key === firstKey) {
+          cacheMock.locks.add(key)
+          return true
+        }
+        if (key === secondKey) {
+          throw new Error('Redis unavailable')
+        }
+        return false
+      })
+
+      await assert.rejects(async () => {
+        await crawler.harvest([foo, bar], false)
+      }, /Redis unavailable/)
+
+      assert.ok(cacheMock.delete.calledWith(firstKey), 'Expected partially acquired lock to be released on error')
+      assert.ok(!cacheMock.locks.has(firstKey), 'Expected partially acquired lock to be cleared after error')
     })
   })
 

--- a/test/providers/harvest/cacheBasedCrawlerTest.ts
+++ b/test/providers/harvest/cacheBasedCrawlerTest.ts
@@ -4,6 +4,7 @@
 import assert from 'node:assert'
 import sinon from 'sinon'
 import cacheBasedHarvester from '../../../providers/harvest/cacheBasedCrawler.ts'
+import { createMockLogger } from '../../helpers/mockLogger.ts'
 
 const inflightKey = (coordinates: string): string => `hrv_inflight_${coordinates.toLowerCase()}`
 
@@ -46,10 +47,7 @@ describe('CacheBasedHarvester', () => {
   const foo = { coordinates: 'pkg/npm/foo/1.0.0' }
   const bar = { coordinates: 'pkg/npm/bar/2.0.0' }
 
-  const loggerMock = {
-    debug: sinon.stub(),
-    error: sinon.stub()
-  }
+  const loggerMock = createMockLogger()
 
   let cacheMock
   let crawler
@@ -129,14 +127,6 @@ describe('CacheBasedHarvester', () => {
         [bar],
         'Expected harvester to be called with the correct entries'
       )
-    })
-
-    it('does not trigger harvest if all entries are filtered out', async () => {
-      cacheMock.store[cacheKeyFoo] = [foo]
-      cacheMock.store[cacheKeyBar] = [bar]
-      await crawler.harvest(spec, false)
-      assert.ok(harvesterMock.harvest.notCalled, 'Expected harvester not to be called')
-      // Pre-filter returns early before any lock is acquired — no inflight delete expected.
     })
 
     it('skips lock acquisition entirely when pre-filter removes all entries', async () => {
@@ -294,18 +284,6 @@ describe('CacheBasedHarvester', () => {
       assert.ok(!cacheMock.locks.has(secondKey), 'Expected second lock to be released at end of harvest')
     })
 
-    it('times out and cleans up local locks when second key is permanently held', async () => {
-      const [, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
-
-      cacheMock.locks.add(secondKey)
-
-      await assert.rejects(async () => {
-        await crawler.harvest([foo, bar], false)
-      }, /Timed out acquiring inflight harvest coordinate locks/)
-
-      assert.strictEqual(crawler._localInflightKeys.size, 0, 'Expected local inflight table to be fully released')
-    })
-
     it('throws when lock acquisition exceeds timeout', async () => {
       const keyFoo = inflightKey(foo.coordinates)
       cacheMock.locks.add(keyFoo)
@@ -333,6 +311,22 @@ describe('CacheBasedHarvester', () => {
       assert.ok(!cacheMock.locks.has(firstKey), 'No lock should remain for first key after timeout')
       assert.ok(cacheMock.locks.has(secondKey), 'Seeded second key should remain (held by another requester)')
       assert.strictEqual(crawler._localInflightKeys.size, 0, 'Local locks should be fully released after timeout')
+    })
+
+    it('emits a warn log when lock acquisition times out', async () => {
+      loggerMock.warn.resetHistory()
+      const keyFoo = inflightKey(foo.coordinates)
+      cacheMock.locks.add(keyFoo)
+
+      await assert.rejects(async () => {
+        await crawler.harvest([foo], false)
+      }, /Timed out acquiring inflight harvest coordinate locks/)
+
+      assert.ok(loggerMock.warn.calledOnce, 'Expected exactly one warn log on timeout')
+      assert.ok(
+        loggerMock.warn.firstCall.args[0].includes('Timed out acquiring'),
+        'Expected warn message to mention timeout'
+      )
     })
 
     it('uses fixed retry delay when min equals max', async () => {
@@ -438,28 +432,6 @@ describe('CacheBasedHarvester', () => {
       assert.ok(cacheMock.delete.calledWith(keyFoo), 'Expected inflight lock released after swallowed tracking error')
       assert.ok(!cacheMock.locks.has(keyFoo), 'Expected no inflight lock to remain after swallowed tracking error')
       assert.strictEqual(crawler._localInflightKeys.size, 0, 'Expected local inflight table to be fully released')
-    })
-
-    it('runs outer local-release finally after inner redis-release finally when tracking fails', async () => {
-      const releaseOrder: string[] = []
-      cacheMock.set = sinon.stub().rejects(new Error('Cache write error'))
-
-      const originalReleaseInflightKeys = crawler._releaseInflightKeys.bind(crawler)
-      const originalReleaseLocalInflightKeys = crawler._releaseLocalInflightKeys.bind(crawler)
-
-      sinon.stub(crawler, '_releaseInflightKeys').callsFake(async keys => {
-        releaseOrder.push('redis')
-        await originalReleaseInflightKeys(keys)
-      })
-
-      sinon.stub(crawler, '_releaseLocalInflightKeys').callsFake(keys => {
-        releaseOrder.push('local')
-        originalReleaseLocalInflightKeys(keys)
-      })
-
-      await assert.doesNotReject(() => crawler.harvest([foo], false))
-
-      assert.deepStrictEqual(releaseOrder, ['redis', 'local'], 'Expected release ordering to be redis then local')
     })
 
     it('throws when local lock acquisition exceeds timeout', async () => {

--- a/test/providers/harvest/cacheBasedCrawlerTest.ts
+++ b/test/providers/harvest/cacheBasedCrawlerTest.ts
@@ -72,6 +72,7 @@ describe('CacheBasedHarvester', () => {
       lockRetryDelayMaxMs: 2,
       lockAcquireTimeoutMs: 100,
       localLockRetryDelayMs: 1,
+      localLockTimeoutBufferMs: 0,
       ...overrides
     })
 
@@ -579,7 +580,70 @@ describe('CacheBasedHarvester', () => {
       const result = await crawler._filterOutTracked(entries, 10)
 
       assert.strictEqual(result.length, entries.length, 'Expected all entries to pass through when none are tracked')
-      assert.strictEqual(maxInFlight, entries.length, `Expected unthrottled execution when limit >= entries, got ${maxInFlight}`)
+      assert.strictEqual(
+        maxInFlight,
+        entries.length,
+        `Expected unthrottled execution when limit >= entries, got ${maxInFlight}`
+      )
+    })
+  })
+
+  describe('_trackHarvests', () => {
+    it('runs tracking writes unthrottled', async () => {
+      const entries = Array.from({ length: 6 }, (_, index) => ({ coordinates: `pkg/npm/item/${index}` }))
+      let inFlight = 0
+      let maxInFlight = 0
+
+      sinon.stub(crawler, '_track').callsFake(async () => {
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await new Promise(resolve => setTimeout(resolve, 5))
+        inFlight -= 1
+      })
+
+      await assert.doesNotReject(() => crawler._trackHarvests(entries))
+
+      assert.strictEqual(
+        maxInFlight,
+        entries.length,
+        `Expected unthrottled tracking writes, got max concurrency ${maxInFlight}`
+      )
+    })
+
+    it('logs individual tracking failures and resolves', async () => {
+      const entries = [foo, bar]
+      const trackError = new Error('Track write failed')
+
+      loggerMock.error.resetHistory()
+      sinon.stub(crawler, '_track').callsFake(async (entry: any) => {
+        if (entry.coordinates === foo.coordinates) {
+          throw trackError
+        }
+      })
+
+      await assert.doesNotReject(() => crawler._trackHarvests(entries))
+      assert.ok(loggerMock.error.calledWith(trackError), 'Expected rejected track operation to be logged')
+    })
+  })
+
+  describe('_releaseInflightKeys', () => {
+    it('logs delete failures and does not throw', async () => {
+      const deleteError = new Error('Delete failed')
+      const keyFoo = inflightKey(foo.coordinates)
+      const keyBar = inflightKey(bar.coordinates)
+
+      loggerMock.error.resetHistory()
+      cacheMock.delete = sinon.stub().callsFake(async key => {
+        if (key === keyFoo) {
+          throw deleteError
+        }
+      })
+
+      await assert.doesNotReject(() => crawler._releaseInflightKeys([keyFoo, keyBar]))
+      assert.ok(
+        loggerMock.error.calledWith('Error releasing inflight lock', deleteError),
+        'Expected release failure to be logged'
+      )
     })
   })
 

--- a/test/providers/harvest/cacheBasedCrawlerTest.ts
+++ b/test/providers/harvest/cacheBasedCrawlerTest.ts
@@ -143,14 +143,80 @@ describe('CacheBasedHarvester', () => {
       cacheMock.store[cacheKeyBar] = [bar]
       await crawler.harvest(spec, false)
       assert.ok(harvesterMock.harvest.notCalled, 'Expected harvester not to be called')
-      assert.ok(
-        cacheMock.delete.calledWith(inflightKey(foo.coordinates)),
-        'Expected inflight lock for foo to be released'
+      // Pre-filter returns early before any lock is acquired — no inflight delete expected.
+    })
+
+    it('skips lock acquisition entirely when pre-filter removes all entries', async () => {
+      const setIfAbsentBatchSpy = sinon.spy(cacheMock, 'setIfAbsentBatch')
+      cacheMock.store[cacheKeyFoo] = [foo]
+      cacheMock.store[cacheKeyBar] = [bar]
+      await crawler.harvest(spec, false)
+      assert.ok(harvesterMock.harvest.notCalled, 'Expected harvester not to be called')
+      assert.ok(setIfAbsentBatchSpy.notCalled, 'Expected no Redis lock acquisition when pre-filter removes all entries')
+      assert.strictEqual(crawler._localInflightKeys.size, 0, 'Expected local inflight table to remain empty')
+    })
+
+    it('acquires locks only for untracked entries after pre-filter', async () => {
+      const setIfAbsentBatchSpy = sinon.spy(cacheMock, 'setIfAbsentBatch')
+      const localAcquireSpy = sinon.spy(crawler, '_acquireSortedLocalInflightKeys')
+      cacheMock.store[cacheKeyFoo] = [foo]
+      await crawler.harvest(spec, false)
+      const expectedKey = inflightKey(bar.coordinates)
+      assert.strictEqual(setIfAbsentBatchSpy.callCount, 1, 'setIfAbsentBatch should be called once (for bar only)')
+      assert.deepStrictEqual(
+        setIfAbsentBatchSpy.getCall(0).args[0],
+        [expectedKey],
+        'Expected Redis lock batch to contain only the untracked entry key'
       )
-      assert.ok(
-        cacheMock.delete.calledWith(inflightKey(bar.coordinates)),
-        'Expected inflight lock for bar to be released'
+      assert.deepStrictEqual(
+        localAcquireSpy.getCall(0).args[0],
+        [expectedKey],
+        'Expected local lock acquisition to contain only the untracked entry key'
       )
+      assert.deepStrictEqual(
+        harvesterMock.harvest.args[0][0],
+        [bar],
+        'Expected harvester to be called with only the untracked entry'
+      )
+    })
+
+    it('uses configured concurrency for outer pre-filter and leaves in-lock recheck unthrottled', async () => {
+      crawler = createCrawler({ concurrencyLimit: 7 })
+      const filterSpy = sinon.spy(crawler, '_filterOutTracked')
+      cacheMock.store[cacheKeyFoo] = [foo]
+
+      await crawler.harvest(spec, false)
+
+      // Fixture expectation: foo is pre-tracked, so pre-filter returns [bar] and in-lock recheck still runs.
+      assert.strictEqual(filterSpy.callCount, 2, 'Expected pre-filter and in-lock recheck calls')
+      assert.deepStrictEqual(filterSpy.getCall(0).args[0], spec, 'Expected outer pre-filter call with original spec')
+      assert.deepStrictEqual(
+        filterSpy.getCall(1).args[0],
+        [bar],
+        'Expected in-lock recheck call with candidate entries'
+      )
+      assert.strictEqual(filterSpy.getCall(0).args[1], 7, 'Expected outer pre-filter to use configured concurrency')
+      assert.strictEqual(filterSpy.getCall(1).args[1], undefined, 'Expected in-lock recheck to remain unthrottled')
+    })
+
+    it('releases inflight locks only for candidate entries after pre-filter', async () => {
+      const deleteSpy = cacheMock.delete
+      cacheMock.store[cacheKeyFoo] = [foo]
+
+      await crawler.harvest(spec, false)
+
+      assert.ok(deleteSpy.calledWith(inflightKey(bar.coordinates)), 'Expected inflight lock release for untracked bar')
+      assert.ok(
+        deleteSpy.neverCalledWith(inflightKey(foo.coordinates)),
+        'Expected no inflight lock release for pre-filtered foo'
+      )
+      assert.strictEqual(deleteSpy.callCount, 1, 'Expected exactly one inflight lock release')
+    })
+
+    it('proceeds through pre-filter and dispatches harvest when cache.get throws', async () => {
+      cacheMock.get = sinon.stub().rejects(new Error('Cache read error'))
+      await assert.doesNotReject(() => crawler.harvest([foo], false))
+      assert.ok(harvesterMock.harvest.calledOnce, 'Expected harvest to proceed when pre-filter cache reads fail')
     })
 
     it('does not call harvester if no entries are provided', async () => {
@@ -385,12 +451,12 @@ describe('CacheBasedHarvester', () => {
       const releaseOrder: string[] = []
       cacheMock.set = sinon.stub().rejects(new Error('Cache write error'))
 
-      const originalReleaseInflightLocks = crawler._releaseInflightLocks.bind(crawler)
+      const originalReleaseInflightKeys = crawler._releaseInflightKeys.bind(crawler)
       const originalReleaseLocalInflightKeys = crawler._releaseLocalInflightKeys.bind(crawler)
 
-      sinon.stub(crawler, '_releaseInflightLocks').callsFake(async entries => {
+      sinon.stub(crawler, '_releaseInflightKeys').callsFake(async keys => {
         releaseOrder.push('redis')
-        await originalReleaseInflightLocks(entries)
+        await originalReleaseInflightKeys(keys)
       })
 
       sinon.stub(crawler, '_releaseLocalInflightKeys').callsFake(keys => {
@@ -474,6 +540,46 @@ describe('CacheBasedHarvester', () => {
       const result = await crawler.isTracked('')
       assert.strictEqual(result, false)
       assert.ok(cacheMock.get.notCalled, 'Expected cache get not to be called')
+    })
+  })
+
+  describe('_filterOutTracked', () => {
+    it('caps parallel tracking checks when concurrency is provided', async () => {
+      const entries = Array.from({ length: 6 }, (_, index) => ({ coordinates: `pkg/npm/item/${index}` }))
+      let inFlight = 0
+      let maxInFlight = 0
+
+      sinon.stub(crawler, '_isTrackedHarvest').callsFake(async () => {
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await new Promise(resolve => setTimeout(resolve, 5))
+        inFlight -= 1
+        return false
+      })
+
+      const result = await crawler._filterOutTracked(entries, 2)
+
+      assert.strictEqual(result.length, entries.length, 'Expected all entries to pass through when none are tracked')
+      assert.ok(maxInFlight <= 2, `Expected max concurrent checks <= 2, got ${maxInFlight}`)
+    })
+
+    it('bypasses throat when concurrency is greater than or equal to entry count', async () => {
+      const entries = Array.from({ length: 6 }, (_, index) => ({ coordinates: `pkg/npm/item/${index}` }))
+      let inFlight = 0
+      let maxInFlight = 0
+
+      sinon.stub(crawler, '_isTrackedHarvest').callsFake(async () => {
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await new Promise(resolve => setTimeout(resolve, 5))
+        inFlight -= 1
+        return false
+      })
+
+      const result = await crawler._filterOutTracked(entries, 10)
+
+      assert.strictEqual(result.length, entries.length, 'Expected all entries to pass through when none are tracked')
+      assert.strictEqual(maxInFlight, entries.length, `Expected unthrottled execution when limit >= entries, got ${maxInFlight}`)
     })
   })
 

--- a/test/providers/harvest/cacheBasedCrawlerTest.ts
+++ b/test/providers/harvest/cacheBasedCrawlerTest.ts
@@ -47,6 +47,23 @@ describe('CacheBasedHarvester', () => {
   let crawler
   let harvesterMock
 
+  const createCrawler = (overrides = {}) =>
+    cacheBasedHarvester({
+      cachingService: cacheMock,
+      harvester: harvesterMock,
+      logger: loggerMock as any,
+      lockRetryDelayMinMs: 1,
+      lockRetryDelayMaxMs: 2,
+      lockAcquireTimeoutMs: 100,
+      ...overrides
+    })
+
+  const addHarvesterDelay = (delayMs = 15) => {
+    harvesterMock.harvest.callsFake(async () => {
+      await new Promise(resolve => setTimeout(resolve, delayMs))
+    })
+  }
+
   beforeEach(() => {
     harvesterMock = {
       harvest: sinon.stub(),
@@ -58,14 +75,7 @@ describe('CacheBasedHarvester', () => {
     sinon.spy(cacheMock, 'set')
     sinon.spy(cacheMock, 'delete')
 
-    crawler = cacheBasedHarvester({
-      cachingService: cacheMock,
-      harvester: harvesterMock,
-      logger: loggerMock as any,
-      lockRetryDelayMinMs: 1,
-      lockRetryDelayMaxMs: 2,
-      lockAcquireTimeoutMs: 100
-    })
+    crawler = createCrawler()
   })
 
   describe('harvest', () => {
@@ -129,9 +139,11 @@ describe('CacheBasedHarvester', () => {
         await crawler.harvest([foo], false)
       }, 'Expected harvest to throw the harvest errors')
 
-      const key = inflightKey(foo.coordinates)
-      assert.ok(cacheMock.delete.calledWith(key), 'Expected inflight lock to be released after failure')
-      assert.ok(!cacheMock.locks.has(key), 'Expected no inflight lock to remain after failure')
+      assert.ok(
+        cacheMock.delete.calledWith(inflightKey(foo.coordinates)),
+        'Expected inflight lock to be released after failure'
+      )
+      assert.ok(!cacheMock.locks.has(inflightKey(foo.coordinates)), 'Expected no inflight lock to remain after failure')
     })
 
     it('handles errors in cache gracefully', async () => {
@@ -142,9 +154,7 @@ describe('CacheBasedHarvester', () => {
     })
 
     it('serializes concurrent requests for same coordinate', async () => {
-      harvesterMock.harvest.callsFake(async () => {
-        await new Promise(resolve => setTimeout(resolve, 15))
-      })
+      addHarvesterDelay()
 
       await Promise.all([crawler.harvest([foo], false), crawler.harvest([foo], false)])
 
@@ -152,13 +162,38 @@ describe('CacheBasedHarvester', () => {
     })
 
     it('does not deadlock for opposite coordinate order requests', async () => {
-      harvesterMock.harvest.callsFake(async () => {
-        await new Promise(resolve => setTimeout(resolve, 15))
-      })
+      addHarvesterDelay()
 
       await Promise.all([crawler.harvest([foo, bar], false), crawler.harvest([bar, foo], false)])
 
-      assert.strictEqual(harvesterMock.harvest.callCount, 1, 'Expected one effective harvest due tracked dedup after lock')
+      assert.strictEqual(
+        harvesterMock.harvest.callCount,
+        1,
+        'Expected one effective harvest due tracked dedup after lock'
+      )
+    })
+
+    it('acquires inflight locks in sorted key order through harvest', async () => {
+      sinon.spy(cacheMock, 'setIfAbsent')
+
+      await crawler.harvest([bar, foo], false)
+
+      const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
+      assert.strictEqual(cacheMock.setIfAbsent.getCall(0).args[0], firstKey, 'First call should use first sorted key')
+      assert.strictEqual(
+        cacheMock.setIfAbsent.getCall(1).args[0],
+        secondKey,
+        'Second call should use second sorted key'
+      )
+    })
+
+    it('normalizes inflight key casing through harvest', async () => {
+      const mixedCase = { coordinates: 'NPM/npmjs/-/LODASH/4.0.0' }
+      sinon.spy(cacheMock, 'setIfAbsent')
+
+      await crawler.harvest([mixedCase], false)
+
+      assert.strictEqual(cacheMock.setIfAbsent.getCall(0).args[0], 'hrv_inflight_npm/npmjs/-/lodash/4.0.0')
     })
 
     it('releases partially acquired locks before retrying', async () => {
@@ -185,6 +220,34 @@ describe('CacheBasedHarvester', () => {
       }, /Timed out acquiring harvest coordinate locks/)
     })
 
+    it('uses fixed retry delay when min equals max', async () => {
+      const fixedDelayMs = 7
+      const keyFoo = inflightKey(foo.coordinates)
+      cacheMock.locks.add(keyFoo)
+
+      const crawlerWithFixedDelay = createCrawler({
+        lockRetryDelayMinMs: fixedDelayMs,
+        lockRetryDelayMaxMs: fixedDelayMs,
+        lockAcquireTimeoutMs: 40
+      })
+
+      sinon.spy(cacheMock, 'setIfAbsent')
+      const clock = sinon.useFakeTimers()
+      try {
+        const pending = crawlerWithFixedDelay.harvest([foo], false)
+        const rejection = assert.rejects(pending, /Timed out acquiring harvest coordinate locks/)
+        await clock.tickAsync(100)
+        await rejection
+
+        assert.ok(
+          cacheMock.setIfAbsent.callCount >= 2,
+          'Expected multiple lock attempts while retrying with fixed delay before timing out'
+        )
+      } finally {
+        clock.restore()
+      }
+    })
+
     it('releases partially acquired locks when setIfAbsent throws mid-acquire', async () => {
       const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
 
@@ -205,6 +268,25 @@ describe('CacheBasedHarvester', () => {
 
       assert.ok(cacheMock.delete.calledWith(firstKey), 'Expected partially acquired lock to be released on error')
       assert.ok(!cacheMock.locks.has(firstKey), 'Expected partially acquired lock to be cleared after error')
+    })
+
+    it('processes independent coordinates concurrently without blocking each other', async () => {
+      await Promise.all([crawler.harvest([foo], false), crawler.harvest([bar], false)])
+
+      assert.strictEqual(harvesterMock.harvest.callCount, 2, 'Both independent coordinates should be harvested')
+      const harvested = harvesterMock.harvest.args.map(([entries]) => entries[0].coordinates)
+      assert.ok(harvested.includes(foo.coordinates), 'Expected foo to be harvested')
+      assert.ok(harvested.includes(bar.coordinates), 'Expected bar to be harvested')
+    })
+
+    it('resolves normally and releases inflight locks when tracking fails', async () => {
+      cacheMock.set = sinon.stub().rejects(new Error('Cache write error'))
+
+      await assert.doesNotReject(() => crawler.harvest([foo], false))
+
+      const keyFoo = inflightKey(foo.coordinates)
+      assert.ok(cacheMock.delete.calledWith(keyFoo), 'Expected inflight lock released after swallowed tracking error')
+      assert.ok(!cacheMock.locks.has(keyFoo), 'Expected no inflight lock to remain after swallowed tracking error')
     })
   })
 

--- a/test/providers/harvest/cacheBasedCrawlerTest.ts
+++ b/test/providers/harvest/cacheBasedCrawlerTest.ts
@@ -136,7 +136,16 @@ describe('CacheBasedHarvester', () => {
       await crawler.harvest(spec, false)
       assert.ok(harvesterMock.harvest.notCalled, 'Expected harvester not to be called')
       assert.ok(setIfAbsentBatchSpy.notCalled, 'Expected no Redis lock acquisition when pre-filter removes all entries')
-      assert.strictEqual(crawler._localInflightKeys.size, 0, 'Expected local inflight table to remain empty')
+      assert.strictEqual(
+        crawler._localInflightKeys.get(inflightKey(foo.coordinates)),
+        null,
+        'Expected local inflight table to remain empty'
+      )
+      assert.strictEqual(
+        crawler._localInflightKeys.get(inflightKey(bar.coordinates)),
+        null,
+        'Expected local inflight table to remain empty'
+      )
     })
 
     it('acquires locks only for untracked entries after pre-filter', async () => {
@@ -292,7 +301,11 @@ describe('CacheBasedHarvester', () => {
         await crawler.harvest([foo], false)
       }, /Timed out acquiring inflight harvest coordinate locks/)
 
-      assert.strictEqual(crawler._localInflightKeys.size, 0, 'Expected local inflight table to be fully released')
+      assert.strictEqual(
+        crawler._localInflightKeys.get(keyFoo),
+        null,
+        'Expected local inflight table to be fully released'
+      )
       assert.strictEqual(
         cacheMock.locks.size,
         1,
@@ -310,7 +323,16 @@ describe('CacheBasedHarvester', () => {
 
       assert.ok(!cacheMock.locks.has(firstKey), 'No lock should remain for first key after timeout')
       assert.ok(cacheMock.locks.has(secondKey), 'Seeded second key should remain (held by another requester)')
-      assert.strictEqual(crawler._localInflightKeys.size, 0, 'Local locks should be fully released after timeout')
+      assert.strictEqual(
+        crawler._localInflightKeys.get(firstKey),
+        null,
+        'Local locks should be fully released after timeout'
+      )
+      assert.strictEqual(
+        crawler._localInflightKeys.get(secondKey),
+        null,
+        'Local locks should be fully released after timeout'
+      )
     })
 
     it('emits a warn log when lock acquisition times out', async () => {
@@ -431,12 +453,16 @@ describe('CacheBasedHarvester', () => {
       const keyFoo = inflightKey(foo.coordinates)
       assert.ok(cacheMock.delete.calledWith(keyFoo), 'Expected inflight lock released after swallowed tracking error')
       assert.ok(!cacheMock.locks.has(keyFoo), 'Expected no inflight lock to remain after swallowed tracking error')
-      assert.strictEqual(crawler._localInflightKeys.size, 0, 'Expected local inflight table to be fully released')
+      assert.strictEqual(
+        crawler._localInflightKeys.get(keyFoo),
+        null,
+        'Expected local inflight table to be fully released'
+      )
     })
 
     it('throws when local lock acquisition exceeds timeout', async () => {
       const keyFoo = inflightKey(foo.coordinates)
-      crawler._localInflightKeys.add(keyFoo)
+      crawler._localInflightKeys.set(keyFoo, '1', 35)
       sinon.spy(cacheMock, 'setIfAbsentBatch')
 
       await assert.rejects(
@@ -449,8 +475,8 @@ describe('CacheBasedHarvester', () => {
         'Redis setIfAbsentBatch should not be called when local times out'
       )
       assert.strictEqual(
-        crawler._localInflightKeys.size,
-        1,
+        crawler._localInflightKeys.get(keyFoo),
+        '1',
         'Only the pre-seeded key should remain — no extra local keys leaked by harvest'
       )
     })

--- a/test/providers/harvest/cacheBasedCrawlerTest.ts
+++ b/test/providers/harvest/cacheBasedCrawlerTest.ts
@@ -25,6 +25,22 @@ function createCacheMock() {
       this.store[key] = value
       return true
     },
+    async setIfAbsentBatch(keys: string[], value: string) {
+      const acquired: string[] = []
+      for (const key of keys) {
+        if (this.locks.has(key)) {
+          for (const k of acquired) {
+            this.locks.delete(k)
+            delete this.store[k]
+          }
+          return false
+        }
+        this.locks.add(key)
+        this.store[key] = value
+        acquired.push(key)
+      }
+      return true
+    },
     async delete(key) {
       this.locks.delete(key)
       delete this.store[key]
@@ -183,26 +199,25 @@ describe('CacheBasedHarvester', () => {
     })
 
     it('acquires inflight locks in sorted key order through harvest', async () => {
-      sinon.spy(cacheMock, 'setIfAbsent')
+      sinon.spy(cacheMock, 'setIfAbsentBatch')
 
       await crawler.harvest([bar, foo], false)
 
-      const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
-      assert.strictEqual(cacheMock.setIfAbsent.getCall(0).args[0], firstKey, 'First call should use first sorted key')
-      assert.strictEqual(
-        cacheMock.setIfAbsent.getCall(1).args[0],
-        secondKey,
-        'Second call should use second sorted key'
+      const sortedKeys = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
+      assert.deepStrictEqual(
+        cacheMock.setIfAbsentBatch.getCall(0).args[0],
+        sortedKeys,
+        'setIfAbsentBatch should be called with keys in sorted order'
       )
     })
 
     it('normalizes inflight key casing through harvest', async () => {
       const mixedCase = { coordinates: 'NPM/npmjs/-/LODASH/4.0.0' }
-      sinon.spy(cacheMock, 'setIfAbsent')
+      sinon.spy(cacheMock, 'setIfAbsentBatch')
 
       await crawler.harvest([mixedCase], false)
 
-      assert.strictEqual(cacheMock.setIfAbsent.getCall(0).args[0], 'hrv_inflight_npm/npmjs/-/lodash/4.0.0')
+      assert.deepStrictEqual(cacheMock.setIfAbsentBatch.getCall(0).args[0], ['hrv_inflight_npm/npmjs/-/lodash/4.0.0'])
     })
 
     it('releases partially acquired locks before retrying', async () => {
@@ -220,20 +235,14 @@ describe('CacheBasedHarvester', () => {
       assert.ok(!cacheMock.locks.has(secondKey), 'Expected second lock to be released at end of harvest')
     })
 
-    it('throws aggregate release error when partial-lock release fails in retry path', async () => {
-      const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
+    it('times out and cleans up local locks when second key is permanently held', async () => {
+      const [, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
 
       cacheMock.locks.add(secondKey)
-      cacheMock.delete = sinon.stub().callsFake(async key => {
-        if (key === firstKey) {
-          throw new Error('Release failed')
-        }
-        cacheMock.locks.delete(key)
-      })
 
       await assert.rejects(async () => {
         await crawler.harvest([foo, bar], false)
-      }, /Failed to release 1 inflight lock\(s\)/)
+      }, /Timed out acquiring inflight harvest coordinate locks/)
 
       assert.strictEqual(crawler._localInflightKeys.size, 0, 'Expected local inflight table to be fully released')
     })
@@ -254,7 +263,7 @@ describe('CacheBasedHarvester', () => {
       )
     })
 
-    it('releases partially acquired redis locks when timeout occurs mid-multi-key acquisition', async () => {
+    it('times out cleanly when one key is held throughout, leaving no leaked locks', async () => {
       const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
       cacheMock.locks.add(secondKey)
 
@@ -262,7 +271,7 @@ describe('CacheBasedHarvester', () => {
         await crawler.harvest([foo, bar], false)
       }, /Timed out acquiring inflight harvest coordinate locks/)
 
-      assert.ok(!cacheMock.locks.has(firstKey), 'Partially acquired first key should be released after timeout')
+      assert.ok(!cacheMock.locks.has(firstKey), 'No lock should remain for first key after timeout')
       assert.ok(cacheMock.locks.has(secondKey), 'Seeded second key should remain (held by another requester)')
       assert.strictEqual(crawler._localInflightKeys.size, 0, 'Local locks should be fully released after timeout')
     })
@@ -278,7 +287,7 @@ describe('CacheBasedHarvester', () => {
         lockAcquireTimeoutMs: 40
       })
 
-      sinon.spy(cacheMock, 'setIfAbsent')
+      sinon.spy(cacheMock, 'setIfAbsentBatch')
       const clock = sinon.useFakeTimers()
       try {
         const pending = crawlerWithFixedDelay.harvest([foo], false)
@@ -287,7 +296,7 @@ describe('CacheBasedHarvester', () => {
         await rejection
 
         assert.ok(
-          cacheMock.setIfAbsent.callCount >= 2,
+          cacheMock.setIfAbsentBatch.callCount >= 2,
           'Expected multiple lock attempts while retrying with fixed delay before timing out'
         )
       } finally {
@@ -295,57 +304,49 @@ describe('CacheBasedHarvester', () => {
       }
     })
 
-    it('releases partially acquired locks when setIfAbsent throws mid-acquire', async () => {
+    it('releases all keys when setIfAbsentBatch throws', async () => {
       const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
 
-      cacheMock.setIfAbsent = sinon.stub().callsFake(async key => {
-        if (key === firstKey) {
-          cacheMock.locks.add(key)
-          return true
-        }
-        if (key === secondKey) {
-          throw new Error('Redis unavailable')
-        }
-        return false
+      cacheMock.setIfAbsentBatch = sinon.stub().callsFake(async (_keys: string[]) => {
+        // Simulate: script acquired some keys server-side before throwing
+        cacheMock.locks.add(firstKey)
+        throw new Error('Redis unavailable')
       })
 
       await assert.rejects(async () => {
         await crawler.harvest([foo, bar], false)
       }, /Redis unavailable/)
 
-      assert.ok(cacheMock.delete.calledWith(firstKey), 'Expected partially acquired lock to be released on error')
-      assert.ok(!cacheMock.locks.has(firstKey), 'Expected partially acquired lock to be cleared after error')
+      assert.ok(cacheMock.delete.calledWith(firstKey), 'Expected all keys to be released on error')
+      assert.ok(cacheMock.delete.calledWith(secondKey), 'Expected all keys to be released on error')
     })
 
-    it('does not attempt lock release when setIfAbsent throws on first key', async () => {
+    it('releases all keys as safety net when setIfAbsentBatch throws without acquiring any', async () => {
+      const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
+
+      cacheMock.setIfAbsentBatch = sinon.stub().callsFake(async () => {
+        throw new Error('Redis unavailable')
+      })
+
+      await assert.rejects(async () => {
+        await crawler.harvest([foo, bar], false)
+      }, /Redis unavailable/)
+
+      assert.ok(
+        cacheMock.delete.calledWith(firstKey),
+        'Expected safety release of first key even with no keys acquired'
+      )
+      assert.ok(
+        cacheMock.delete.calledWith(secondKey),
+        'Expected safety release of second key even with no keys acquired'
+      )
+    })
+
+    it('rethrows setIfAbsentBatch error even when safety release also fails', async () => {
       const [firstKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
 
-      cacheMock.setIfAbsent = sinon.stub().callsFake(async key => {
-        if (key === firstKey) {
-          throw new Error('Redis unavailable')
-        }
-        return false
-      })
-
-      await assert.rejects(async () => {
-        await crawler.harvest([foo, bar], false)
-      }, /Redis unavailable/)
-
-      assert.ok(cacheMock.delete.notCalled, 'Expected no delete calls when no lock was acquired')
-    })
-
-    it('rethrows original setIfAbsent error when partial lock release also fails', async () => {
-      const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
-
-      cacheMock.setIfAbsent = sinon.stub().callsFake(async key => {
-        if (key === firstKey) {
-          cacheMock.locks.add(key)
-          return true
-        }
-        if (key === secondKey) {
-          throw new Error('Redis unavailable')
-        }
-        return false
+      cacheMock.setIfAbsentBatch = sinon.stub().callsFake(async () => {
+        throw new Error('Redis unavailable')
       })
 
       cacheMock.delete = sinon.stub().callsFake(async key => {
@@ -405,14 +406,17 @@ describe('CacheBasedHarvester', () => {
     it('throws when local lock acquisition exceeds timeout', async () => {
       const keyFoo = inflightKey(foo.coordinates)
       crawler._localInflightKeys.add(keyFoo)
-      sinon.spy(cacheMock, 'setIfAbsent')
+      sinon.spy(cacheMock, 'setIfAbsentBatch')
 
       await assert.rejects(
         () => crawler.harvest([foo], false),
         /Timed out acquiring local inflight harvest coordinate locks/
       )
 
-      assert.ok(cacheMock.setIfAbsent.notCalled, 'Redis setIfAbsent should not be called when local times out')
+      assert.ok(
+        cacheMock.setIfAbsentBatch.notCalled,
+        'Redis setIfAbsentBatch should not be called when local times out'
+      )
       assert.strictEqual(
         crawler._localInflightKeys.size,
         1,
@@ -422,15 +426,15 @@ describe('CacheBasedHarvester', () => {
 
     it('local gate prevents simultaneous Redis acquire attempts for same-instance concurrent requests', async () => {
       addHarvesterDelay(15)
-      sinon.spy(cacheMock, 'setIfAbsent')
+      sinon.spy(cacheMock, 'setIfAbsentBatch')
 
       await Promise.all([crawler.harvest([foo], false), crawler.harvest([foo], false)])
 
       assert.strictEqual(harvesterMock.harvest.callCount, 1, 'Only one harvest dispatched')
-      // With local gate: each request acquires Redis lock exactly once, no retry contention.
-      // Without local gate: requests race at Redis and setIfAbsent is called many more times.
+      // With local gate: each request calls setIfAbsentBatch exactly once, no retry contention.
+      // Without local gate: requests race at Redis and setIfAbsentBatch is called many more times.
       assert.strictEqual(
-        cacheMock.setIfAbsent.callCount,
+        cacheMock.setIfAbsentBatch.callCount,
         2,
         'Each request hits Redis exactly once — local gate prevents simultaneous Redis contention'
       )
@@ -504,6 +508,13 @@ describe('CacheBasedHarvester', () => {
       assert.ok(cacheMock.delete.calledOnce, 'Expected cache delete to be called')
       isBarTracked = await crawler.isTracked(bar.coordinates)
       assert.ok(!isBarTracked, 'Expected cache to not be set for bar')
+    })
+
+    it('resolves and logs when cache.delete throws', async () => {
+      cacheMock.delete = sinon.stub().rejects(new Error('Cache error'))
+
+      await assert.doesNotReject(() => crawler.done(foo.coordinates))
+      assert.ok(loggerMock.error.called, 'Expected error to be logged')
     })
   })
 

--- a/test/providers/harvest/cacheBasedCrawlerTest.ts
+++ b/test/providers/harvest/cacheBasedCrawlerTest.ts
@@ -126,6 +126,14 @@ describe('CacheBasedHarvester', () => {
       cacheMock.store[cacheKeyBar] = [bar]
       await crawler.harvest(spec, false)
       assert.ok(harvesterMock.harvest.notCalled, 'Expected harvester not to be called')
+      assert.ok(
+        cacheMock.delete.calledWith(inflightKey(foo.coordinates)),
+        'Expected inflight lock for foo to be released'
+      )
+      assert.ok(
+        cacheMock.delete.calledWith(inflightKey(bar.coordinates)),
+        'Expected inflight lock for bar to be released'
+      )
     })
 
     it('does not call harvester if no entries are provided', async () => {
@@ -211,6 +219,22 @@ describe('CacheBasedHarvester', () => {
       assert.ok(!cacheMock.locks.has(secondKey), 'Expected second lock to be released at end of harvest')
     })
 
+    it('throws aggregate release error when partial-lock release fails in retry path', async () => {
+      const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
+
+      cacheMock.locks.add(secondKey)
+      cacheMock.delete = sinon.stub().callsFake(async key => {
+        if (key === firstKey) {
+          throw new Error('Release failed')
+        }
+        cacheMock.locks.delete(key)
+      })
+
+      await assert.rejects(async () => {
+        await crawler.harvest([foo, bar], false)
+      }, /Failed to release 1 inflight lock\(s\)/)
+    })
+
     it('throws when lock acquisition exceeds timeout', async () => {
       const keyFoo = inflightKey(foo.coordinates)
       cacheMock.locks.add(keyFoo)
@@ -268,6 +292,49 @@ describe('CacheBasedHarvester', () => {
 
       assert.ok(cacheMock.delete.calledWith(firstKey), 'Expected partially acquired lock to be released on error')
       assert.ok(!cacheMock.locks.has(firstKey), 'Expected partially acquired lock to be cleared after error')
+    })
+
+    it('does not attempt lock release when setIfAbsent throws on first key', async () => {
+      const [firstKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
+
+      cacheMock.setIfAbsent = sinon.stub().callsFake(async key => {
+        if (key === firstKey) {
+          throw new Error('Redis unavailable')
+        }
+        return false
+      })
+
+      await assert.rejects(async () => {
+        await crawler.harvest([foo, bar], false)
+      }, /Redis unavailable/)
+
+      assert.ok(cacheMock.delete.notCalled, 'Expected no delete calls when no lock was acquired')
+    })
+
+    it('rethrows original setIfAbsent error when partial lock release also fails', async () => {
+      const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
+
+      cacheMock.setIfAbsent = sinon.stub().callsFake(async key => {
+        if (key === firstKey) {
+          cacheMock.locks.add(key)
+          return true
+        }
+        if (key === secondKey) {
+          throw new Error('Redis unavailable')
+        }
+        return false
+      })
+
+      cacheMock.delete = sinon.stub().callsFake(async key => {
+        if (key === firstKey) {
+          throw new Error('Release failed')
+        }
+        cacheMock.locks.delete(key)
+      })
+
+      await assert.rejects(async () => {
+        await crawler.harvest([foo, bar], false)
+      }, /Redis unavailable/)
     })
 
     it('processes independent coordinates concurrently without blocking each other', async () => {

--- a/test/providers/harvest/cacheBasedCrawlerTest.ts
+++ b/test/providers/harvest/cacheBasedCrawlerTest.ts
@@ -55,6 +55,7 @@ describe('CacheBasedHarvester', () => {
       lockRetryDelayMinMs: 1,
       lockRetryDelayMaxMs: 2,
       lockAcquireTimeoutMs: 100,
+      localLockRetryDelayMs: 1,
       ...overrides
     })
 
@@ -233,6 +234,8 @@ describe('CacheBasedHarvester', () => {
       await assert.rejects(async () => {
         await crawler.harvest([foo, bar], false)
       }, /Failed to release 1 inflight lock\(s\)/)
+
+      assert.strictEqual(crawler._localInflightKeys.size, 0, 'Expected local inflight table to be fully released')
     })
 
     it('throws when lock acquisition exceeds timeout', async () => {
@@ -241,7 +244,27 @@ describe('CacheBasedHarvester', () => {
 
       await assert.rejects(async () => {
         await crawler.harvest([foo], false)
-      }, /Timed out acquiring harvest coordinate locks/)
+      }, /Timed out acquiring inflight harvest coordinate locks/)
+
+      assert.strictEqual(crawler._localInflightKeys.size, 0, 'Expected local inflight table to be fully released')
+      assert.strictEqual(
+        cacheMock.locks.size,
+        1,
+        'Only the seeded key should remain in Redis — no locks leaked by harvest'
+      )
+    })
+
+    it('releases partially acquired redis locks when timeout occurs mid-multi-key acquisition', async () => {
+      const [firstKey, secondKey] = [inflightKey(foo.coordinates), inflightKey(bar.coordinates)].sort()
+      cacheMock.locks.add(secondKey)
+
+      await assert.rejects(async () => {
+        await crawler.harvest([foo, bar], false)
+      }, /Timed out acquiring inflight harvest coordinate locks/)
+
+      assert.ok(!cacheMock.locks.has(firstKey), 'Partially acquired first key should be released after timeout')
+      assert.ok(cacheMock.locks.has(secondKey), 'Seeded second key should remain (held by another requester)')
+      assert.strictEqual(crawler._localInflightKeys.size, 0, 'Local locks should be fully released after timeout')
     })
 
     it('uses fixed retry delay when min equals max', async () => {
@@ -259,7 +282,7 @@ describe('CacheBasedHarvester', () => {
       const clock = sinon.useFakeTimers()
       try {
         const pending = crawlerWithFixedDelay.harvest([foo], false)
-        const rejection = assert.rejects(pending, /Timed out acquiring harvest coordinate locks/)
+        const rejection = assert.rejects(pending, /Timed out acquiring inflight harvest coordinate locks/)
         await clock.tickAsync(100)
         await rejection
 
@@ -354,6 +377,63 @@ describe('CacheBasedHarvester', () => {
       const keyFoo = inflightKey(foo.coordinates)
       assert.ok(cacheMock.delete.calledWith(keyFoo), 'Expected inflight lock released after swallowed tracking error')
       assert.ok(!cacheMock.locks.has(keyFoo), 'Expected no inflight lock to remain after swallowed tracking error')
+      assert.strictEqual(crawler._localInflightKeys.size, 0, 'Expected local inflight table to be fully released')
+    })
+
+    it('runs outer local-release finally after inner redis-release finally when tracking fails', async () => {
+      const releaseOrder: string[] = []
+      cacheMock.set = sinon.stub().rejects(new Error('Cache write error'))
+
+      const originalReleaseInflightLocks = crawler._releaseInflightLocks.bind(crawler)
+      const originalReleaseLocalInflightKeys = crawler._releaseLocalInflightKeys.bind(crawler)
+
+      sinon.stub(crawler, '_releaseInflightLocks').callsFake(async entries => {
+        releaseOrder.push('redis')
+        await originalReleaseInflightLocks(entries)
+      })
+
+      sinon.stub(crawler, '_releaseLocalInflightKeys').callsFake(keys => {
+        releaseOrder.push('local')
+        originalReleaseLocalInflightKeys(keys)
+      })
+
+      await assert.doesNotReject(() => crawler.harvest([foo], false))
+
+      assert.deepStrictEqual(releaseOrder, ['redis', 'local'], 'Expected release ordering to be redis then local')
+    })
+
+    it('throws when local lock acquisition exceeds timeout', async () => {
+      const keyFoo = inflightKey(foo.coordinates)
+      crawler._localInflightKeys.add(keyFoo)
+      sinon.spy(cacheMock, 'setIfAbsent')
+
+      await assert.rejects(
+        () => crawler.harvest([foo], false),
+        /Timed out acquiring local inflight harvest coordinate locks/
+      )
+
+      assert.ok(cacheMock.setIfAbsent.notCalled, 'Redis setIfAbsent should not be called when local times out')
+      assert.strictEqual(
+        crawler._localInflightKeys.size,
+        1,
+        'Only the pre-seeded key should remain — no extra local keys leaked by harvest'
+      )
+    })
+
+    it('local gate prevents simultaneous Redis acquire attempts for same-instance concurrent requests', async () => {
+      addHarvesterDelay(15)
+      sinon.spy(cacheMock, 'setIfAbsent')
+
+      await Promise.all([crawler.harvest([foo], false), crawler.harvest([foo], false)])
+
+      assert.strictEqual(harvesterMock.harvest.callCount, 1, 'Only one harvest dispatched')
+      // With local gate: each request acquires Redis lock exactly once, no retry contention.
+      // Without local gate: requests race at Redis and setIfAbsent is called many more times.
+      assert.strictEqual(
+        cacheMock.setIfAbsent.callCount,
+        2,
+        'Each request hits Redis exactly once — local gate prevents simultaneous Redis contention'
+      )
     })
   })
 

--- a/test/providers/harvest/cacheBasedCrawlerTest.ts
+++ b/test/providers/harvest/cacheBasedCrawlerTest.ts
@@ -17,14 +17,6 @@ function createCacheMock() {
     async set(key, value) {
       this.store[key] = value
     },
-    async setIfAbsent(key, value) {
-      if (this.locks.has(key)) {
-        return false
-      }
-      this.locks.add(key)
-      this.store[key] = value
-      return true
-    },
     async setIfAbsentBatch(keys: string[], value: string) {
       const acquired: string[] = []
       for (const key of keys) {


### PR DESCRIPTION
## Summary

A prior change added tracked-harvest caching (`hrv_<coord>` keys in Redis) to avoid re-dispatching coordinates already sent to the crawler. That reduced queue volume from about 170M to about 2M, but concurrent requests still needed protection in the gap before tracking is written — two requests arriving simultaneously for the same coordinate could both pass the tracking check and both dispatch.

This PR closes that gap with a two-layer inflight lock:

- **Local `MemoryCache<string>` layer** — serialises concurrent requests within the same process; acquired synchronously in a single event-loop tick, blocking concurrent async handlers before either can dispatch
- **Redis `setIfAbsentBatch` layer** — atomic Lua script that acquires all locks for a batch in a single round-trip; the only mechanism that prevents duplicate dispatch across instances

The local layer eliminates redundant Redis calls within a process. Cross-instance correctness depends entirely on Redis.

**Correctness properties:**
- **Sorted key order** — both layers acquire keys in the same global sorted order, eliminating hold-and-wait deadlock cycles when overlapping batches race
- **All-or-nothing Lua** — on any collision the script rolls back previously acquired keys; no partial lock state is left in Redis
- **Pre-filter** — coordinates whose `hrv_<coord>` tracking key is already present are skipped before lock acquisition, reducing contention on the lock path; a recheck under lock closes the TOCTOU window between the pre-filter read and the lock grant
- **Unthrottled in-lock path** — tracked checks and tracking writes run unthrottled inside the lock to minimise hold time; correctness is still guaranteed by the under-lock recheck and lock ownership

**Operational bounds:**
- **TTL safety net** (60s) on inflight keys — if the lock holder crashes before releasing, the key expires and a waiting instance can proceed
- **Ownerless release** — the current DEL has no token check; if dispatch latency spikes close to 60s, a stale DEL from the original holder could hit a key already acquired by a successor; token-based release can be added as a follow-up if needed
- **Retry with jitter** (300–500ms) so concurrent requests that collide converge to a single dispatch rather than thundering-herding after each retry
- **`lockAcquireTimeoutMs=25s`** — if the lock cannot be acquired within 25s, the request fails with a structured error rather than hanging until the API gateway cuts it off (Cloudflare 524 fires at 60s); a `warn` log is emitted on timeout with elapsed time and configured timeout for monitoring
- **Redis unavailable** → fail-closed; both lock layers are released in `finally` regardless of outcome

---

## Test Coverage

In addition to unit tests, the following integration and stress test cases exercise the full lock path end-to-end.

### Single-instance (T1–T12)

| Test | What it covers |
|------|----------------|
| T1 | Sequential same-coordinate dedup — tracking filter skips already-dispatched coord |
| T2 | Concurrent same-coordinate inflight lock — 20 parallel requests collapse to 1 dispatch |
| T3 | Independent coordinates in one batch — different coords do not block each other |
| T3a | 3 concurrent single-coord POSTs for independent coords — no cross-blocking |
| T4 | High-concurrency mixed overlapping coords — 40 parallel, two orderings, deadlock safety |
| T4a | Two-phase 40-concurrent with computeLock pipeline overlap |
| T4b | 20-coord batch with one key pre-locked — partial-release rollback, retry, and eventual success |
| T5 | Compute → harvest fire-and-forget — 40 concurrent GETs trigger inflight dedup |
| T5a | Delayed computeLock overlap with concurrent POST harvest |
| T6 | TTL safety net — stranded inflight key expires, successor dispatches without manual DEL |
| T7 | Lock acquisition timeout — 25s hold causes structured 5xx, not hang |
| T8 | `done()` lifecycle — tracking set after dispatch, cleared by `done()`, re-harvest fires |
| T9 | Non-npm Maven coordinate — key format and case folding |
| T10 | Large uncontested batch — 20 unique coords, elapsed < 5s |
| T11 | Large realistic batch — 500 coords, within 15s timeout budget |
| T12 | Two parallel POSTs with same 500 coords — local Set serialises intra-process contention |

### Cross-instance stress (ST1–ST11)

Two service instances sharing a single Redis.

| Test | Shape | What it covers |
|------|-------|----------------|
| ST1  | 1 coord, both instances POST concurrently | Cross-instance dedup for a single coordinate |
| ST2  | Both instances POST same 500 coords | Redis Lua winner-takes-all at batch scale |
| ST3  | 300+300 with 100 overlap (unique=500) | Atomic Lua prevents double-dispatch of the overlap zone |
| ST4  | 10×2 concurrent batches, same 500 coords | Lua atomicity under extreme cross-instance burst |
| ST5  | 400 pre-tracked + 100 new | Pre-filter skips already-tracked; only 100 new dispatched |
| ST6  | 1 coord, inflight key pre-locked with TTL=5s | Cross-instance TTL safety net: lock expires, other instance retries to success |
| ST7  | 3 waves, overlapping 500-coord subsets, no flush between waves | Tracking carry-over: waves 2+3 dispatch 0 |
| ST8  | Phase 1 track 100; Phase 2 DEL tracking + both re-POST | `done()` race — exactly 100 dispatched, no double-dispatch |
| ST9  | service1 POSTs 500; service2 restarted mid-lock; service2 re-POSTs | Cold-start join: empty local Set, Redis coordination prevents dup |
| ST10 | 25 concurrent POSTs to each instance, same 500 coords | Thundering herd — jitter sufficient, no timeouts |
| ST11 | Both POST 100; Redis restarted mid-phase; re-POST | Redis restart recovery — phase 2 returns 201, ≤100 dispatch, ≤100 residual |
