### PR TITLE
Wire CACHING_REDIS_TLS env var into redisConfig

### DIFF
--- a/providers/caching/redisConfig.ts
+++ b/providers/caching/redisConfig.ts
@@ -14,7 +14,8 @@ function serviceFactory(options?: RedisCacheOptions): RedisCache {
   const realOptions = options || {
     service: config.get('CACHING_REDIS_SERVICE'),
     apiKey: config.get('CACHING_REDIS_API_KEY'),
-    port: Number(config.get('CACHING_REDIS_PORT')) || 6380
+    port: Number(config.get('CACHING_REDIS_PORT')) || 6380,
+    tls: String(config.get('CACHING_REDIS_TLS')).toLowerCase() !== 'false'
   }
   return redis(realOptions)
 }

--- a/test/providers/caching/redisConfig.ts
+++ b/test/providers/caching/redisConfig.ts
@@ -57,15 +57,21 @@ describe('redisConfig.serviceFactory', () => {
     const configGet = mappingGet({
       CACHING_REDIS_SERVICE: 'redis://example',
       CACHING_REDIS_API_KEY: 'secret-key',
-      CACHING_REDIS_PORT: '6380'
+      CACHING_REDIS_PORT: '6380',
+      CACHING_REDIS_TLS: 'true'
     })
 
     const serviceFactory = await loadServiceFactory(configGet)
     const result = serviceFactory()
 
-    expectConfigGetCalled(configGet, ['CACHING_REDIS_SERVICE', 'CACHING_REDIS_API_KEY', 'CACHING_REDIS_PORT'])
+    expectConfigGetCalled(configGet, [
+      'CACHING_REDIS_SERVICE',
+      'CACHING_REDIS_API_KEY',
+      'CACHING_REDIS_PORT',
+      'CACHING_REDIS_TLS'
+    ])
 
-    const expectedOptions = { service: 'redis://example', apiKey: 'secret-key', port: 6380 }
+    const expectedOptions = { service: 'redis://example', apiKey: 'secret-key', port: 6380, tls: true }
     expectRedisCalledWith(expectedOptions, result)
   })
 
@@ -78,9 +84,59 @@ describe('redisConfig.serviceFactory', () => {
     const serviceFactory = await loadServiceFactory(configGet)
     const result = serviceFactory()
 
-    expectConfigGetCalled(configGet, ['CACHING_REDIS_SERVICE', 'CACHING_REDIS_API_KEY', 'CACHING_REDIS_PORT'])
+    expectConfigGetCalled(configGet, [
+      'CACHING_REDIS_SERVICE',
+      'CACHING_REDIS_API_KEY',
+      'CACHING_REDIS_PORT',
+      'CACHING_REDIS_TLS'
+    ])
 
-    const expectedOptions = { service: 'redis://example', apiKey: 'secret-key', port: 6380 }
+    const expectedOptions = { service: 'redis://example', apiKey: 'secret-key', port: 6380, tls: true }
+    expectRedisCalledWith(expectedOptions, result)
+  })
+
+  it('disables TLS when CACHING_REDIS_TLS is false', async () => {
+    const configGet = mappingGet({
+      CACHING_REDIS_SERVICE: 'redis://example',
+      CACHING_REDIS_API_KEY: 'secret-key',
+      CACHING_REDIS_PORT: '6379',
+      CACHING_REDIS_TLS: 'false'
+    })
+
+    const serviceFactory = await loadServiceFactory(configGet)
+    const result = serviceFactory()
+
+    const expectedOptions = { service: 'redis://example', apiKey: 'secret-key', port: 6379, tls: false }
+    expectRedisCalledWith(expectedOptions, result)
+  })
+
+  it('disables TLS when CACHING_REDIS_TLS is False (case-insensitive)', async () => {
+    const configGet = mappingGet({
+      CACHING_REDIS_SERVICE: 'redis://example',
+      CACHING_REDIS_API_KEY: 'secret-key',
+      CACHING_REDIS_PORT: '6379',
+      CACHING_REDIS_TLS: 'False'
+    })
+
+    const serviceFactory = await loadServiceFactory(configGet)
+    const result = serviceFactory()
+
+    const expectedOptions = { service: 'redis://example', apiKey: 'secret-key', port: 6379, tls: false }
+    expectRedisCalledWith(expectedOptions, result)
+  })
+
+  it('disables TLS when CACHING_REDIS_TLS is boolean false', async () => {
+    const configGet = mappingGet({
+      CACHING_REDIS_SERVICE: 'redis://example',
+      CACHING_REDIS_API_KEY: 'secret-key',
+      CACHING_REDIS_PORT: '6379',
+      CACHING_REDIS_TLS: false
+    })
+
+    const serviceFactory = await loadServiceFactory(configGet)
+    const result = serviceFactory()
+
+    const expectedOptions = { service: 'redis://example', apiKey: 'secret-key', port: 6379, tls: false }
     expectRedisCalledWith(expectedOptions, result)
   })
 })


### PR DESCRIPTION
## Summary

- Reads `CACHING_REDIS_TLS` from config and passes it to the Redis client
- Defaults to `true` (TLS on) when the env var is absent, preserving existing production behaviour on Azure Redis
- Set `CACHING_REDIS_TLS=false` to disable TLS — supports the Redis container added to the local Azurite docker-compose stack in [docker_dev_env_experiment#22](https://github.com/clearlydefined/docker_dev_env_experiment/pull/22), which runs a plain (non-TLS) Redis
- Value is parsed case-insensitively (`'false'`, `'False'`, `'FALSE'`) and also accepts a boolean `false`

## Test plan

- [ ] New unit tests cover: TLS on (explicit `'true'`), TLS on (env var absent), TLS off (`'false'`), TLS off (`'False'` case-insensitive), TLS off (boolean `false`)
- [ ] Verify local Azurite stack with `CACHING_REDIS_TLS=false` connects to the Redis container without TLS errors